### PR TITLE
fix(ci): auto-post the Announce Discussion for every release

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -5,10 +5,17 @@ name: Announce
 #  - X (Twitter) and LinkedIn drafts are attached to the release for a human to
 #    copy-paste (never auto-posted to third-party networks)
 #
-# Note on timing: this fires when the release.yml workflow cuts the GitHub
-# Release, which happens at npm STAGE time — the package goes live only once you
-# approve the staged version (see RELEASING.md). Approve promptly so the
-# announcement and the live npm version line up.
+# How it's triggered: release.yml explicitly DISPATCHES this workflow (per tag)
+# right after it cuts each GitHub Release. The `release: published` event does NOT
+# fire for those releases because release.yml creates them with GITHUB_TOKEN, and
+# GitHub suppresses token-created events to prevent recursion — workflow_dispatch
+# is the documented exception, so dispatch is the reliable path. The `release`
+# trigger is kept for releases created by a human/PAT. Run by hand from the Actions
+# tab (workflow_dispatch) for any tag too.
+#
+# Note on timing: release.yml cuts the GitHub Release at npm STAGE time — the
+# package goes live only once you approve the staged version (see RELEASING.md).
+# Approve promptly so the announcement and the live npm version line up.
 
 on:
   release:
@@ -50,8 +57,11 @@ jobs:
             printf 'skip=true\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Fail closed on anything that isn't one of our package tags.
-          if ! printf '%s' "$RAW_TAG" | grep -Eq '^(geoalgeria|@geoalgeria/(poste|emploi|mobilis|banques|telecom|aviation|livraison))@[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # Fail closed on anything that isn't one of our package tags. Match any
+          # @geoalgeria/<name> scoped package (or the unscoped flagship) plus a
+          # semver suffix — generic so a new package never needs this list edited
+          # (the old hardcoded list silently failed jeunesse + enseignement-superieur).
+          if ! printf '%s' "$RAW_TAG" | grep -Eq '^(geoalgeria|@geoalgeria/[a-z][a-z0-9]*(-[a-z0-9]+)*)@[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Refusing to announce malformed tag: $RAW_TAG"
             exit 1
           fi
@@ -116,7 +126,9 @@ jobs:
             --jq '.data.createDiscussion.discussion.url'
 
       - name: Attach social drafts to the release
-        if: steps.tag.outputs.skip != 'true' && github.event_name == 'release'
+        # Runs for dispatched runs too (release.yml dispatches us after the release
+        # exists); the upload no-ops with a warning if the release isn't there yet.
+        if: steps.tag.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      actions: write # dispatch the Announce workflow after cutting each release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -119,4 +120,11 @@ jobs:
               echo "::warning::No CHANGELOG section found for $TAG; using auto-generated notes"
               gh release create "$TAG" --title "$TAG" --target "$GITHUB_SHA" --generate-notes "$BUNDLE"
             fi
+
+            # Announce this release. The release: published event won't fire (this
+            # release was created with GITHUB_TOKEN, which GitHub suppresses to avoid
+            # recursion), so dispatch Announce explicitly — workflow_dispatch is the
+            # documented exception GITHUB_TOKEN is allowed to trigger.
+            gh workflow run announce.yml -f tag="$TAG" \
+              || echo "::warning::Could not dispatch Announce for $TAG — run it by hand (Actions tab → Announce)."
           done


### PR DESCRIPTION
The GitHub **Announcements Discussion** stopped posting for new package launches (jeunesse, enseignement-superieur both missing theirs; backfilled by hand as #45/#46). Two root causes, both fixed here.

### 1. `announce.yml` run-failure — stale tag allowlist
The "Resolve tag" step's allowlist hardcoded package names and was missing `jeunesse` + `enseignement-superieur`, so their runs failed with `Refusing to announce malformed tag` and exit 1. Replaced with a generic, npm-name-correct pattern:
```
^(geoalgeria|@geoalgeria/[a-z][a-z0-9]*(-[a-z0-9]+)*)@[0-9]+\.[0-9]+\.[0-9]+$
```
Future packages never need this edited. Still a tight fail-closed gate (rejects the umbrella `vX.Y.Z`, foreign scopes, malformed names, and injection — `RAW_TAG` is never shell-interpolated).

### 2. Trigger gap — `release: published` doesn't fire for token-created releases
`release.yml` creates releases with `GITHUB_TOKEN`, and GitHub suppresses token-created events to prevent recursion, so `announce.yml`'s `release` trigger never fired. Fix: `release.yml` now runs `gh workflow run announce.yml -f tag="$TAG"` after each `gh release create` — `workflow_dispatch` is the documented exception `GITHUB_TOKEN` **is** allowed to trigger. Added `actions: write` (the minimal scope for self-dispatch). The dispatch sits after the patch/already-released `continue`s, so it only fires for tags that actually got a release. Idempotency is preserved by announce.yml's existing "already exists" discussion check.

### Review
Focused security + correctness review: 0 critical/high. Confirmed the `workflow_dispatch` recursion-exception (the crux), no shell-injection surface, `actions: write` is minimal, and all edge cases (patch skips, umbrella skip, double-post guard, draft-attach) hold.

CI-only change. Validated: both YAMLs parse; the new regex accepts every real tag and rejects malformed/umbrella/foreign ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)