### PR TITLE
Cut GitHub Releases for the pharma-sector & ooredoo packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Dry-run publish
         run: |
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo; do
             PKG_NAME=$(node -p "require('./$pkg/package.json').name")
             PKG_VER=$(node -p "require('./$pkg/package.json').version")
             REGISTRY_VER=$(npm view "$PKG_NAME" version 2>/dev/null || echo "")
@@ -74,13 +74,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # @geoalgeria/transport (umbrella) is excluded — it has no data/
-          # bundle and is published manually via pnpm. (djezzy, mosquees and
+          # The @geoalgeria/transport and @geoalgeria/pharma umbrellas are
+          # excluded — they have no data/ bundle and are published manually via
+          # pnpm (workspace: deps). (djezzy, mosquees and
           # sante originally shipped in the combined v1.4.0/v1.5.0 project
           # releases; their per-package releases were backfilled 2026-07-05, so
           # future bumps flow through here normally — the tag-existence guard
           # below skips the already-released 1.0.0 tags.)
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo; do
             NAME=$(node -p "require('./$pkg/package.json').name")
             VER=$(node -p "require('./$pkg/package.json').version")
             TAG="$NAME@$VER"


### PR DESCRIPTION
## Summary

The Release workflow's **"Dry-run publish"** and **"GitHub Releases + data bundles"** steps iterate a **hardcoded package list** that was never updated for the packages added in #99. As a result, when #100 (version packages) merged, no GitHub Release / data bundle was cut for `@geoalgeria/industrie-pharmaceutique`, `/pharmacies` or `/ooredoo`, and future bumps would keep skipping them (the same gap that had djezzy/mosquees/sante backfilled earlier).

## Change

Add the three new **data** packages to both loops. The `@geoalgeria/pharma` umbrella stays excluded — like `@geoalgeria/transport`, it has no `data/` bundle and is published via `pnpm` (workspace deps).

Note: the **staged-publish** step is unaffected — `scripts/stage-publish.js` already derives packages dynamically from the workspace.

## Effect

The **tag-existence guard** in the Releases step means the next release run (or a `workflow_dispatch`) will **backfill the missing `@1.0.0` GitHub Releases** for the three packages and cut all future ones normally.