### PR TITLE
docs: add djezzy + mosquees to maintainer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ This file is the short version of how work flows here; deeper docs are linked.
 | `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network — universities, grandes écoles, ENS, centres + private & other-ministry institutions (MESRS) |
 | `packages/tourisme/` | `@geoalgeria/tourisme` | tourism infrastructure — hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
 | `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training — CFPA, INSFP, DFEPs, private centers (MFEP / takwin.dz) |
+| `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques — geocoded retail stores with category & hours (djezzy.dz) |
+| `packages/mosquees/` | `@geoalgeria/mosquees` | mosques — Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
 
 The postal data under `packages/dataset/data/poste/` is a **generated mirror** —
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ This is a small monorepo:
 | `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network — universities, grandes écoles, ENS, centres + private & other-ministry institutions (MESRS) |
 | `packages/tourisme/` | `@geoalgeria/tourisme` | tourism infrastructure — hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
 | `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training establishments (MFEP / takwin.dz) |
+| `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques — geocoded retail stores (djezzy.dz) |
+| `packages/mosquees/` | `@geoalgeria/mosquees` | mosques — Wikidata + OpenStreetMap composite (all 69 wilayas) |
 
 ## How to contribute
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
-GeoAlgeria publishes thirteen packages to npm — **`geoalgeria`** (the dataset, kept
+GeoAlgeria publishes fifteen packages to npm — **`geoalgeria`** (the dataset, kept
 unscoped as the flagship) plus **`@geoalgeria/poste`**, **`@geoalgeria/emploi`**,
 **`@geoalgeria/mobilis`**, **`@geoalgeria/telecom`**, **`@geoalgeria/aviation`**,
 **`@geoalgeria/banques`**, **`@geoalgeria/livraison`**, **`@geoalgeria/jeunesse`**,
 **`@geoalgeria/sports`**, **`@geoalgeria/enseignement-superieur`**,
-**`@geoalgeria/tourisme`** and
-**`@geoalgeria/formation-professionnelle`** (under the
+**`@geoalgeria/tourisme`**, **`@geoalgeria/formation-professionnelle`**,
+**`@geoalgeria/djezzy`** and **`@geoalgeria/mosquees`** (under the
 `@geoalgeria` org) — using
 [Changesets](https://github.com/changesets/changesets) with a **"Version
 Packages" PR** and **staged Trusted Publishing** (the same flow as the GPC
@@ -158,8 +158,8 @@ These are prerequisites the workflow can't do for you:
 3. **Trusted Publisher per package** — on npmjs.com, for each of `geoalgeria`,
    `@geoalgeria/poste`, `@geoalgeria/emploi`, `@geoalgeria/mobilis`, `@geoalgeria/telecom`,
    `@geoalgeria/aviation`, `@geoalgeria/banques`, `@geoalgeria/livraison`, `@geoalgeria/jeunesse`,
-   `@geoalgeria/enseignement-superieur`, `@geoalgeria/tourisme`,
-   `@geoalgeria/formation-professionnelle`: *Settings →
+   `@geoalgeria/sports`, `@geoalgeria/enseignement-superieur`, `@geoalgeria/tourisme`,
+   `@geoalgeria/formation-professionnelle`, `@geoalgeria/djezzy`, `@geoalgeria/mosquees`: *Settings →
    Trusted Publisher → GitHub Actions*, repo **`yasserstudio/geoalgeria`**,
    workflow `release.yml`.
    No `NPM_TOKEN` — auth is the workflow's OIDC `id-token`.


### PR DESCRIPTION
Brings the maintainer/reference docs in line with v1.4.0 (the README trio + CHANGELOG were updated in #73).

- **AGENTS.md** / **CONTRIBUTING.md** — package layout tables now list `@geoalgeria/djezzy` + `@geoalgeria/mosquees`.
- **RELEASING.md** — package count 13 -> 15, intro list + Trusted-Publisher setup list updated (the latter also adds `@geoalgeria/sports`, which was missing).