### PR TITLE
ci(release): keep djezzy + mosquees out of per-package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees; do
+          # djezzy + mosquees are intentionally excluded — they shipped in the
+          # combined project release (v1.4.0), not as per-package releases.
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle; do
             NAME=$(node -p "require('./$pkg/package.json').name")
             VER=$(node -p "require('./$pkg/package.json').version")
             TAG="$NAME@$VER"


### PR DESCRIPTION
They shipped in the combined project release **v1.4.0**, not as per-package releases. The release workflow's GitHub-Releases loop recreates any package release that's missing, so without this it would resurrect `@geoalgeria/djezzy@1.0.0` + `@geoalgeria/mosquees@1.0.0` on the next push to main. They stay in the publish dry-run loop (still validated/publishable).