### PR TITLE
feat: bundle TypeScript types for the scoped packages

### DIFF
--- a/.changeset/emploi-typescript-types.md
+++ b/.changeset/emploi-typescript-types.md
@@ -1,0 +1,5 @@
+---
+"@geoalgeria/emploi": minor
+---
+
+Bundle TypeScript type definitions. `Awem`, `Alem`, and `Metadata` interfaces plus typed loaders (`awem()`, `alem()`, `agencies()`, `metadata()`) now ship with the package and resolve automatically via the `types` export condition. No runtime or data changes.

--- a/.changeset/mobilis-typescript-types.md
+++ b/.changeset/mobilis-typescript-types.md
@@ -1,0 +1,5 @@
+---
+"@geoalgeria/mobilis": minor
+---
+
+Bundle TypeScript type definitions. `Agence`, `Pdv`, and `Metadata` interfaces plus typed loaders (`agences()`, `pdv()`, `all()`, `metadata()`) now ship with the package and resolve automatically via the `types` export condition. No runtime or data changes.

--- a/.changeset/poste-typescript-types.md
+++ b/.changeset/poste-typescript-types.md
@@ -1,0 +1,5 @@
+---
+"@geoalgeria/poste": minor
+---
+
+Bundle TypeScript type definitions. `PostOffice`, `Atm`, and `Metadata` interfaces plus typed loaders (`postOffices()`, `atms()`, `metadata()`) now ship with the package and resolve automatically via the `types` export condition. No runtime or data changes.

--- a/packages/emploi/README.md
+++ b/packages/emploi/README.md
@@ -57,6 +57,13 @@ import alem from "@geoalgeria/emploi/data/alem.json" with { type: "json" };
 // https://cdn.jsdelivr.net/npm/@geoalgeria/emploi/data/alem.json
 ```
 
+The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+
+```ts
+import emploi, { type Awem, type Alem } from "@geoalgeria/emploi";
+const local: Alem[] = emploi.alem();
+```
+
 **CSV and GeoJSON** are in the repo under [`data/`](data) and bundled in every
 [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases):
 

--- a/packages/emploi/package.json
+++ b/packages/emploi/package.json
@@ -4,12 +4,17 @@
   "type": "module",
   "description": "Algeria public employment agencies — 58 AWEM (wilaya) + 273 ALEM (local) offices with address, phone, manager, communes served, and coordinates. Sourced from ANEM (anem.dz). JSON, CSV, GeoJSON.",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    },
     "./data/*": "./data/*"
   },
   "files": [
     "data/**/*.json",
+    "types/",
     "index.js"
   ],
   "scripts": {

--- a/packages/emploi/types/index.d.ts
+++ b/packages/emploi/types/index.d.ts
@@ -1,0 +1,90 @@
+// Type definitions for @geoalgeria/emploi
+// Data sourced from ANEM (Agence Nationale de l'Emploi, anem.dz).
+
+/** A wilaya-level employment agency (AWEM). */
+export interface Awem {
+  /** Agency id. */
+  id: string;
+  /** Internal ANEM code, if assigned. */
+  code: string | null;
+  /** Record type discriminator (e.g. "awem"). */
+  type: string;
+  /** Agency name. */
+  name: string;
+  /** Street address. */
+  address: string;
+  /** Phone number. */
+  phone: string;
+  /** Fax number. */
+  fax: string;
+  /** Contact email. */
+  email: string;
+  /** Agency manager/director. */
+  manager: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Latitude (AWEM agencies are fully geocoded). */
+  lat: number;
+  /** Longitude (AWEM agencies are fully geocoded). */
+  lng: number;
+}
+
+/** A local employment agency (ALEM). */
+export interface Alem {
+  /** Agency id. */
+  id: string;
+  /** Internal ANEM code, if assigned. */
+  code: string | null;
+  /** Record type discriminator (e.g. "alem"). */
+  type: string;
+  /** Agency name. */
+  name: string;
+  /** Street address. */
+  address: string;
+  /** Phone number. */
+  phone: string;
+  /** Fax number, if any. */
+  fax: string | null;
+  /** Contact email, if any. */
+  email: string | null;
+  /** Agency manager/director. */
+  manager: string;
+  /** Comma-separated list of communes served. */
+  communes: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Latitude, or null when not geocoded. */
+  lat: number | null;
+  /** Longitude. */
+  lng: number;
+}
+
+/** Dataset metadata (data/metadata.json). */
+export interface Metadata {
+  source: string;
+  origin: string;
+  license: string;
+  awem: number;
+  alem: number;
+  total: number;
+  wilayas_covered: number;
+  /** ISO date (YYYY-MM-DD) the snapshot was generated. */
+  generated_at: string;
+}
+
+/** All wilaya-level agencies (AWEM). */
+export function awem(): Awem[];
+/** All local agencies (ALEM). */
+export function alem(): Alem[];
+/** AWEM and ALEM combined (AWEM first). */
+export function agencies(): Array<Awem | Alem>;
+/** Dataset metadata. */
+export function metadata(): Metadata;
+
+declare const _default: {
+  awem: typeof awem;
+  alem: typeof alem;
+  agencies: typeof agencies;
+  metadata: typeof metadata;
+};
+export default _default;

--- a/packages/mobilis/README.md
+++ b/packages/mobilis/README.md
@@ -65,6 +65,13 @@ import agences from "@geoalgeria/mobilis/data/agences.json" with { type: "json" 
 // https://cdn.jsdelivr.net/npm/@geoalgeria/mobilis/data/agences.json
 ```
 
