### PR TITLE
docs(release): make jeunesse@1.0.0 style the documented + automated format

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -7,58 +7,81 @@ automation works. **This is the source of truth** for release-note structure;
 ## How a release note flows
 
 ```
-changeset note  →  packages/<pkg>/CHANGELOG.md section  →  GitHub Release body
-                                                            (release.yml extracts
-                                                             the section verbatim)
+changeset note  →  packages/<pkg>/CHANGELOG.md section  →  GitHub Release
+                   (finalized in the "Version             (release.yml runs
+                    Packages" PR to the format below)      scripts/release-notes.mjs:
+                                                            title = the headline line,
+                                                            body  = the ### sections)
                                                          →  Announce workflow
-                                                            (headline = first bullet)
 ```
 
-So the **changeset note you write is the release note**. Write it well once.
+## The format (modeled on `@geoalgeria/jeunesse@1.0.0`)
 
-## The template
-
-When you run `pnpm changeset`, structure the note like this:
-
-```
-- <Title: short, factual, what changed. ≤ ~50 chars / ~8 words. No period. THIS is the title.>
-- <Detail: the concrete facts — counts, fields, formats. Lead with the number.>
-- Source: <JORA n° XX / Algérie Poste / ONS / Interior Ministry>   ← for data changes
-```
-
-With `pnpm changeset`, the first line of your summary becomes this first bullet —
-write it as a **short, sober title**, and put the detail in the lines below.
-
-Rules:
-- **First bullet is the title — keep it short.** Aim for **≤ ~50 characters / ~8
-  words**, no trailing period. It states *what changed*, not a pitch:
-  "Branches for all 21 licensed banks" — not "Every licensed bank in Algeria now
-  has branch locations, all 21!".
-- **Titles render as just the `<title>`.** `release.yml` and the announcer use the
-  first bullet verbatim, so a GitHub Release & Discussion title looks like
-  **`Branches for all 21 licensed banks`**. The **version and package name/scope**
-  are never in the title — they're already in the release tag chip + URL (which is
-  why the title alone must say what changed). The same title is also the social hook.
-- **Tone: sober and factual.** No emoji, no hype, no marketing CTAs ("ship fast",
-  "🇩🇿", "drop it into your app"). This is a data project — state the facts, cite
-  the source, link npm + the release. Let the numbers do the selling.
-- **Always cite a source** for data changes (it's also the contribution rule).
-- **Bump:** `major` = breaking schema · `minor` = new data/format/package ·
-  `patch` = corrections to existing records. The bump gates auto-announce
-  (minor/major post a Discussion; patch stays quiet).
-- New package → its first release is a `minor` and **deserves a real note** — do
-  not let it ship with an empty auto-generated changelog (see emploi@1.0.0).
-
-## Worked example (geoalgeria@1.1.0)
+A CHANGELOG section is a **descriptive title line**, then **keep-a-changelog
+sections** — `### Added`, `### Improved`, `### Dropped` (use only the ones that
+apply):
 
 ```
-- Real postal codes for ~1,440 communes
-- Corrected from Algérie Poste data (previously only ~88 matched reality).
-- Added 3,908 post offices and 2,026 ATMs (codes, bilingual names, coordinates) in JSON, CSV, GeoJSON.
-- Added postOffices / atms / getPostOfficesByCommune() JS API + TypeScript types.
-- Source: Algérie Poste (baridimap.poste.dz).
+## 2.0.0
+
+Algeria's youth establishments — 2,334 from the official Ministère de la Jeunesse GIS, typed and geocoded.
+
+### Added
+
+- name_ar (Arabic name, backfilled by type-checked geo-match, ~59% of records)
+- Per-record address, capacity, year, operational status, PMR accessibility, built/land area
+
+### Improved
+
+- Rebuilt from the official Ministère de la Jeunesse et des Sports GIS — 2,334 establishments (was 2,076)
+
+### Dropped
+
+- Arabic as the primary `name` (now French — read `name_ar`); old type codes and ids
 ```
 
-That section becomes a GitHub Release titled *"Real postal codes for ~1,440
-communes"* (tag `geoalgeria@1.1.0`), a matching Discussion, and X/LinkedIn drafts
-— no extra work.
+`scripts/release-notes.mjs` turns that into a GitHub Release titled
+*"Algeria's youth establishments — 2,334 from the official Ministère de la Jeunesse
+GIS, typed and geocoded."* with the `### Added/Improved/Dropped` sections as the body.
+
+### Title — the headline line
+
+- Pattern: **`Algeria's <thing> — <N> from <Source>, <qualities>.`** A descriptive
+  sentence; a trailing period is fine. The count and source belong in it.
+  Examples: *"Algeria's higher-education network — 177 from the MESRS, now with
+  private & other-ministry institutions."*, *"Branches for all 21 licensed banks"*.
+- It is the **headline line of the section** (the first non-blank, non-heading,
+  non-bullet line). The version and package name/scope are **never** in the title —
+  both are already in the release tag chip + URL. The same title is the social hook.
+- If a section has **no** headline line (e.g. a raw changesets `### Minor Changes`
+  block), the extractor falls back to the first bullet — so always write the
+  headline line, don't rely on the fallback.
+
+### Body — Added / Improved / Dropped
+
+- **`### Added`** — new data, fields, formats, helpers. **`### Improved`** — bigger
+  counts, better sourcing, refinements to existing records. **`### Dropped`** —
+  removed/renamed fields, breaking changes (say `BREAKING` and the migration).
+- Bullets are **sober and factual** — no emoji, no hype, no CTAs. State the facts,
+  lead with the number, **cite the source** (it's also the contribution rule). Let
+  the numbers do the selling.
+- A **new package**'s first release is a `minor` and is all `### Added` — give it a
+  real note, never an empty auto-generated changelog.
+
+## Writing it: changeset → Version PR
+
+1. `pnpm changeset` — pick package(s) + bump, and write the note with the headline
+   line first, then the `### Added/Improved/Dropped` sections.
+2. The Release workflow opens the **"Version Packages" PR**. Changesets renders the
+   note under a `### Major/Minor/Patch Changes` heading; **before merging, finalize
+   that CHANGELOG section to the format above** (headline line + `###` sections, drop
+   the changeset hash). This is the one manual step that keeps every release on-style.
+3. Merge the Version PR → `release.yml` cuts the GitHub Release with the data bundle,
+   title and body from `scripts/release-notes.mjs`.
+
+## Bump rules
+
+`major` = breaking schema (renamed/removed fields) · `minor` = new data / format /
+package · `patch` = corrections to existing records. **Patches get no GitHub
+Release** (detected by version delta in `release-notes.mjs`) — the npm version and
+committed data cover them, and the Releases feed stays meaningful.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,30 +91,25 @@ jobs:
               (cd "$pkg" && zip -qr "$BUNDLE" data)
             fi
 
-            NOTES="$RUNNER_TEMP/$(basename "$NAME")-notes.md"  # basename: scoped names contain '/'
-            awk -v ver="$VER" '
-              BEGIN { gsub(/\./, "\\.", ver); re = "(^|[^0-9.])" ver "([^0-9.]|$)" }
-              /^## / { if (grab) exit; if ($0 ~ re) { grab=1; next } }
-              grab { print }
-            ' "$pkg/CHANGELOG.md" > "$NOTES" || true
+            # Title + body + patch-flag come from scripts/release-notes.mjs (see
+            # RELEASE_TEMPLATE.md). Title = the descriptive headline line of the
+            # CHANGELOG section (falls back to the first bullet); body = the
+            # ### Added/Improved/Dropped sections. The version + package scope are
+            # never in the title — both are already in the release tag chip + URL.
+            RN="node scripts/release-notes.mjs $pkg/CHANGELOG.md $VER $TAG"
 
             # Patches (docs/corrections) don't get a GitHub Release — the npm version
             # and the repo's committed data cover them, and the feed stays meaningful.
-            # Minor/major (new data/format/package) always get a release + bundle.
-            if grep -q '^### Patch Changes' "$NOTES"; then
+            if [ "$($RN is-patch)" = "yes" ]; then
               echo "skip release: $TAG is a patch — no GitHub Release"
               continue
             fi
 
+            NOTES="$RUNNER_TEMP/$(basename "$NAME")-notes.md"  # basename: scoped names contain '/'
+            $RN body > "$NOTES" || true
+
             if [ -s "$NOTES" ]; then
-              # Title = the headline (the first bullet) verbatim. The version and
-              # package name/scope are never in the title — both are already in the
-              # release tag chip + URL. (drop the list marker + changeset hash + bold.)
-              # See RELEASE_TEMPLATE.md.
-              HEADLINE=$(grep -m1 -E '^[-*][[:space:]]' "$NOTES" \
-                | sed -E 's/^[-*][[:space:]]+//; s/^[0-9a-f]{7,}:[[:space:]]*//; s/\*\*//g')
-              TITLE="$TAG"
-              [ -n "$HEADLINE" ] && TITLE="$HEADLINE"
+              TITLE=$($RN title)
               gh release create "$TAG" --title "$TITLE" --target "$GITHUB_SHA" --notes-file "$NOTES" "$BUNDLE"
             else
               echo "::warning::No CHANGELOG section found for $TAG; using auto-generated notes"

--- a/packages/enseignement-superieur/CHANGELOG.md
+++ b/packages/enseignement-superieur/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0
 
+Algeria's higher-education network — 177 from the MESRS, now with private & other-ministry institutions.
+
 ### Added
 
 - 19 licensed private institutions and 48 establishments under other ministries

--- a/packages/jeunesse/CHANGELOG.md
+++ b/packages/jeunesse/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0
 
+Algeria's youth establishments — 2,334 from the official Ministère de la Jeunesse GIS, typed and geocoded.
+
 ### Added
 
 - `name_ar` (Arabic name, backfilled from the legacy ministry map by type-checked

--- a/packages/sports/CHANGELOG.md
+++ b/packages/sports/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0
 
+Algeria's sports facilities — 5,141 from the Ministère de la Jeunesse et des Sports GIS, typed and geocoded.
+
 ### Added
 
 - 5,141 sports facilities across 58 wilayas, sourced from the Ministère de la

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Extract the GitHub Release title + body for one package version from its
+ * CHANGELOG.md, following RELEASE_TEMPLATE.md. Replaces the inline awk/grep/sed
+ * in release.yml so the logic is readable and testable.
+ *
+ * A CHANGELOG section is everything between `## <version>` and the next `## `.
+ * Two shapes are supported, both detected automatically:
+ *
+ *   Preferred (jeunesse style) — a descriptive title line, then keep-a-changelog
+ *   sections. The prose line is the Release TITLE; the `###` sections are the body:
+ *       ## 2.0.0
+ *       Algeria's youth establishments — 2,334 from the Ministère de la Jeunesse GIS…
+ *       ### Added
+ *       - …
+ *
+ *   Changesets fallback — `### Major/Minor Changes` + bullets. The first bullet is
+ *   the TITLE (hash/marker/bold stripped); the whole section is the body.
+ *
+ * Usage: node scripts/release-notes.mjs <changelog> <version> <tag> <title|body|is-patch>
+ */
+
+import { readFileSync } from "node:fs";
+
+const [, , changelogPath, version, tag, mode] = process.argv;
+if (!changelogPath || !version || !tag || !mode) {
+  console.error("usage: release-notes.mjs <changelog> <version> <tag> <title|body|is-patch>");
+  process.exit(2);
+}
+
+const lines = readFileSync(changelogPath, "utf8").split("\n");
+
+// Collect this version's section (between its `## ` heading and the next), and the
+// list of every `## x.y.z` version in file order (for patch detection).
+const esc = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const verRe = new RegExp(`(^|[^0-9.])${esc}([^0-9.]|$)`);
+const section = [];
+const versions = [];
+let grab = false;
+for (const line of lines) {
+  if (/^##\s/.test(line)) {
+    const m = line.match(/(\d+\.\d+\.\d+)/);
+    if (m) versions.push(m[1]);
+    if (grab) grab = false; // next heading ends our section
+    if (verRe.test(line)) { grab = true; continue; }
+  }
+  if (grab) section.push(line);
+}
+
+// --- is-patch: version-based, so it works for both note formats ----------------
+function isPatch() {
+  const i = versions.indexOf(version);
+  const prev = i >= 0 && i + 1 < versions.length ? versions[i + 1] : null;
+  if (!prev) return false; // first release of this package is never a patch
+  const a = prev.split(".").map(Number);
+  const b = version.split(".").map(Number);
+  return b[0] === a[0] && b[1] === a[1] && b[2] !== a[2];
+}
+
+// --- title ---------------------------------------------------------------------
+const isHeading = (l) => /^#{1,6}\s/.test(l);
+const isBullet = (l) => /^\s*[-*]\s+/.test(l);
+const cleanBullet = (l) =>
+  l.replace(/^\s*[-*]\s+/, "").replace(/^[0-9a-f]{7,}:\s*/i, "").replace(/\*\*/g, "").trim();
+
+function title() {
+  for (const l of section) {
+    if (!l.trim()) continue;
+    if (isHeading(l)) continue;
+    if (isBullet(l)) break; // hit the bullets before any prose → use the bullet path
+    return l.trim().replace(/\*\*/g, ""); // prose title line (jeunesse style)
+  }
+  const bullet = section.find(isBullet);
+  return bullet ? cleanBullet(bullet) : tag;
+}
+
+// --- body ----------------------------------------------------------------------
+function body() {
+  // If a prose title line precedes the sections, the body is the `###` sections
+  // (the title isn't repeated in the body). Otherwise the whole section is the body.
+  let hasProseTitle = false;
+  for (const l of section) {
+    if (!l.trim()) continue;
+    if (isHeading(l)) break;
+    if (isBullet(l)) break;
+    hasProseTitle = true;
+    break;
+  }
+  let out = section;
+  if (hasProseTitle) {
+    const firstHeading = section.findIndex(isHeading);
+    if (firstHeading >= 0) out = section.slice(firstHeading);
+  }
+  return out.join("\n").trim() + "\n";
+}
+
+if (mode === "title") process.stdout.write(title() + "\n");
+else if (mode === "body") process.stdout.write(body());
+else if (mode === "is-patch") process.stdout.write(isPatch() ? "yes\n" : "no\n");
+else { console.error(`unknown mode: ${mode}`); process.exit(2); }


### PR DESCRIPTION
## Why
The repo was internally inconsistent about release notes, which is why they kept coming out wrong:
- `.github/RELEASE_TEMPLATE.md` documented a flat *"short title + bullets"* style (no period, no package name).
- `release.yml` derived the Release **title from the first bullet** and the body from the raw changesets section.
- But the releases the project actually wants follow the **`@geoalgeria/jeunesse@1.0.0`** style — a descriptive *"Algeria's &lt;thing&gt; — &lt;N&gt; from &lt;Source&gt;, &lt;qualities&gt;."* title with **`### Added` / `### Improved` / `### Dropped`** notes.

## What changed
- **`scripts/release-notes.mjs`** (new) — a small, testable extractor: `title` = the section's descriptive headline line (falls back to the first bullet for legacy changesets sections), `body` = the `###` sections, `is-patch` = version-delta based (format-independent, replaces the `### Patch Changes` grep).
- **`.github/workflows/release.yml`** — calls the script instead of inline `awk`/`grep`/`sed`.
- **`.github/RELEASE_TEMPLATE.md`** — rewritten to document the jeunesse@1.0.0 style end-to-end (format, title pattern, Added/Improved/Dropped, the changeset → Version PR finalization step).
- **jeunesse / enseignement-superieur / sports CHANGELOGs** — add the descriptive headline line so they (and future automated releases) render correctly.

## Verification
Ran the extractor against **all 12 packages** locally:
- Descriptive titles for the new-style sections (jeunesse, ens-sup, sports).
- First-bullet fallback preserved for the changesets-format ones (poste, emploi, mobilis, …) — **no regression**.
- Patches (geoalgeria@1.1.2, banques@1.1.2, livraison@1.0.1) correctly detected → skipped.
- `release.yml` validates as YAML.

No package data or versions change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)