### PR TITLE
fix(purge-cdn): derive package list from the workspace

### DIFF
--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -15,17 +15,25 @@
  * No dependencies — uses global fetch (Node >= 18).
  */
 
-// Versionless paths track the npm "latest" tag — exactly what users hit.
-const DEFAULT_PATHS = [
-  "npm/geoalgeria", // package root + metadata
-  "npm/geoalgeria/data/ecommerce/communes.json", // advertised in the README
-  "npm/@geoalgeria/poste",
-  "npm/@geoalgeria/emploi",
-  "npm/@geoalgeria/mobilis",
-  "npm/@geoalgeria/banques",
-];
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-const paths = [...DEFAULT_PATHS, ...process.argv.slice(2)];
+const PKGS = join(dirname(fileURLToPath(import.meta.url)), "..", "packages");
+
+// Derive the package roots from the workspace so a new package is never silently
+// skipped — every published (non-private) package's versionless path tracks its npm
+// "latest" tag, exactly what users hit. Plus the specific deep paths the docs advertise.
+const pkgPaths = readdirSync(PKGS)
+  .map((d) => join(PKGS, d, "package.json"))
+  .filter((f) => existsSync(f))
+  .map((f) => JSON.parse(readFileSync(f, "utf8")))
+  .filter((p) => p.name && !p.private)
+  .map((p) => `npm/${p.name}`)
+  .sort();
+const EXTRA_PATHS = ["npm/geoalgeria/data/ecommerce/communes.json"]; // advertised in the README
+
+const paths = [...pkgPaths, ...EXTRA_PATHS, ...process.argv.slice(2)];
 
 let failed = 0;
 for (const p of paths) {


### PR DESCRIPTION
`scripts/purge-cdn.js` had a hardcoded `DEFAULT_PATHS` that went stale: it listed only `geoalgeria`, `poste`, `emploi`, `mobilis`, `banques` — silently **omitting `@geoalgeria/aviation`, `@geoalgeria/telecom` and `@geoalgeria/livraison`**. Those packages' jsDelivr `@latest` edge cache was never purged on release (a release runs `pnpm purge-cdn`, which just skipped them).

Surfaced while shipping `@geoalgeria/livraison`: the purge reported `6/6` and the new package wasn't in the list.

**Fix:** derive the package roots from `packages/*/package.json` (non-private `name`s) at runtime, so any newly added package is always covered. The one advertised deep path (`geoalgeria/data/ecommerce/communes.json`) and CLI extras are kept.

Verified locally — `pnpm purge-cdn` now purges all 8 packages + the deep path (`9/9 purged`), including aviation, telecom and livraison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)