### PR TITLE
docs(changelog): use Added/Improved/Dropped release-notes format

### DIFF
--- a/packages/enseignement-superieur/CHANGELOG.md
+++ b/packages/enseignement-superieur/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 ## 1.1.0
 
-### Minor Changes
+### Added
 
-- 8ddc502: Add private and other-ministry institutions
+- 19 licensed private institutions and 48 establishments under other ministries
+  (Santé 25, Défense 16, Culture 4, Poste 2, Travail 1) that MESRS supervises
+  pedagogically — sourced from the ministry's Arabic listing, which the English
+  page omits (110 → 177 institutions)
+- New fields: `name_ar` (Arabic name; also backfilled for the public network via
+  website join — 164/177 records), `sector` (`public` / `private`), and
+  `supervisory_ministry`
+- New helper `institutionsBySector("public" | "private")`
 
-  - 177 higher-education institutions (was 110): +19 licensed private and +48 establishments under other ministries (Santé 25, Défense 16, Culture 4, Poste 2, Travail 1) that MESRS supervises pedagogically — sourced from the ministry's Arabic listing, which the English page omits
-  - New fields: `name_ar` (Arabic name — present for every new institution and backfilled for the public network via website join, 164/177 records), `sector` (`"public"` | `"private"`), `supervisory_ministry` (the supervising ministry for non-MESRS institutions, else `null`)
-  - New helper `institutionsBySector("public" | "private")`; `name` is now nullable (the private/other-ministry institutions are published in Arabic only, so they carry `name_ar` with `name: null`)
-  - Additive and backward-compatible: existing records unchanged; new institutions placed at their wilaya centroid (`geo_precision: "wilaya"`). TypeScript consumers reading `.name` on the new records should null-check (`name ?? name_ar`)
-  - Source: MESRS Arabic listing (mesrs.dz/reseau-universitaire-ar)
+### Improved
+
+- `name` is now nullable, so the Arabic-only private/other-ministry institutions
+  ship with `name_ar` (use `name ?? name_ar` for a display label)
 
 ## 1.0.0
 

--- a/packages/jeunesse/CHANGELOG.md
+++ b/packages/jeunesse/CHANGELOG.md
@@ -2,16 +2,27 @@
 
 ## 2.0.0
 
-### Major Changes
+### Added
 
-- 7b93dcf: Rebuilt from the official Youth Ministry GIS
+- `name_ar` (Arabic name, backfilled from the legacy ministry map by type-checked
+  nearest-neighbour geo-match, ~59% of records)
+- New per-record fields: address, capacity, year of reception, operational status,
+  PMR accessibility, and built / land area
+- Sister package to `@geoalgeria/sports` — both from the same official Ministère de
+  la Jeunesse et des Sports GIS (sig.mjs.gov.dz)
 
-  - 2,334 youth establishments (was 2,076), spanning 58 wilayas — now sourced from the MJS SIG (sig.mjs.gov.dz), the same system behind the sports dataset
-  - Names are now French (`name`); the Arabic name is backfilled into a new `name_ar` field by type-checked nearest-neighbour geo-match (~59% of records)
-  - New fields: `name_ar`, `address`, `capacity`, `year`, `operational`, `pmr` (PMR accessibility), `surface_built_m2`, `surface_land_m2`
-  - New stable type codes for the nine youth-establishment types (`MJ`, `CSP`, `SPA`, `AJ`, `CJ`, `CLS`, `FJ`, `CC`, `BA`); `id` is now a stable sequential integer
-  - BREAKING: `name` and the commune/daira/wilaya_name fields are now French, not Arabic; type codes and ids changed. Join `wilaya_code` against `geoalgeria` for French divisions, or read `name_ar` for the Arabic name where available
-  - Source: Ministère de la Jeunesse et des Sports — SIG (sig.mjs.gov.dz)
+### Improved
+
+- Rebuilt from the official Ministère de la Jeunesse et des Sports GIS — 2,334
+  establishments (was 2,076), spanning 58 wilayas
+- Primary names are now French, with stable type codes (`MJ`, `CSP`, `SPA`, `AJ`,
+  `CJ`, `CLS`, `FJ`, `CC`, `BA`) and sequential integer ids
+
+### Dropped
+
+- Arabic as the primary `name` (now French — read `name_ar` for the Arabic name)
+  and the legacy youthconnect source; old type codes and ids. Join `wilaya_code`
+  against `geoalgeria` for French commune/wilaya names
 
 ## 1.0.0
 

--- a/packages/sports/CHANGELOG.md
+++ b/packages/sports/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## 1.0.0
 
-### Major Changes
+### Added
 
-- Initial release — 5,141 sports facilities across 58 wilayas, sourced from the Ministère de la Jeunesse et des Sports GIS (sig.mjs.gov.dz).
-- 27 facility types: proximity fields, stadiums, swimming pools, halls, athletics tracks, tennis courts, equestrian centers, nautical bases and more.
-- Each facility includes name, type, address, commune/daïra/wilaya, capacity, year of reception, operational status, PMR accessibility, built and land area, and GPS coordinates.
-- Ships as JSON, CSV, GeoJSON with TypeScript definitions and programmatic loaders.
+- 5,141 sports facilities across 58 wilayas, sourced from the Ministère de la
+  Jeunesse et des Sports GIS (sig.mjs.gov.dz)
+- 27 facility types: proximity fields, stadiums, swimming pools, halls, athletics
+  tracks, tennis courts, equestrian centers, nautical bases and more
+- Per-facility name, type, address, commune / daïra / wilaya, capacity, year of
+  reception, operational status, PMR accessibility, built / land area, and GPS
+  coordinates
+- Wilaya linkage (`wilaya_code`) joining the geoalgeria wilaya model
+- Export formats: JSON, CSV, GeoJSON, with TypeScript types and helper accessors


### PR DESCRIPTION
Aligns the committed changelogs with the established **jeunesse@1.0.0** release style the project uses for GitHub Releases:

- **Title**: descriptive — `Algeria's <thing> — <N> from <Source>, <qualities>.`
- **Body**: keep-a-changelog sections — `### Added` / `### Improved` / `### Dropped`

The changesets automation had produced `### Major/Minor Changes` with a hash-prefixed title and nested sub-bullets; this rewrites the jeunesse 2.0.0, enseignement-superieur 1.1.0 and sports 1.0.0 sections to the Added/Improved/Dropped format, matching the live GitHub Release bodies (corrected the same way).

Release-notes wording only — no version/code changes.