### PR TITLE
fix(stage-publish): derive package list from the workspace

### DIFF
--- a/scripts/stage-publish.js
+++ b/scripts/stage-publish.js
@@ -10,25 +10,26 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const PACKAGES = [
-  "packages/dataset",
-  "packages/poste",
-  "packages/emploi",
-  "packages/mobilis",
-  "packages/telecom",
-  "packages/aviation",
-  "packages/banques",
-];
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Derive the publishable packages from the workspace so a newly added package is
+// never silently skipped (it would otherwise never stage on release). Every
+// non-private package dir under packages/ is a staging candidate.
+const PACKAGES = readdirSync(join(ROOT, "packages"))
+  .map((d) => `packages/${d}`)
+  .filter((p) => existsSync(join(ROOT, p, "package.json")) && !JSON.parse(readFileSync(join(ROOT, p, "package.json"), "utf8")).private)
+  .sort();
 
 let staged = 0;
 let skipped = 0;
 const failed = [];
 
 for (const pkg of PACKAGES) {
-  const pkgJson = JSON.parse(readFileSync(join(pkg, "package.json"), "utf8"));
+  const pkgJson = JSON.parse(readFileSync(join(ROOT, pkg, "package.json"), "utf8"));
   const { name, version } = pkgJson;
 
   let registryVersion;
@@ -60,7 +61,7 @@ for (const pkg of PACKAGES) {
   console.log(`staging: ${name}@${version} (registry: ${registryVersion ?? "unpublished"})`);
   try {
     const out = execFileSync("npm", ["stage", "publish", "--ignore-scripts"], {
-      cwd: pkg,
+      cwd: join(ROOT, pkg),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });


### PR DESCRIPTION
The staged-publish step skipped `@geoalgeria/livraison`: `scripts/stage-publish.js` had a hardcoded `PACKAGES` array of 7 dirs that omitted `packages/livraison`. So the `1.0.1` release ran `0 staged, 7 skipped` and never put livraison into npm's staging area.

This is the same stale-hardcoded-list bug already fixed in `purge-cdn`, `release.yml` and `announce.yml`. Fix: derive the list from `packages/*/package.json` (non-private) so a new package always stages; also make the loop cwd-independent (resolve paths from the script root).

Verified locally: derivation yields all 8 packages including `@geoalgeria/livraison@1.0.1`; `node --check` passes.

On merge, the Release workflow re-runs and stages livraison `1.0.1` (then it needs maintainer approval on npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)