### PR TITLE
chore: umbrella v1.2.0 (adds jeunesse + enseignement-superieur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Bumps: **major** = breaking change to the project's shape (a package removed/ren
 schema break) · **minor** = a new dataset/package or a substantial data expansion ·
 **patch** = corrections and small refreshes.
 
+## 1.2.0 — 2026-06-20
+
+Added two new datasets/packages since 1.1.0.
+
+- **Youth & sports institutions** (`@geoalgeria/jeunesse`): 2,076 institutions across 50 wilayas — maisons de jeunes, complexes sportifs, salles polyvalentes, auberges de jeunes, cultural centers and more (Ministère de la Jeunesse), each with its Arabic name, type, commune/daïra/wilaya and coordinates.
+- **Higher education** (`@geoalgeria/enseignement-superieur`): 110 institutions across 51 wilayas — 58 universities, 35 grandes écoles, 12 écoles normales supérieures and 5 centres universitaires (MESRS), each with its official website, type, and wilaya/commune linkage. Coordinates are OpenStreetMap-derived (ODbL) and labelled per record (`geo_precision`).
+
+Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/enseignement-superieur`.
+
 ## 1.1.0 — 2026-06-18
 
 Added a new dataset/package since 1.0.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoalgeria-monorepo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis, @geoalgeria/telecom, @geoalgeria/aviation, @geoalgeria/banques, @geoalgeria/livraison, @geoalgeria/jeunesse, @geoalgeria/enseignement-superieur) published to npm",


### PR DESCRIPTION
Project-level (umbrella) version milestone. Bumps root `package.json` 1.1.0 → **1.2.0** and adds the root `CHANGELOG.md` entry covering the two datasets added since the `v1.1.0` tag:

- **`@geoalgeria/jeunesse`** — 2,076 youth & sports institutions (Ministère de la Jeunesse), 50 wilayas.
- **`@geoalgeria/enseignement-superieur`** — 110 higher-education institutions (MESRS), 51 wilayas, with official websites; OSM-derived coordinates labelled per record.

Per `RELEASING.md` › *Project (umbrella) versions*, this is a **tag + root CHANGELOG**, not a GitHub Release. After merge, the `v1.2.0` tag is pushed onto the merge commit. No npm/package effect (root is `private`, no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)