### PR TITLE
docs: shrink README logo to width 280

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [Français](README.fr.md) | **العربية**
 
-<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="جيو الجزائر — GeoAlgeria" width="440"></picture></a>
+<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="جيو الجزائر — GeoAlgeria" width="280"></picture></a>
 
 <sub>من</sub><br>
 <a href="https://yasser.studio"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/yasser-studio-logo-white.svg"><img src="./assets/yasser-studio-logo.svg" alt="Yasser's Studio" height="28"></picture></a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | **Français** | [العربية](README.ar.md)
 
-<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="440"></picture></a>
+<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="280"></picture></a>
 
 <sub>par</sub><br>
 <a href="https://yasser.studio"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/yasser-studio-logo-white.svg"><img src="./assets/yasser-studio-logo.svg" alt="Yasser's Studio" height="28"></picture></a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **English** | [Français](README.fr.md) | [العربية](README.ar.md)
 
-<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="440"></picture></a>
+<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="280"></picture></a>
 
 <sub>by</sub><br>
 <a href="https://yasser.studio"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/yasser-studio-logo-white.svg"><img src="./assets/yasser-studio-logo.svg" alt="Yasser's Studio" height="28"></picture></a>

--- a/assets/brand/BRAND.md
+++ b/assets/brand/BRAND.md
@@ -19,7 +19,7 @@ icon, colors, and usage rules.
 Used in `README.md`, `README.fr.md`, `README.ar.md` as:
 
 ```html
-<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="440"></picture></a>
+<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="GeoAlgeria" width="280"></picture></a>
 ```
 
 ## Concept


### PR DESCRIPTION
Logo header was too large at width 440. Reduce to 280 (~1/3 smaller) across the EN/FR/AR READMEs and update the embed snippet in BRAND.md.