### PR TITLE
chore(release): drop version prefix from Release/Discussion titles

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -34,11 +34,11 @@ Rules:
   words**, no trailing period. It states *what changed*, not a pitch:
   "Branches for all 21 licensed banks" — not "Every licensed bank in Algeria now
   has branch locations, all 21!".
-- **Titles render as `<version> - <title>`.** `release.yml` and the announcer
-  prepend the version automatically, so a GitHub Release & Discussion title looks
-  like **`1.1.0 - Branches for all 21 licensed banks`**. The package **name/scope**
-  is never in the title — it's already in the release chip + URL. Used verbatim as
-  the Release title, the Discussion title, and (without the version) the social hook.
+- **Titles render as just the `<title>`.** `release.yml` and the announcer use the
+  first bullet verbatim, so a GitHub Release & Discussion title looks like
+  **`Branches for all 21 licensed banks`**. The **version and package name/scope**
+  are never in the title — they're already in the release tag chip + URL (which is
+  why the title alone must say what changed). The same title is also the social hook.
 - **Tone: sober and factual.** No emoji, no hype, no marketing CTAs ("ship fast",
   "🇩🇿", "drop it into your app"). This is a data project — state the facts, cite
   the source, link npm + the release. Let the numbers do the selling.

--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -111,7 +111,7 @@ jobs:
               }
             }' \
             -f repoId="$REPO_ID" -f catId="$CAT_ID" \
-            -f title="${TAG##*@} - $HEADLINE" \
+            -f title="$HEADLINE" \
             -F body=@.release-notes/announcement.md \
             --jq '.data.createDiscussion.discussion.url'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,14 +106,14 @@ jobs:
             fi
 
             if [ -s "$NOTES" ]; then
-              # Title = "<version> - <headline>" (the headline is the first bullet).
-              # The package name/scope is never in the title — it's already in the
-              # release chip + URL. (drop the list marker + changeset hash + bold.)
+              # Title = the headline (the first bullet) verbatim. The version and
+              # package name/scope are never in the title — both are already in the
+              # release tag chip + URL. (drop the list marker + changeset hash + bold.)
               # See RELEASE_TEMPLATE.md.
               HEADLINE=$(grep -m1 -E '^[-*][[:space:]]' "$NOTES" \
                 | sed -E 's/^[-*][[:space:]]+//; s/^[0-9a-f]{7,}:[[:space:]]*//; s/\*\*//g')
-              TITLE="$VER"
-              [ -n "$HEADLINE" ] && TITLE="$VER - $HEADLINE"
+              TITLE="$TAG"
+              [ -n "$HEADLINE" ] && TITLE="$HEADLINE"
               gh release create "$TAG" --title "$TITLE" --target "$GITHUB_SHA" --notes-file "$NOTES" "$BUNDLE"
             else
               echo "::warning::No CHANGELOG section found for $TAG; using auto-generated notes"


### PR DESCRIPTION
The Releases feed read as a wall of **`1.0.0 - …`**: titles led with the bare version, and since each package is versioned independently, three new packages (`telecom`, `aviation`, `livraison`) all sit at their first release `1.0.0`. The version alone doesn't say *which* package.

The package name + version already appear in the release **tag chip** and **URL** (`@geoalgeria/livraison@1.0.0`), so the title is redundant carrying the version. Now the title uses the **headline (first CHANGELOG bullet) verbatim** — e.g. `Algeria's 33 civil airports`, `5G coverage (1,681 sites)`.

Changes:
- `release.yml` — GitHub Release title = headline (fallback to the tag if no headline).
- `announce.yml` — Discussion title = headline (was `<version> - <headline>`).
- `RELEASE_TEMPLATE.md` — convention updated to match.

Existing releases + the livraison Discussion are being retitled separately to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)