### PR TITLE
chore: cover @geoalgeria/telecom in the validate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,6 @@ jobs:
         working-directory: packages/emploi
         run: node --input-type=module -e "import('./index.js').then(m=>{const w=m.awem(),l=m.alem(); if(!Array.isArray(w)||!w.length||!Array.isArray(l)||!l.length){console.error('empty data');process.exit(1)} console.log('emploi:',w.length,'awem,',l.length,'alem')})"
 
-      - name: Validate @geoalgeria/telecom (5G coverage)
-        if: matrix.node-version == 22
-        working-directory: packages/telecom
-        run: node scripts/validate.mjs
-
       - name: Smoke test — @geoalgeria/telecom (ESM)
         working-directory: packages/telecom
         run: node --input-type=module -e "import('./index.js').then(m=>{const s=m.coverage(); if(!Array.isArray(s)||!s.length){console.error('empty data');process.exit(1)} console.log('telecom:',s.length,'5G sites,',m.metadata().coverage['5G'].wilayas_covered,'wilayas')})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Validate dataset before any publish
+      - name: Validate all packages before any publish
         run: pnpm validate
 
       - name: Dry-run publish

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "geoalgeria-monorepo",
   "private": true,
   "type": "module",
-  "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis) published to npm",
+  "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis, @geoalgeria/telecom) published to npm",
   "packageManager": "pnpm@11.3.0",
   "scripts": {
-    "validate": "pnpm --filter ./packages/dataset validate && node scripts/validate-packages.mjs",
+    "validate": "pnpm --filter ./packages/dataset validate && node scripts/validate-packages.mjs && node packages/telecom/scripts/validate.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm validate && changeset publish",


### PR DESCRIPTION
## What
Closes a gap from #18: `@geoalgeria/telecom` shipped a package-local validator (`scripts/validate.mjs`) that was **never wired into the root `validate`**. So `pnpm validate` — and therefore `release.yml`'s *"validate before any publish"* gate — skipped telecom. Only CI's bespoke step caught it, meaning telecom could publish **unvalidated**.

## Changes
- **Root `validate` now chains telecom's validator** (`… && node packages/telecom/scripts/validate.mjs`), the same way the `dataset` package's own validator is chained. The release gate now validates **all five** packages.
- **Drop the redundant per-telecom CI step** — it's now covered by the `pnpm validate` step, making telecom consistent with poste/mobilis/emploi (which have no bespoke step).
- Rename release step `Validate dataset…` → `Validate all packages…` (accuracy).
- List `@geoalgeria/telecom` in the monorepo `description`.

### Why chain, not fold into `scripts/validate-packages.mjs`?
telecom's metadata is nested (`coverage.5G.total`) and it does cross-dataset checks (per-operator files' ids must equal `sites.json`) that don't fit that file's flat per-dataset spec model. Chaining a focused per-package validator (as `dataset` already does) is cleaner than special-casing the generic one.

## Verification
- `pnpm validate` → PASS across all five (dataset, poste, mobilis, emploi, telecom).
- `pnpm install --frozen-lockfile` clean; no lockfile change.

Config-only; no package code or data touched.