### PR TITLE
docs(sante): use English ministry name in English text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This file is the short version of how work flows here; deeper docs are linked.
 | `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training — CFPA, INSFP, DFEPs, private centers (MFEP / takwin.dz) |
 | `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques — geocoded retail stores with category & hours (djezzy.dz) |
 | `packages/mosquees/` | `@geoalgeria/mosquees` | mosques — Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
-| `packages/sante/` | `@geoalgeria/sante` | public health establishments — EPH, EPSP, EHS, CHU (Ministère de la Santé), bilingual, geocoded via OSM + Wikidata |
+| `packages/sante/` | `@geoalgeria/sante` | public health establishments — EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
 
 The postal data under `packages/dataset/data/poste/` is a **generated mirror** —
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ schema break) · **minor** = a new dataset/package or a substantial data expansi
 
 ## 1.5.0 — 2026-06-27
 
-Added a new dataset: Algeria's public health establishments from the Ministère de la Santé.
+Added a new dataset: Algeria's public health establishments from the Ministry of Health.
 
-- **Health establishments** (`@geoalgeria/sante`, new): 695 public health establishments across the 58 wilayas with health directorates — 270 EPH (public hospitals), 292 EPSP (proximity-health), 108 EHS (specialized hospitals), 20 CHU (university hospitals) and 5 other public hospitals, from the Ministère de la Santé registry (sante.gov.dz). Bilingual French/Arabic (563 with both names), official `type` and `sector`, with commune/wilaya linkage. 600 geocoded via OpenStreetMap (121) and Wikidata (3), the rest to commune centroid; every record labelled with `source` and `geo_precision`. Names + type + wilaya are official; coordinates are best-effort.
+- **Health establishments** (`@geoalgeria/sante`, new): 695 public health establishments across the 58 wilayas with health directorates — 270 EPH (public hospitals), 292 EPSP (proximity-health), 108 EHS (specialized hospitals), 20 CHU (university hospitals) and 5 other public hospitals, from the Ministry of Health registry (sante.gov.dz). Bilingual French/Arabic (563 with both names), official `type` and `sector`, with commune/wilaya linkage. 600 geocoded via OpenStreetMap (121) and Wikidata (3), the rest to commune centroid; every record labelled with `source` and `geo_precision`. Names + type + wilaya are official; coordinates are best-effort.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This is a small monorepo:
 | `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training establishments (MFEP / takwin.dz) |
 | `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques — geocoded retail stores (djezzy.dz) |
 | `packages/mosquees/` | `@geoalgeria/mosquees` | mosques — Wikidata + OpenStreetMap composite (all 69 wilayas) |
-| `packages/sante/` | `@geoalgeria/sante` | public health establishments — EPH/EPSP/EHS/CHU (Ministère de la Santé), bilingual, geocoded via OSM + Wikidata |
+| `packages/sante/` | `@geoalgeria/sante` | public health establishments — EPH/EPSP/EHS/CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dz.getPostOfficesByCommune(1731); // real Algérie Poste offices
 | **Vocational training** | 1,932 | 856 CFPA + 182 INSFP + 723 private accredited + 58 DFEPs + more across 58 wilayas (MFEP / takwin.dz) — [`@geoalgeria/formation-professionnelle`](packages/formation-professionnelle) |
 | **Mosques** | 20,759 | Wikidata + OpenStreetMap composite — Arabic & French names, denomination, all 69 wilayas — [`@geoalgeria/mosquees`](packages/mosquees) |
 | **Djezzy boutiques** | 128 | geocoded retail stores with category, hours & commune/wilaya linkage (djezzy.dz) — [`@geoalgeria/djezzy`](packages/djezzy) |
