### PR TITLE
docs(changeset): conform release titles to RELEASE_TEMPLATE

### DIFF
--- a/.changeset/enseignement-superieur-private-other-ministries.md
+++ b/.changeset/enseignement-superieur-private-other-ministries.md
@@ -2,11 +2,10 @@
 "@geoalgeria/enseignement-superieur": minor
 ---
 
-Expand to the full higher-education registry — 179 institutions (was 110).
+Add private and other-ministry institutions
 
-- Add the 19 licensed **private** institutions and the 50 establishments under **other ministries** (Défense, Santé, Culture, Poste, Travail) that MESRS supervises pedagogically — sourced from the ministry's Arabic listing, which the English page omits.
-- New fields: `name_ar` (Arabic name — present for every new institution and backfilled for ~88% of the public network via website join), `sector` (`"public"` | `"private"`), `supervisory_ministry` (the supervising ministry for non-MESRS institutions, else `null`).
-- New helper `institutionsBySector("public" | "private")`.
-- `name` is now nullable: the private/other-ministry institutions are published in Arabic only, so they carry `name_ar` with `name: null`.
-
-Additive and backward-compatible: existing fields and records are unchanged; the new institutions are placed at their wilaya centroid (`geo_precision: "wilaya"`), as the source publishes no address for them. Note for TypeScript consumers: `name` is now `string | null`, so code reading `.name` on the new records should null-check (use `name ?? name_ar`).
+- 177 higher-education institutions (was 110): +19 licensed private and +48 establishments under other ministries (Santé 25, Défense 16, Culture 4, Poste 2, Travail 1) that MESRS supervises pedagogically — sourced from the ministry's Arabic listing, which the English page omits
+- New fields: `name_ar` (Arabic name — present for every new institution and backfilled for the public network via website join, 164/177 records), `sector` (`"public"` | `"private"`), `supervisory_ministry` (the supervising ministry for non-MESRS institutions, else `null`)
+- New helper `institutionsBySector("public" | "private")`; `name` is now nullable (the private/other-ministry institutions are published in Arabic only, so they carry `name_ar` with `name: null`)
+- Additive and backward-compatible: existing records unchanged; new institutions placed at their wilaya centroid (`geo_precision: "wilaya"`). TypeScript consumers reading `.name` on the new records should null-check (`name ?? name_ar`)
+- Source: MESRS Arabic listing (mesrs.dz/reseau-universitaire-ar)

--- a/.changeset/jeunesse-geoserver-v2.md
+++ b/.changeset/jeunesse-geoserver-v2.md
@@ -2,12 +2,11 @@
 "@geoalgeria/jeunesse": major
 ---
 
-Rebuild from the official Ministère de la Jeunesse et des Sports GIS (sig.mjs.gov.dz), the same system behind @geoalgeria/sports.
+Rebuilt from the official Youth Ministry GIS
 
-- 2,334 youth establishments (was 2,076), spanning 58 wilayas
+- 2,334 youth establishments (was 2,076), spanning 58 wilayas — now sourced from the MJS SIG (sig.mjs.gov.dz), the same system behind the sports dataset
 - Names are now French (`name`); the Arabic name is backfilled into a new `name_ar` field by type-checked nearest-neighbour geo-match (~59% of records)
 - New fields: `name_ar`, `address`, `capacity`, `year`, `operational`, `pmr` (PMR accessibility), `surface_built_m2`, `surface_land_m2`
-- New stable type codes for the GIS's nine youth-establishment types (`MJ`, `CSP`, `SPA`, `AJ`, `CJ`, `CLS`, `FJ`, `CC`, `BA`)
-- `id` is now a stable sequential integer assigned at build time
-
-BREAKING: `name` and the commune/daira/wilaya_name fields are now French, not Arabic; type codes and ids changed. Join `wilaya_code` against `geoalgeria` for French divisions, or read `name_ar` for the Arabic name where available.
+- New stable type codes for the nine youth-establishment types (`MJ`, `CSP`, `SPA`, `AJ`, `CJ`, `CLS`, `FJ`, `CC`, `BA`); `id` is now a stable sequential integer
+- BREAKING: `name` and the commune/daira/wilaya_name fields are now French, not Arabic; type codes and ids changed. Join `wilaya_code` against `geoalgeria` for French divisions, or read `name_ar` for the Arabic name where available
+- Source: Ministère de la Jeunesse et des Sports — SIG (sig.mjs.gov.dz)


### PR DESCRIPTION
The first bullet of a changeset note becomes the GitHub Release & Discussion title (`release.yml` + announce workflow extract it verbatim). The jeunesse and enseignement-superieur changesets had long first lines with package names and trailing periods — fixed to short factual headlines per `.github/RELEASE_TEMPLATE.md`:

- **jeunesse** → `Rebuilt from the official Youth Ministry GIS`
- **enseignement-superieur** → `Add private and other-ministry institutions`

Also corrects the ens-sup count to **177** (a stale **179** remained from before the source-duplicate dedup).

No code or version changes — only the changeset note wording. The open "Version Packages" PR (#60) will regenerate with the corrected CHANGELOG titles.