### PR TITLE
chore(livraison): wire into release + announce workflows

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -51,7 +51,7 @@ jobs:
             exit 0
           fi
           # Fail closed on anything that isn't one of our package tags.
-          if ! printf '%s' "$RAW_TAG" | grep -Eq '^(geoalgeria|@geoalgeria/(poste|emploi|mobilis|banques|telecom|aviation))@[0-9]+\.[0-9]+\.[0-9]+$'; then
+          if ! printf '%s' "$RAW_TAG" | grep -Eq '^(geoalgeria|@geoalgeria/(poste|emploi|mobilis|banques|telecom|aviation|livraison))@[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Refusing to announce malformed tag: $RAW_TAG"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Dry-run publish
         run: |
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison; do
             PKG_NAME=$(node -p "require('./$pkg/package.json').name")
             PKG_VER=$(node -p "require('./$pkg/package.json').version")
             REGISTRY_VER=$(npm view "$PKG_NAME" version 2>/dev/null || echo "")
@@ -73,7 +73,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison; do
             NAME=$(node -p "require('./$pkg/package.json').name")
             VER=$(node -p "require('./$pkg/package.json').version")
             TAG="$NAME@$VER"

--- a/packages/livraison/CHANGELOG.md
+++ b/packages/livraison/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Algeria's COD / e-commerce delivery layer, as installable data: a 16-carrier registry,
+  411 geocoded stop-desks across 61 wilayas, and per-carrier coverage, in JSON, CSV and GeoJSON
 - Carrier registry — 16 Algerian COD / e-commerce delivery companies, each with
   website, service model (stop-desk / home / both), cash-on-delivery support, scope,
   how openly it publishes agency data, and public-API availability


### PR DESCRIPTION
Prep for announcing `@geoalgeria/livraison@1.0.0`. Two stale/fail-closed allowlists omitted the new package:

- **`announce.yml`** — the tag regex (`fail closed on anything that isn't one of our package tags`) didn't include `livraison`, so the Announce workflow would **reject** the `@geoalgeria/livraison@1.0.0` tag and post no Discussion / drafts.
- **`release.yml`** — the stage + GitHub-Release loops skipped `packages/livraison`, so future bumps would never stage or cut a Release + data bundle.

Added `livraison` to both. Also reshaped the livraison `CHANGELOG.md` so its **first bullet is a clean, em-dash-free headline** — that bullet becomes the release title and the announcement hook (per `RELEASE_TEMPLATE.md` / GPC voice).

No data changes. Needed on `main` before the GitHub Release is cut (the Announce workflow runs `announce.yml` from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)