-| **Health establishments** | 695 | EPH · EPSP · EHS · CHU from the Ministère de la Santé — bilingual, 600 geocoded via OSM + Wikidata — [`@geoalgeria/sante`](packages/sante) |
+| **Health establishments** | 695 | EPH · EPSP · EHS · CHU from the Ministry of Health — bilingual, 600 geocoded via OSM + Wikidata — [`@geoalgeria/sante`](packages/sante) |
 
 Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships JSON to stay light; CSV/GeoJSON/SQL ride in every [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -104,7 +104,7 @@ Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships 
 | [`packages/formation-professionnelle`](packages/formation-professionnelle) | [`@geoalgeria/formation-professionnelle`](https://www.npmjs.com/package/@geoalgeria/formation-professionnelle) | Vocational training — 1,932 CFPA, INSFP, IFEP, IEP, DFEPs & private centers from MFEP (takwin.dz), with capacity, boarding & coordinates |
 | [`packages/djezzy`](packages/djezzy) | [`@geoalgeria/djezzy`](https://www.npmjs.com/package/@geoalgeria/djezzy) | Djezzy boutiques — 128 geocoded retail stores from djezzy.dz, with category, hours & commune/wilaya linkage |
 | [`packages/mosquees`](packages/mosquees) | [`@geoalgeria/mosquees`](https://www.npmjs.com/package/@geoalgeria/mosquees) | Mosques of Algeria — 20,759 geocoded, a Wikidata + OpenStreetMap composite with Arabic & French names, denomination & commune/wilaya linkage |
-| [`packages/sante`](packages/sante) | [`@geoalgeria/sante`](https://www.npmjs.com/package/@geoalgeria/sante) | Public health establishments — 695 from the Ministère de la Santé (EPH, EPSP, EHS, CHU), bilingual, geocoded via OSM + Wikidata with commune/wilaya linkage |
+| [`packages/sante`](packages/sante) | [`@geoalgeria/sante`](https://www.npmjs.com/package/@geoalgeria/sante) | Public health establishments — 695 from the Ministry of Health (EPH, EPSP, EHS, CHU), bilingual, geocoded via OSM + Wikidata with commune/wilaya linkage |
 
 [Browse all packages →](https://geoalgeria.com/data) · [API docs & field reference →](https://geoalgeria.com/data/docs)
 

--- a/packages/sante/CHANGELOG.md
+++ b/packages/sante/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ## 1.0.0
 
-Algeria's public health establishments — 695 from the Ministère de la Santé, bilingual, typed and mostly geocoded.
+Algeria's public health establishments — 695 from the Ministry of Health, bilingual, typed and mostly geocoded.
 
 ### Added
 
 - 695 public health establishments across the 58 wilayas with health
-  directorates, from the Ministère de la Santé (MSP) registry — 270 EPH
+  directorates, from the Ministry of Health (MoH) registry — 270 EPH
   (public hospitals), 292 EPSP (proximity health), 108 EHS (specialized),
   20 CHU (university hospitals) and 5 other hospitals
 - Bilingual naming (563 records with both French and Arabic names), official
   `type` with French and Arabic labels, and `sector` (`public` for the whole
-  MSP registry; private clinics will carry `private`)
+  MoH registry; private clinics will carry `private`)
 - Commune/wilaya linkage (`wilaya`, `wilaya_ar`, `wilaya_code`, `commune`,
-  `commune_code`) — wilaya from the MSP tag (exact), commune by matching the
+  `commune_code`) — wilaya from the MoH tag (exact), commune by matching the
   establishment locality to the geoalgeria commune set (best-effort)
 - Coordinates on 600 of 695 records, with per-record `geo_precision`: 121 from
   an OpenStreetMap facility, 3 from Wikidata, 476 from the commune centroid;

--- a/packages/sante/README.md
+++ b/packages/sante/README.md
@@ -14,8 +14,7 @@
 
 **695 public health establishments** across all **58 wilayas** with health
 directorates — public hospitals (EPH), proximity-health establishments (EPSP),
-specialized hospitals (EHS) and university hospitals (CHU) from the **Ministère
-de la Santé (MSP)**, bilingual French/Arabic, **600 geocoded** via OpenStreetMap
+specialized hospitals (EHS) and university hospitals (CHU) from the **Ministry of Health (MoH)**, bilingual French/Arabic, **600 geocoded** via OpenStreetMap
 and Wikidata with commune/wilaya linkage. Shipped as JSON, CSV, GeoJSON, and
 TypeScript. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
 
@@ -70,9 +69,9 @@ const mappable = all.filter((e) => e.lat != null);
 | `none` | 95 | locality not resolved to a commune — no coordinates |
 
 > **The registry is official; the coordinates are best-effort.** Names, type and
-> wilaya come from the Ministère de la Santé. The MSP publishes no coordinates,
+> wilaya come from the Ministry of Health. The MoH publishes no coordinates,
 > so GeoAlgeria derives them — see *Source & method* below. Counts move as the
-> MSP, OpenStreetMap and Wikidata are edited; each rebuild reflects their current
+> MoH, OpenStreetMap and Wikidata are edited; each rebuild reflects their current
 > state.
 
 ## Formats
@@ -132,14 +131,14 @@ data/
 ```
 
 `id` is a stable `{wilaya_code}-{type}-{seq}` key synthesized by GeoAlgeria (the
-MSP publishes no establishment code). `name` is the French name where available,
+MoH publishes no establishment code). `name` is the French name where available,
 else Arabic. `type` is derived from the establishment's title; `wilaya` from the
-MSP's wilaya tag. `sector` is `"public"` for the whole MSP registry (private
+MoH's wilaya tag. `sector` is `"public"` for the whole MoH registry (private
 clinics, when added, will carry `"private"`). `source` records which registries
 contributed; `geo_precision` records where the coordinate came from. `lat`/`lng`
 are `null` for the 95 records whose locality could not be matched to a commune.
 
-> **Coordinates and commune are derived, not from the MSP.** The Ministère de la
+> **Coordinates and commune are derived, not from the MoH.** The Ministère de la
 > Santé lists names, type and wilaya only. GeoAlgeria matches each
 > establishment's locality to the [`geoalgeria`](https://www.npmjs.com/package/geoalgeria)
 > commune set within its wilaya (giving `commune`, `commune_code` and a centroid
@@ -158,7 +157,7 @@ you turn an establishment's `commune_code` into a polygon or centroid. Use
 
 Run `npm run fetch` to regenerate every output. It:
 
-1. pulls the **Ministère de la Santé** establishment registry from the
+1. pulls the **Ministry of Health** establishment registry from the
    `sante.gov.dz` WordPress REST API (`healthinstitution`), in French and Arabic,
    each tagged with its wilaya;
 2. derives the **type** from each title and **pairs** the French and Arabic posts
@@ -176,7 +175,7 @@ Raw source pulls are cached under
 
 Package **code** is [MIT](LICENSE). The **data** is a composite:
 
-- The **Ministère de la Santé** registry (names, type, wilaya) is a factual
+- The **Ministry of Health** registry (names, type, wilaya) is a factual
   public-sector listing.
 - **Coordinates** are derived from **Wikidata** (**CC0**, public domain) and
   **OpenStreetMap** (**© OpenStreetMap contributors**, licensed under the

--- a/packages/sante/data/metadata.json
+++ b/packages/sante/data/metadata.json
@@ -1,7 +1,7 @@
 {
-  "source": "Ministère de la Santé (sante.gov.dz) health-establishment registry, geocoded via OpenStreetMap (ODbL) + Wikidata (CC0)",
+  "source": "Ministry of Health (sante.gov.dz) health-establishment registry, geocoded via OpenStreetMap (ODbL) + Wikidata (CC0)",
   "origin": "https://sante.gov.dz, https://www.openstreetmap.org, https://www.wikidata.org",
-  "license": "MSP registry: factual public-sector listing. OpenStreetMap data © OpenStreetMap contributors, ODbL 1.0; Wikidata data is CC0. See README for attribution.",
+  "license": "MoH registry: factual public-sector listing. OpenStreetMap data © OpenStreetMap contributors, ODbL 1.0; Wikidata data is CC0. See README for attribution.",
   "sante": 695,
   "by_type": {
     "eph": 270,
@@ -24,7 +24,7 @@
   "wilayas_covered": 58,
   "geocoded": 600,
   "bilingual": 563,
-  "linkage_note": "Establishment names + type + wilaya are from the MSP registry; the MSP carries no coordinates. Commune is derived by matching the establishment locality to the geoalgeria commune set within the wilaya; coordinates are that commune's centroid, upgraded to a precise OSM/Wikidata point where one sits in the same commune (see geo_precision).",
-  "coverage_note": "695 public health establishments from the Ministère de la Santé — 600 geocoded (124 to a precise OSM/Wikidata point, the rest to commune centroid). Names + type + wilaya are official; coordinates are best-effort.",
+  "linkage_note": "Establishment names + type + wilaya are from the MoH registry; the MoH carries no coordinates. Commune is derived by matching the establishment locality to the geoalgeria commune set within the wilaya; coordinates are that commune's centroid, upgraded to a precise OSM/Wikidata point where one sits in the same commune (see geo_precision).",
+  "coverage_note": "695 public health establishments from the Ministry of Health — 600 geocoded (124 to a precise OSM/Wikidata point, the rest to commune centroid). Names + type + wilaya are official; coordinates are best-effort.",
   "generated_at": "2026-06-27"
 }

--- a/packages/sante/package.json
+++ b/packages/sante/package.json
@@ -2,7 +2,7 @@
   "name": "@geoalgeria/sante",
   "version": "1.0.0",
   "type": "module",
-  "description": "Public health establishments of Algeria — hospitals (EPH), proximity health (EPSP), specialized hospitals (EHS) and university hospitals (CHU) from the Ministère de la Santé, bilingual FR/AR, geocoded via OpenStreetMap & Wikidata, with commune/wilaya linkage. JSON, CSV, GeoJSON, TypeScript.",
+  "description": "Public health establishments of Algeria — hospitals (EPH), proximity health (EPSP), specialized hospitals (EHS) and university hospitals (CHU) from the Ministry of Health, bilingual FR/AR, geocoded via OpenStreetMap & Wikidata, with commune/wilaya linkage. JSON, CSV, GeoJSON, TypeScript.",
   "main": "index.js",
   "types": "types/index.d.ts",
   "exports": {

--- a/packages/sante/scripts/fetch.mjs
+++ b/packages/sante/scripts/fetch.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 /**
  * Build Algeria's public health-establishment dataset from the Ministère de la
- * Santé (MSP) registry and emit JSON, CSV, and GeoJSON to ../data. Raw source
+ * Santé (MoH) registry and emit JSON, CSV, and GeoJSON to ../data. Raw source
  * pulls are cached under research/sante/.
  *
- * Identity / names (authoritative): the MSP publishes its establishments as a
+ * Identity / names (authoritative): the MoH publishes its establishments as a
  * WordPress custom post type at sante.gov.dz, exposed via the REST API
  * (/wp-json/wp/v2/healthinstitution). French and Arabic are separate parallel
  * posts; each is tagged with its wilaya (categorie-healthinstitution taxonomy).
- * The MSP carries no coordinates, address, or commune — only name + type
+ * The MoH carries no coordinates, address, or commune — only name + type
  * (in the title) + wilaya. Type is derived from the title; the FR and AR posts
  * are paired into one bilingual record.
  *
@@ -20,7 +20,7 @@
  * `geo_precision` so the coordinate's origin is explicit.
  *
  * Note: sante.gov.dz may be unreachable from non-Algerian networks / sandboxes;
- * run with direct network access if the MSP pull fails.
+ * run with direct network access if the MoH pull fails.
  *
  * Usage: node scripts/fetch.mjs
  */
@@ -127,7 +127,7 @@ function httpGetBuffer(url, maxBytes = 256 * 1024) {
   });
 }
 
-// --- MSP registry (sante.gov.dz) -------------------------------------------
+// --- MoH registry (sante.gov.dz) -------------------------------------------
 const MSP_BASE = "https://sante.gov.dz/wp-json/wp/v2";
 // sante.gov.dz serves an incomplete TLS chain (leaf only, no intermediate).
 // We fetch the Sectigo intermediate named in the leaf's AIA extension and
@@ -148,7 +148,7 @@ async function mspCA() {
     const pem = new X509Certificate(der).toString();
     _mspCA = [pem, ...tls.rootCertificates];
   } catch (e) {
-    console.warn(`  could not obtain a pinned MSP intermediate CA (${e.message}); using default trust store`);
+    console.warn(`  could not obtain a pinned MoH intermediate CA (${e.message}); using default trust store`);
     _mspCA = null;
   }
   return _mspCA;
@@ -167,7 +167,7 @@ async function fetchPaginated(path, fields, ca) {
 }
 
 async function fetchMSP() {
-  console.log("Fetching MSP health establishments (sante.gov.dz)…");
+  console.log("Fetching MoH health establishments (sante.gov.dz)…");
   const ca = await mspCA();
   const posts = await fetchPaginated("healthinstitution", "id,title,slug,categorie-healthinstitution", ca);
   const byId = new Map();
@@ -176,7 +176,7 @@ async function fetchMSP() {
   console.log(`  ${records.length} establishment posts (FR + AR)`);
   const taxonomy = await fetchPaginated("categorie-healthinstitution", "id,name", ca);
   console.log(`  ${taxonomy.length} wilaya taxonomy terms`);
-  if (records.length < 400) throw new Error("MSP returned too few posts; treating as partial");
+  if (records.length < 400) throw new Error("MoH returned too few posts; treating as partial");
   mkdirSync(RESEARCH_DIR, { recursive: true });
   writeFileSync(join(RESEARCH_DIR, "msp-healthinstitution-raw.json"), JSON.stringify(records, null, 1) + "\n");
   writeFileSync(join(RESEARCH_DIR, "msp-wilaya-taxonomy.json"), JSON.stringify(taxonomy, null, 1) + "\n");
@@ -185,7 +185,7 @@ async function fetchMSP() {
 
 // --- text normalization ----------------------------------------------------
 // WordPress title.rendered is HTML-encoded — decode the entities that appear in
-// MSP titles (en-dash, curly apostrophe, ampersand, …) so names and matching
+// MoH titles (en-dash, curly apostrophe, ampersand, …) so names and matching
 // tokens are clean. Numeric first, then named, then &amp; last.
 function decodeEntities(s) {
   if (typeof s !== "string") return s;
@@ -255,7 +255,7 @@ function lev1(a, b) {
   return 1;
 }
 
-// --- type derivation (keyword-based; robust to MSP typos) -------------------
+// --- type derivation (keyword-based; robust to MoH typos) -------------------
 const TYPE_LABELS = {
   eph: { fr: "Établissement Public Hospitalier", ar: "المؤسسة العمومية الاستشفائية" },
   epsp: { fr: "Établissement Public de Santé de Proximité", ar: "المؤسسة العمومية للصحة الجوارية" },
@@ -659,7 +659,7 @@ function buildEstablishments(records, taxMap, wil, communesByWilaya, stats) {
       type: base.type,
       type_label_fr: TYPE_LABELS[base.type].fr,
       type_label_ar: TYPE_LABELS[base.type].ar,
-      sector: "public", // MSP registry is public establishments; private clinics will carry "private"
+      sector: "public", // MoH registry is public establishments; private clinics will carry "private"
       wilaya: w.name_fr,
       wilaya_ar: w.name_ar,
       wilaya_code: wcode(base.wilayaCode),
@@ -947,10 +947,10 @@ async function main() {
   const geocoded = rows.filter((r) => r.lat != null).length;
   const bilingual = rows.filter((r) => r.name_ar && r.name_fr).length;
   const metadata = {
-    source: "Ministère de la Santé (sante.gov.dz) health-establishment registry, geocoded via OpenStreetMap (ODbL) + Wikidata (CC0)",
+    source: "Ministry of Health (sante.gov.dz) health-establishment registry, geocoded via OpenStreetMap (ODbL) + Wikidata (CC0)",
     origin: "https://sante.gov.dz, https://www.openstreetmap.org, https://www.wikidata.org",
     license:
-      "MSP registry: factual public-sector listing. OpenStreetMap data © OpenStreetMap contributors, ODbL 1.0; Wikidata data is CC0. See README for attribution.",
+      "MoH registry: factual public-sector listing. OpenStreetMap data © OpenStreetMap contributors, ODbL 1.0; Wikidata data is CC0. See README for attribution.",
     sante: rows.length,
     by_type: {
       eph: by("type", "eph"), epsp: by("type", "epsp"), ehs: by("type", "ehs"),
@@ -967,8 +967,8 @@ async function main() {
     geocoded,
     bilingual,
     linkage_note:
-      "Establishment names + type + wilaya are from the MSP registry; the MSP carries no coordinates. Commune is derived by matching the establishment locality to the geoalgeria commune set within the wilaya; coordinates are that commune's centroid, upgraded to a precise OSM/Wikidata point where one sits in the same commune (see geo_precision).",
-    coverage_note: `${rows.length} public health establishments from the Ministère de la Santé — ${geocoded} geocoded (${by("geo_precision", "osm_point") + by("geo_precision", "wikidata_point")} to a precise OSM/Wikidata point, the rest to commune centroid). Names + type + wilaya are official; coordinates are best-effort.`,
+      "Establishment names + type + wilaya are from the MoH registry; the MoH carries no coordinates. Commune is derived by matching the establishment locality to the geoalgeria commune set within the wilaya; coordinates are that commune's centroid, upgraded to a precise OSM/Wikidata point where one sits in the same commune (see geo_precision).",
+    coverage_note: `${rows.length} public health establishments from the Ministry of Health — ${geocoded} geocoded (${by("geo_precision", "osm_point") + by("geo_precision", "wikidata_point")} to a precise OSM/Wikidata point, the rest to commune centroid). Names + type + wilaya are official; coordinates are best-effort.`,
     generated_at: new Date().toISOString().slice(0, 10),
   };
 

--- a/packages/sante/types/index.d.ts
+++ b/packages/sante/types/index.d.ts
@@ -1,11 +1,11 @@
 // Type definitions for @geoalgeria/sante
-// Public health establishments of Algeria — the Ministère de la Santé (MSP)
+// Public health establishments of Algeria — the Ministry of Health (MoH)
 // registry, geocoded via OpenStreetMap (ODbL) and Wikidata (CC0).
 
 /** Establishment category. */
 export type HealthType = "eph" | "epsp" | "ehs" | "chu" | "clinique" | "hopital";
 
-/** Ownership sector. The MSP registry is public; private clinics carry "private". */
+/** Ownership sector. The MoH registry is public; private clinics carry "private". */
 export type HealthSector = "public" | "private";
 
 /** Where the record's identity came from, plus which geo sources contributed a precise point. */
@@ -38,7 +38,7 @@ export interface HealthEstablishment {
   type_label_fr: string;
   /** Canonical Arabic label for the type. */
   type_label_ar: string;
-  /** Ownership sector ("public" for the MSP registry). */
+  /** Ownership sector ("public" for the MoH registry). */
   sector: HealthSector;
   /** Wilaya name (French). */
   wilaya: string;
@@ -54,7 +54,7 @@ export interface HealthEstablishment {
   lat: number | null;
   /** Longitude, or null when the establishment could not be geocoded. */
   lng: number | null;
-  /** Provenance: MSP registry, plus OSM/Wikidata where a precise point matched. */
+  /** Provenance: MoH registry, plus OSM/Wikidata where a precise point matched. */
   source: HealthSource;
   /** How `lat`/`lng` were obtained. */
   geo_precision: GeoPrecision;


### PR DESCRIPTION
Follow-up to #77. English-facing texts said "Ministère de la Santé"; they now read **Ministry of Health (MoH)**. French stays in `README.fr.md` (Ministère de la Santé), Arabic in `README.ar.md` (وزارة الصحة). Code identifiers (`MSP_BASE`, `mspCA`, …) and the `msp_id` field are unchanged. Touches READMEs, CHANGELOGs, types, package description, `metadata.json` and `fetch.mjs` comments/strings.