### PR TITLE
fix(release): stage @geoalgeria/telecom + don't abort on one package's failure

### DIFF
--- a/scripts/stage-publish.js
+++ b/scripts/stage-publish.js
@@ -13,10 +13,17 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const PACKAGES = ["packages/dataset", "packages/poste", "packages/emploi", "packages/mobilis"];
+const PACKAGES = [
+  "packages/dataset",
+  "packages/poste",
+  "packages/emploi",
+  "packages/mobilis",
+  "packages/telecom",
+];
 
 let staged = 0;
 let skipped = 0;
+const failed = [];
 
 for (const pkg of PACKAGES) {
   const pkgJson = JSON.parse(readFileSync(join(pkg, "package.json"), "utf8"));
@@ -67,13 +74,20 @@ for (const pkg of PACKAGES) {
       skipped++;
       continue;
     }
+    // Keep going so one package's missing Trusted Publisher (or other error)
+    // doesn't block staging the rest; surface all failures at the end.
     console.error(`FAILED to stage ${name}@${version}`);
     if (log) console.error(log);
-    process.exit(1);
+    failed.push(name);
   }
 }
 
-console.log(`\nDone: ${staged} staged, ${skipped} skipped`);
+console.log(`\nDone: ${staged} staged, ${skipped} skipped, ${failed.length} failed`);
+if (failed.length) {
+  console.error(`Failed to stage: ${failed.join(", ")}`);
+  console.error("Likely a missing Trusted Publisher on npmjs.com for the package(s). See RELEASING.md.");
+  process.exit(1);
+}
 if (staged > 0) {
   console.log("Approve staged packages on npmjs.com → Account → Staged packages");
   console.log("Or run locally: npm stage list && npm stage approve <stage-id>");


### PR DESCRIPTION
## Context
The first release run with all five packages **partly worked and partly exposed gaps**. The validate gate passed (all 5, incl. telecom via #20), `geoalgeria@1.1.1` skipped (already published), **`poste@1.1.0` staged ✓**, but **`emploi@1.1.0` failed with `E401`** and the run aborted before reaching `mobilis`.

## Two real gaps fixed here (in `scripts/stage-publish.js`)
1. **telecom was missing from the publish list** — `release.yml`'s loops were updated when telecom landed (#18) but this script wasn't, so telecom would never stage. Added `packages/telecom` (the script's existing new-package guard skips it until its one-time manual bootstrap publish).
2. **Abort-on-first-failure** meant emploi's failure blocked `mobilis`. Now it collects failures, stages everything it can, and exits non-zero at the end listing all failures.

## What this does NOT fix (yours to do on npmjs.com)
The `E401` is per-package **npm Trusted Publisher** config. `poste` has one (it staged); `emploi`, `mobilis`, and eventually `telecom` need one configured on npmjs.com → package → Settings → Trusted Publisher (GitHub Actions, this repo + `release.yml`). See RELEASING.md.

## Verify
- `node --check scripts/stage-publish.js` ✓
- Logic: 409-already-staged still skips; other errors collected and surfaced; exit 1 if any failed.