### PR TITLE
chore: umbrella v1.1.0 + refresh RELEASING + queue livraison 1.0.1

### DIFF
--- a/.changeset/livraison-describe-networks.md
+++ b/.changeset/livraison-describe-networks.md
@@ -1,0 +1,5 @@
+---
+"@geoalgeria/livraison": patch
+---
+
+Metadata: complete the package description and keywords to name the Anderson, Noest and Maystro networks alongside Yalidine and Guepex (data unchanged).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Bumps: **major** = breaking change to the project's shape (a package removed/ren
 schema break) · **minor** = a new dataset/package or a substantial data expansion ·
 **patch** = corrections and small refreshes.
 
+## 1.1.0 — 2026-06-18
+
+Added a new dataset/package since 1.0.0.
+
+- **Delivery carriers** (`@geoalgeria/livraison`): a 16-carrier registry, 411 geocoded stop-desks across 61 wilayas, and per-carrier coverage. Stop-desks come from the carriers that publish open agency data — the Yalidine + Guepex relay plus the Anderson, Noest and Maystro networks (each geocoded from its agency cards' Google Maps links).
+
+Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`.
+
 ## 1.0.0 — 2026-06-16
 
 First tagged release of the project as a whole — the state of every dataset today.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
-GeoAlgeria publishes four packages to npm — **`geoalgeria`** (the dataset, kept
-unscoped as the flagship), **`@geoalgeria/poste`**, **`@geoalgeria/emploi`** and
-**`@geoalgeria/mobilis`** (under the `@geoalgeria` org) — using
+GeoAlgeria publishes eight packages to npm — **`geoalgeria`** (the dataset, kept
+unscoped as the flagship) plus **`@geoalgeria/poste`**, **`@geoalgeria/emploi`**,
+**`@geoalgeria/mobilis`**, **`@geoalgeria/telecom`**, **`@geoalgeria/aviation`**,
+**`@geoalgeria/banques`** and **`@geoalgeria/livraison`** (under the `@geoalgeria` org) — using
 [Changesets](https://github.com/changesets/changesets) with a **"Version
 Packages" PR** and **staged Trusted Publishing** (the same flow as the GPC
 monorepo). The web app lives in the separate **`geoalgeria.com`** repo and is
@@ -151,8 +152,8 @@ These are prerequisites the workflow can't do for you:
    ```
    After that, future bumps go through the staged workflow.
 3. **Trusted Publisher per package** — on npmjs.com, for each of `geoalgeria`,
-   `@geoalgeria/poste`, `@geoalgeria/emploi`, `@geoalgeria/mobilis`,
-   `@geoalgeria/banques`: *Settings →
+   `@geoalgeria/poste`, `@geoalgeria/emploi`, `@geoalgeria/mobilis`, `@geoalgeria/telecom`,
+   `@geoalgeria/aviation`, `@geoalgeria/banques`, `@geoalgeria/livraison`: *Settings →
    Trusted Publisher → GitHub Actions*, repo **`yasserstudio/geoalgeria`**,
    workflow `release.yml`.
    No `NPM_TOKEN` — auth is the workflow's OIDC `id-token`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoalgeria-monorepo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis, @geoalgeria/telecom, @geoalgeria/aviation, @geoalgeria/banques, @geoalgeria/livraison) published to npm",


### PR DESCRIPTION
Pre-launch cleanup (the three items chosen):

**1. Umbrella project → v1.1.0** — a new package warrants a project minor bump (per RELEASING). Adds the `CHANGELOG.md` section for `@geoalgeria/livraison` and bumps root `package.json` to `1.1.0`. The `v1.1.0` **git tag** is pushed separately after merge (the umbrella is tag + root CHANGELOG only — no GitHub Release, no npm).

**2. RELEASING.md refresh** — "publishes **four** packages" → eight; the per-package **Trusted Publisher** checklist now includes `telecom`, `aviation` and `livraison` (was missing them).

**3. livraison `1.0.1` patch (queued)** — a Changeset so the completed package **description + keywords** (now naming Anderson/Noest/Maystro) reach the npm page via the staged Trusted-Publishing flow. On merge, the bot opens the "Version Packages" PR. Patch = no GitHub Release; npm only.

`changeset status` → `@geoalgeria/livraison` bumps at patch. `pnpm validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)