### PR TITLE
docs(livraison): add to root README + complete npm description

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ dz.getPostOfficesByCommune(1731); // real Algérie Poste offices
 | **5G coverage** | 1,681 | Djezzy + Mobilis + Ooredoo 5G sites — [`@geoalgeria/telecom`](packages/telecom) |
 | **Civil airports** | 33 | ANAC: names, ICAO codes, contacts, coordinates — [`@geoalgeria/aviation`](packages/aviation) |
 | **Banks & branches** | 1,704 | all 21 licensed banks + 8 institutions; branches with RIB/SWIFT codes, ownership, coordinates — [`@geoalgeria/banques`](packages/banques) |
+| **Delivery carriers** | 411 | 16-carrier registry + 411 geocoded stop-desks across 61 wilayas (Yalidine, Guepex, Anderson, Noest, Maystro) — [`@geoalgeria/livraison`](packages/livraison) |
 
 Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships JSON to stay light; CSV/GeoJSON/SQL ride in every [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -85,6 +86,7 @@ Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships 
 | [`packages/telecom`](packages/telecom) | [`@geoalgeria/telecom`](https://www.npmjs.com/package/@geoalgeria/telecom) | Cross-operator 5G coverage (Djezzy + Mobilis + Ooredoo) |
 | [`packages/aviation`](packages/aviation) | [`@geoalgeria/aviation`](https://www.npmjs.com/package/@geoalgeria/aviation) | Civil airports from ANAC — names, ICAO codes, coordinates |
 | [`packages/banques`](packages/banques) | [`@geoalgeria/banques`](https://www.npmjs.com/package/@geoalgeria/banques) | All 21 licensed banks + financial institutions & 1,704 branches (RIB, SWIFT, ownership, coordinates) |
+| [`packages/livraison`](packages/livraison) | [`@geoalgeria/livraison`](https://www.npmjs.com/package/@geoalgeria/livraison) | Delivery carrier registry + 411 geocoded stop-desks & per-carrier coverage (Yalidine, Guepex, Anderson, Noest, Maystro) |
 
 ## Use without npm
 

--- a/packages/livraison/package.json
+++ b/packages/livraison/package.json
@@ -2,7 +2,7 @@
   "name": "@geoalgeria/livraison",
   "version": "1.0.0",
   "type": "module",
-  "description": "Algeria's COD / e-commerce delivery layer — a registry of delivery carriers, geocoded stop-desk / relay-point locations (Yalidine, Guepex & partner operators), and per-carrier wilaya coverage. JSON, CSV, GeoJSON, TypeScript.",
+  "description": "Algeria's COD / e-commerce delivery layer — a registry of delivery carriers, geocoded stop-desk / relay-point locations (Yalidine, Guepex, Anderson, Noest, Maystro & partner operators), and per-carrier wilaya coverage. JSON, CSV, GeoJSON, TypeScript.",
   "main": "index.js",
   "types": "types/index.d.ts",
   "exports": {
@@ -31,6 +31,9 @@
     "stopdesk",
     "yalidine",
     "guepex",
+    "anderson",
+    "noest",
+    "maystro",
     "ecommerce",
     "logistics",
     "geojson",


### PR DESCRIPTION
Pre-launch doc pass for `@geoalgeria/livraison`:

- **Root README** — the new package was missing from both tables. Added it to the "what's covered" summary (411 geocoded stop-desks across 61 wilayas) and the Packages table.
- **`packages/livraison/package.json`** — the description + keywords credited only Yalidine/Guepex; they now name **Anderson, Noest and Maystro** too (no hardcoded counts, so it stays evergreen).

Verified: livraison README already consistent (411 stop-desks / 16 carriers / 9 coverage / 61 wilayas, Maystro throughout); `pnpm validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)