### PR TITLE
docs: align package listings across the repo (all 10 packages)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ This file is the short version of how work flows here; deeper docs are linked.
 | `packages/poste/` | `@geoalgeria/poste` | post offices & ATMs (Algérie Poste) |
 | `packages/emploi/` | `@geoalgeria/emploi` | employment agencies (ANEM: AWEM + ALEM) |
 | `packages/mobilis/` | `@geoalgeria/mobilis` | Mobilis agencies & approved points of sale (mobilis.dz) |
+| `packages/telecom/` | `@geoalgeria/telecom` | cross-operator 5G coverage (Djezzy, Mobilis, Ooredoo) |
+| `packages/aviation/` | `@geoalgeria/aviation` | civil airports with ICAO codes (ANAC) |
+| `packages/banques/` | `@geoalgeria/banques` | licensed banks, institutions & branches (RIB/SWIFT) |
+| `packages/livraison/` | `@geoalgeria/livraison` | delivery carriers & geocoded stop-desks |
+| `packages/jeunesse/` | `@geoalgeria/jeunesse` | youth & sports institutions (Ministère de la Jeunesse) |
+| `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network — universities, grandes écoles, ENS, centres (MESRS) |
 
 The postal data under `packages/dataset/data/poste/` is a **generated mirror** —
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ This is a small monorepo:
 | `packages/poste/` | `@geoalgeria/poste` | post offices & ATMs (Algérie Poste) |
 | `packages/emploi/` | `@geoalgeria/emploi` | employment agencies (ANEM: AWEM + ALEM) |
 | `packages/mobilis/` | `@geoalgeria/mobilis` | Mobilis agencies & approved points of sale (mobilis.dz) |
+| `packages/telecom/` | `@geoalgeria/telecom` | cross-operator 5G coverage (Djezzy, Mobilis, Ooredoo) |
+| `packages/aviation/` | `@geoalgeria/aviation` | civil airports with ICAO codes (ANAC) |
+| `packages/banques/` | `@geoalgeria/banques` | licensed banks, institutions & branches (RIB/SWIFT) |
+| `packages/livraison/` | `@geoalgeria/livraison` | delivery carriers & geocoded stop-desks |
+| `packages/jeunesse/` | `@geoalgeria/jeunesse` | youth & sports institutions (Ministère de la Jeunesse) |
+| `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network — universities, grandes écoles, ENS, centres (MESRS) |
 
 ## How to contribute
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,8 @@ Include:
 
 ## Supported versions
 
-Only the latest published version of each package (`geoalgeria`,
-`@geoalgeria/poste`, `@geoalgeria/emploi`, `@geoalgeria/mobilis`) is supported.
-Fixes ship forward in a
+Only the latest published version of each package (`geoalgeria` and every
+`@geoalgeria/*` scoped package) is supported. Fixes ship forward in a
 new release rather than as patches to old versions.
 
 ## Supply-chain practices

--- a/packages/dataset/README.md
+++ b/packages/dataset/README.md
@@ -184,6 +184,26 @@ This dataset uses [Semantic Versioning](https://semver.org/). See [CHANGELOG.md]
 
 ---
 
+## The GeoAlgeria ecosystem
+
+`geoalgeria` is the administrative base layer. Domain datasets install alongside it and join on `wilaya_code`:
+
+| Package | What |
+| --- | --- |
+| [`@geoalgeria/poste`](https://www.npmjs.com/package/@geoalgeria/poste) | Post offices & ATMs (Algérie Poste) |
+| [`@geoalgeria/emploi`](https://www.npmjs.com/package/@geoalgeria/emploi) | Employment agencies (ANEM: AWEM + ALEM) |
+| [`@geoalgeria/mobilis`](https://www.npmjs.com/package/@geoalgeria/mobilis) | Mobilis agencies & approved points of sale |
+| [`@geoalgeria/telecom`](https://www.npmjs.com/package/@geoalgeria/telecom) | Cross-operator 5G coverage (Djezzy, Mobilis, Ooredoo) |
+| [`@geoalgeria/aviation`](https://www.npmjs.com/package/@geoalgeria/aviation) | Civil airports with ICAO codes (ANAC) |
+| [`@geoalgeria/banques`](https://www.npmjs.com/package/@geoalgeria/banques) | Licensed banks, institutions & branches (RIB/SWIFT) |
+| [`@geoalgeria/livraison`](https://www.npmjs.com/package/@geoalgeria/livraison) | Delivery carriers & geocoded stop-desks |
+| [`@geoalgeria/jeunesse`](https://www.npmjs.com/package/@geoalgeria/jeunesse) | Youth & sports institutions (Ministère de la Jeunesse) |
+| [`@geoalgeria/enseignement-superieur`](https://www.npmjs.com/package/@geoalgeria/enseignement-superieur) | Higher-education network — universities, grandes écoles, ENS, centres (MESRS) |
+
+Full list and the monorepo: [github.com/yasserstudio/geoalgeria](https://github.com/yasserstudio/geoalgeria).
+
+---
+
 ## Built With This Data
 
 Using geoalgeria in your project? [Open a discussion](https://github.com/yasserstudio/geoalgeria/discussions) and we'll feature it here.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,10 @@ importers:
 
   packages/emploi: {}
 
+  packages/enseignement-superieur: {}
+
+  packages/jeunesse: {}
+
   packages/livraison: {}
 
   packages/mobilis: {}


### PR DESCRIPTION
Consistency pass after adding `jeunesse`, `enseignement-superieur`, and the `v1.2.0` umbrella.

- **AGENTS.md / CONTRIBUTING.md** — the layout tables listed only the original 4 packages (dataset, poste, emploi, mobilis); expanded both to all **10**.
- **SECURITY.md** — generalized supported-versions from a hard-coded 3-package list to "`geoalgeria` + every `@geoalgeria/*` scoped package" so it can't go stale again.
- **flagship `geoalgeria` README** — added a **GeoAlgeria ecosystem** table linking out to all 9 sibling packages (they already link back to it; this closes the loop).
- **pnpm-lock.yaml** — registered the missing `enseignement-superieur` **and** `jeunesse` workspace entries so the lockfile matches `packages/` (keeps `--frozen-lockfile` green in the release workflow). Verified: `pnpm install --frozen-lockfile` passes.

Already consistent (no change needed): root README tables, RELEASING ("ten packages"), all per-package `package.json` descriptions, and the dataset README's 1,528/1,541 commune reconciliation wording.

Docs + lockfile only — no code or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)