### PR TITLE
fix(announce): register @geoalgeria/culture in announce.js

### DIFF
--- a/scripts/announce.js
+++ b/scripts/announce.js
@@ -33,6 +33,10 @@ const PACKAGES = {
   "@geoalgeria/tourisme": { dir: "packages/tourisme", label: "Algeria's tourism infrastructure" },
   "@geoalgeria/formation-professionnelle": { dir: "packages/formation-professionnelle", label: "Algeria's vocational training establishments" },
   "@geoalgeria/sports": { dir: "packages/sports", label: "Algeria's sports infrastructure" },
+  "@geoalgeria/djezzy": { dir: "packages/djezzy", label: "Djezzy boutiques" },
+  "@geoalgeria/mosquees": { dir: "packages/mosquees", label: "Algeria's mosques" },
+  "@geoalgeria/sante": { dir: "packages/sante", label: "Algeria's public health establishments" },
+  "@geoalgeria/culture": { dir: "packages/culture", label: "Algeria's cultural atlas" },
 };
 
 const tag = process.env.GEOALGERIA_TAG || process.argv[2];


### PR DESCRIPTION
`announce.js`'s `PACKAGES` registry was missing the four most recent packages (djezzy, mosquees, sante, culture), so the per-package **Announce** workflow failed at "Build announce kit" for `@geoalgeria/culture@1.0.0` (`Unknown package`). Adds all four so the announce kit + Discussion generate.

The npm package and GitHub Release for `@geoalgeria/culture@1.0.0` are already live; this only fixes the announce drafts.