+The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+
+```ts
+import mobilis, { type Agence, type Pdv } from "@geoalgeria/mobilis";
+const agences: Agence[] = mobilis.agences();
+```
+
 **CSV and GeoJSON** are in the repo under [`data/`](data) and bundled in every
 [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases):
 

--- a/packages/mobilis/package.json
+++ b/packages/mobilis/package.json
@@ -4,12 +4,17 @@
   "type": "module",
   "description": "Mobilis (ATM Mobilis) sales network in Algeria — 165 commercial agencies (geocoded, bilingual FR/AR) + 12,180 approved points of sale (commune-level directory). Sourced from mobilis.dz. JSON, CSV, GeoJSON.",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    },
     "./data/*": "./data/*"
   },
   "files": [
     "data/**/*.json",
+    "types/",
     "index.js"
   ],
   "scripts": {

--- a/packages/mobilis/types/index.d.ts
+++ b/packages/mobilis/types/index.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for @geoalgeria/mobilis
+// Data sourced from Mobilis (ATM Mobilis, mobilis.dz).
+
+/** A geocoded Mobilis commercial agency. */
+export interface Agence {
+  /** Agency id. */
+  id: string;
+  /** Mobilis internal code. */
+  code: string;
+  /** Record type discriminator (e.g. "agence"). */
+  type: string;
+  /** Agency name in French. */
+  name: string;
+  /** Agency name in Arabic. */
+  name_ar: string;
+  /** Street address in French. */
+  address: string;
+  /** Street address in Arabic. */
+  address_ar: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Latitude (agencies are fully geocoded). */
+  lat: number;
+  /** Longitude (agencies are fully geocoded). */
+  lng: number;
+}
+
+/** An approved point of sale (commune-level directory entry). */
+export interface Pdv {
+  /** Point-of-sale id. */
+  id: string;
+  /** Mobilis internal code. */
+  code: string;
+  /** Record type discriminator (e.g. "pdv"). */
+  type: string;
+  /** Point-of-sale name. */
+  name: string;
+  /** Street address. */
+  address: string;
+  /** Commune name. */
+  commune: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Points of sale are not geocoded — always null. */
+  lat: number | null;
+  /** Points of sale are not geocoded — always null. */
+  lng: number | null;
+}
+
+/** Dataset metadata (data/metadata.json). */
+export interface Metadata {
+  source: string;
+  origin: string;
+  license: string;
+  agences: number;
+  pdv: number;
+  total: number;
+  wilayas_covered: number;
+  agences_geocoded: number;
+  pdv_geocoded: number;
+  /** ISO date (YYYY-MM-DD) the snapshot was generated. */
+  generated_at: string;
+}
+
+/** All Mobilis agencies. */
+export function agences(): Agence[];
+/** All approved points of sale. */
+export function pdv(): Pdv[];
+/** Agencies and points of sale combined (agencies first). */
+export function all(): Array<Agence | Pdv>;
+/** Dataset metadata. */
+export function metadata(): Metadata;
+
+declare const _default: {
+  agences: typeof agences;
+  pdv: typeof pdv;
+  all: typeof all;
+  metadata: typeof metadata;
+};
+export default _default;

--- a/packages/poste/README.md
+++ b/packages/poste/README.md
@@ -52,6 +52,13 @@ import offices from "@geoalgeria/poste/data/postoffices.json" with { type: "json
 // https://cdn.jsdelivr.net/npm/@geoalgeria/poste/data/postoffices.json
 ```
 
+The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+
+```ts
+import poste, { type PostOffice, type Atm } from "@geoalgeria/poste";
+const offices: PostOffice[] = poste.postOffices();
+```
+
 **CSV and GeoJSON** are in the repo under [`data/`](data) and bundled in every
 [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases):
 

--- a/packages/poste/package.json
+++ b/packages/poste/package.json
@@ -4,12 +4,17 @@
   "type": "module",
   "description": "Algeria post offices (3908) and ATMs (2026) — real postal codes, bilingual names, coordinates, commune/wilaya linkage. Sourced from Algérie Poste (baridimap.poste.dz). JSON, CSV, GeoJSON.",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    },
     "./data/*": "./data/*"
   },
   "files": [
     "data/**/*.json",
+    "types/",
     "index.js"
   ],
   "scripts": {

--- a/packages/poste/types/index.d.ts
+++ b/packages/poste/types/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for @geoalgeria/poste
+// Data sourced from Algérie Poste (baridimap.poste.dz).
+
+/** A post office (bureau de poste). */
+export interface PostOffice {
+  /** Numeric office id. */
+  id: number;
+  /** Office name (French / transliterated). */
+  name: string;
+  /** Office name in Arabic. */
+  name_ar: string;
+  /** Office class/category (e.g. "RP"). */
+  class: string;
+  /** 5-digit postal code. */
+  postal_code: string;
+  /** Previous postal code, if the office was renumbered. */
+  postal_code_old: string | null;
+  /** Street address. */
+  address: string;
+  /** 4-digit zero-padded commune code; links to geoalgeria communes. */
+  commune_code: string;
+  /** Commune name in French. */
+  commune_fr: string;
+  /** Commune name in Arabic. */
+  commune_ar: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Wilaya name in French. */
+  wilaya_fr: string;
+  /** Wilaya name in Arabic. */
+  wilaya_ar: string;
+  /** Latitude, or null when the office is not geocoded. */
+  lat: number | null;
+  /** Longitude, or null when the office is not geocoded. */
+  lng: number | null;
+}
+
+/** An ATM (distributeur automatique). */
+export interface Atm {
+  /** ATM id. */
+  id: string;
+  /** ATM name/label. */
+  name: string;
+  /** Operational status. */
+  status: string;
+  /** 5-digit postal code of the hosting office. */
+  postal_code: string;
+  /** Previous postal code, if renumbered. */
+  postal_code_old: string | null;
+  /** Street address. Currently null for every ATM (the source omits it); typed
+   *  as `string | null` so a future populated value is not a breaking change. */
+  address: string | null;
+  /** Commune name in French. */
+  commune_fr: string;
+  /** Commune name in Arabic. */
+  commune_ar: string;
+  /** Wilaya code as a string ("1".."58"). */
+  wilaya_code: string;
+  /** Wilaya name in French. */
+  wilaya_fr: string;
+  /** Wilaya name in Arabic. */
+  wilaya_ar: string;
+  /** Latitude, or null when not geocoded. */
+  lat: number | null;
+  /** Longitude, or null when not geocoded. */
+  lng: number | null;
+}
+
+/** Dataset metadata (data/metadata.json). */
+export interface Metadata {
+  source: string;
+  api: string;
+  license: string;
+  postoffices: number;
+  atms: number;
+  distinct_postal_codes: number;
+  /** ISO date (YYYY-MM-DD) the snapshot was generated. */
+  generated_at: string;
+}
+
+/** All post offices. */
+export function postOffices(): PostOffice[];
+/** All ATMs. */
+export function atms(): Atm[];
+/** Dataset metadata. */
+export function metadata(): Metadata;
+
+declare const _default: {
+  postOffices: typeof postOffices;
+  atms: typeof atms;
+  metadata: typeof metadata;
+};
+export default _default;


### PR DESCRIPTION
## What
Adds hand-written TypeScript type definitions to the three scoped packages — `@geoalgeria/poste`, `@geoalgeria/mobilis`, `@geoalgeria/emploi`. Previously only the flagship `geoalgeria` shipped types; TS consumers of the scoped packages got `any`.

Coordinated **minor** bump for all three (additive, non-breaking).

## Changes (per package)
- `types/index.d.ts` — record interfaces, `Metadata`, and typed loader signatures, matching the data **exactly**:
  - the `postoffices.id: number` vs `atms.id: string` quirk is preserved
  - per-dataset coordinate nullability (`number | null` only where the data actually has nulls)
  - union returns for `mobilis.all()` (`Array<Agence | Pdv>`) and `emploi.agencies()` (`Array<Awem | Alem>`)
- `package.json` — top-level `types`, a **types-first** `exports["."]` condition (`{ types, default }`), and `types/` added to `files`
- `README.md` — short bundled-types usage snippet
- `.changeset/*` — `minor` for each package

## Verification
- `tsc --strict` on all three declarations → clean
- by-name consumer typecheck under `moduleResolution: nodenext` → resolves via the `exports` `types` condition; exercises the id quirk, nullable coords, and the union returns
- runtime by-name import smoke → `all()`=12345, `agencies()`=331 as expected
- `npm pack --dry-run` → `types/index.d.ts` present in each tarball

## Reviewed
Two review agents (type-fidelity vs raw JSON, and packaging/exports). No critical issues; all three packages consistent. One reviewer-suggested comment fix on `Atm.address` applied. Two **pre-existing, flagship-only** type issues were noted as a separate follow-up (not introduced here):
- `packages/dataset` lists `require` before `types` in `exports`
- `packages/dataset/types/index.d.ts` uses `export =` alongside other exports (fails strict `nodenext`)

## Note
Stacked conceptually after #16 (validation gate), but independent — touches different packages/lines and targets `main` directly.