### PR TITLE
Align docs with the pharma sector + Ooredoo release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Bumps: **major** = breaking change to the project's shape (a package removed/ren
 schema break) · **minor** = a new dataset/package or a substantial data expansion ·
 **patch** = corrections and small refreshes.
 
+## 1.9.0 — 2026-07-05
+
+Added a new **Pharma sector** — pharmaceutical manufacturers and pharmacies — plus `@geoalgeria/ooredoo`, which completes the telecom retail trio, and a `@geoalgeria/pharma` umbrella.
+
+- **Pharmaceutical manufacturers** (`@geoalgeria/industrie-pharmaceutique`, new): 171 approved manufacturers (120 medicine/PP, 48 medical-device/DM, 3 mixte) from the Ministry of Pharmaceutical Industry fabrication register (updated 28/06/2026), bilingual, typed by nature, geocoded to commune/wilaya centroid across 25 wilayas. The register carries no coordinates; wilaya/commune are resolved from the 2023 MIP edition's wilaya column, place tokens in operator names, and a verified per-company research pass for makers absent from 2023 — never guessed. Multi-site firms (Saidal, GPA) are disambiguated by site; ~15 sous-traitance / unlocatable makers are omitted rather than placed speculatively.
+- **Pharmacies** (`@geoalgeria/pharmacies`, new): 3,790 pharmacies (officines) across 67 wilayas from OpenStreetMap (ODbL), geocoded, bilingual FR/AR where named, with phone/opening-hours/`dispensing` where tagged and wilaya/commune linkage by nearest-centroid join. Honest partial coverage (~3.8k mapped vs an estimated ~11k officines nationally; no open official registry). A 1,769-record OpenStreetMap bulk-import artifact near Attatba (Tipaza) is detected and excluded.
+- **Ooredoo stores** (`@geoalgeria/ooredoo`, new): 572 stores (436 Espaces Services, 100 Espaces Ooredoo, 36 City Shops) with real coordinates from the operator locator API; wilaya/commune reconciled from the coordinates (legacy 48 → current 69 scheme). Completes the telecom retail trio with `mobilis` + `djezzy`.
+- **Pharma umbrella** (`@geoalgeria/pharma`, new): one install that re-exports `industrie-pharmaceutique` + `pharmacies`.
+
+Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`, `/agriculture`, `/ecoles`, `/gares-routieres`, `/ferroviaire`, `/buses`, `/transport`, `/industrie-pharmaceutique`, `/pharmacies`, `/ooredoo`, `/pharma`.
+
 ## 1.8.0 — 2026-07-03
 
 Added a new dataset: Algeria's schools, the largest openly-geocoded school layer for the country.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,11 @@ This is a small monorepo:
 | `packages/gares-routieres/` | `@geoalgeria/gares-routieres` | intercity bus stations — 74 SOGRAL gares routières, 51 wilayas, geocoded with surfaces (live.sogral.com) |
 | `packages/ferroviaire/` | `@geoalgeria/ferroviaire` | rail & urban transit — 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OSM composite, bilingual |
 | `packages/buses/` | `@geoalgeria/buses` | urban bus networks — 50 ETUSA (Alger) lines, line-level v1 (fr.wikipedia) |
+| `packages/industrie-pharmaceutique/` | `@geoalgeria/industrie-pharmaceutique` | pharmaceutical manufacturers — 171 medicine & medical-device makers (Ministry of Pharmaceutical Industry), bilingual, geocoded |
+| `packages/pharmacies/` | `@geoalgeria/pharmacies` | pharmacies (officines) — 3,790 geocoded, 67 wilayas (OpenStreetMap) |
+| `packages/ooredoo/` | `@geoalgeria/ooredoo` | Ooredoo stores — 572 EO/CSO/ESO with real coordinates (ooredoo.dz); completes the telecom retail trio |
 | `packages/transport/` | `@geoalgeria/transport` | transport umbrella — re-exports aviation + ferroviaire + gares-routieres + buses |
+| `packages/pharma/` | `@geoalgeria/pharma` | pharma umbrella — re-exports industrie-pharmaceutique + pharmacies |
 
 ## How to contribute
 

--- a/README.ar.md
+++ b/README.ar.md
@@ -64,6 +64,9 @@ dz.getPostOfficesByCommune(1731); // مكاتب بريد الجزائر الحق
 | **المحطات البرية** | 74 | محطات سوقرال البرية عبر 51 ولاية — الأسماء، العناوين، المساحات، الإحداثيات — [`@geoalgeria/gares-routieres`](packages/gares-routieres) |
 | **السكك والنقل الحضري** | 692 | عُقَد القطار والترامواي والمترو والتلفريك (SNTF / SETRAM / SEMA) — تجميعة Wikidata + OSM، ثنائية اللغة، 50 ولاية — [`@geoalgeria/ferroviaire`](packages/ferroviaire) |
 | **خطوط الحافلات الحضرية** | 50 | ETUSA (الجزائر) — المحطتان الطرفيتان، عدد المواقف، البلديات والمحطات المخدومة — [`@geoalgeria/buses`](packages/buses) |
+| **الصيدليات** | 3٬790 | صيدليات (officines) مُحدَّدة جغرافيًا من OpenStreetMap، ثنائية اللغة عند التسمية، مربوطة بالبلدية/الولاية — [`@geoalgeria/pharmacies`](packages/pharmacies) |
+| **مصنّعو الأدوية** | 171 | مصنّعون معتمدون للأدوية والأجهزة الطبية من سجل وزارة الصناعة الصيدلانية، مُحدَّدون جغرافيًا — [`@geoalgeria/industrie-pharmaceutique`](packages/industrie-pharmaceutique) |
+| **نقاط بيع أوريدو** | 572 | فضاءات أوريدو ومتاجر المدينة وفضاءات الخدمات بإحداثيات حقيقية، مربوطة بالبلدية/الولاية (ooredoo.dz) — [`@geoalgeria/ooredoo`](packages/ooredoo) |
 
 الصيغ: **JSON · CSV · GeoJSON · SQL · TypeScript**. حزمة npm تتضمن JSON فقط للحفاظ على الحجم الخفيف؛ CSV/GeoJSON/SQL متوفرة في كل [إصدار GitHub](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -119,7 +122,11 @@ dz.getPostOfficesByCommune(1731); // مكاتب بريد الجزائر الحق
 | [`packages/gares-routieres`](packages/gares-routieres) | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | المحطات البرية — 74 محطة سوقرال عبر 51 ولاية، بإحداثيات ومساحات وربط بالبلدية/الولاية |
 | [`packages/ferroviaire`](packages/ferroviaire) | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | السكك والنقل الحضري — 692 عقدة قطار/ترامواي/مترو/تلفريك (SNTF/SETRAM/SEMA)، تجميعة Wikidata + OSM، ثنائية اللغة |
 | [`packages/buses`](packages/buses) | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | شبكات الحافلات الحضرية — 50 خط ETUSA (الجزائر) مع المحطتين الطرفيتين والمواقف والبلديات والمحطات المخدومة (مستوى الخط، v1) |
+| [`packages/industrie-pharmaceutique`](packages/industrie-pharmaceutique) | [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | مصنّعو الأدوية — 171 مصنّعًا معتمدًا للأدوية (PP) والأجهزة الطبية (DM) من سجل وزارة الصناعة الصيدلانية، ثنائيو اللغة، مُحدَّدون إلى مركز البلدية/الولاية |
+| [`packages/pharmacies`](packages/pharmacies) | [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | الصيدليات (officines) — 3٬790 مُحدَّدة جغرافيًا عبر 67 ولاية من OpenStreetMap، ثنائية اللغة عند التسمية، مع الهاتف/الساعات/dispensing عند توفّرها والربط بالبلدية/الولاية |
+| [`packages/ooredoo`](packages/ooredoo) | [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | نقاط بيع أوريدو — 572 فضاء أوريدو / متجر مدينة / فضاء خدمات بإحداثيات حقيقية والربط بالبلدية/الولاية (ooredoo.dz)؛ يُكمل ثلاثي الاتصالات |
 | [`packages/transport`](packages/transport) | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | مظلة — تثبّت aviation + ferroviaire + gares-routieres + buses دفعة واحدة |
+| [`packages/pharma`](packages/pharma) | [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | مظلة — تثبّت industrie-pharmaceutique + pharmacies دفعة واحدة |
 
 [تصفح جميع الحزم →](https://geoalgeria.com/data) · [توثيق API ومرجع الحقول →](https://geoalgeria.com/data/docs)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -62,6 +62,9 @@ dz.getPostOfficesByCommune(1731); // vrais bureaux d'Algérie Poste
 | **Gares routières** | 74 | Gares routières SOGRAL sur 51 wilayas — noms, adresses, superficies, coordonnées — [`@geoalgeria/gares-routieres`](packages/gares-routieres) |
 | **Rail & transport urbain** | 692 | nœuds train, tram, métro, téléphérique & télécabine (SNTF / SETRAM / SEMA) — composite Wikidata + OSM, bilingue, 50 wilayas — [`@geoalgeria/ferroviaire`](packages/ferroviaire) |
 | **Lignes de bus urbaines** | 50 | ETUSA (Alger) — terminus, nombre d'arrêts, communes & stations desservies — [`@geoalgeria/buses`](packages/buses) |
+| **Pharmacies** | 3 790 | officines géolocalisées depuis OpenStreetMap, bilingues si nommées, rattachées commune/wilaya — [`@geoalgeria/pharmacies`](packages/pharmacies) |
+| **Fabricants pharmaceutiques** | 171 | fabricants agréés de médicaments & dispositifs médicaux du registre du Ministère de l'Industrie Pharmaceutique, géolocalisés — [`@geoalgeria/industrie-pharmaceutique`](packages/industrie-pharmaceutique) |
+| **Points de vente Ooredoo** | 572 | Espaces Ooredoo, City Shops & Espaces Services avec coordonnées réelles, rattachés commune/wilaya (ooredoo.dz) — [`@geoalgeria/ooredoo`](packages/ooredoo) |
 
 Formats : **JSON · CSV · GeoJSON · SQL · TypeScript**. Le paquet npm contient le JSON pour rester léger ; les CSV/GeoJSON/SQL sont dans chaque [release GitHub](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -117,7 +120,11 @@ Formats : **JSON · CSV · GeoJSON · SQL · TypeScript**. Le paquet npm contien
 | [`packages/gares-routieres`](packages/gares-routieres) | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Gares routières — 74 gares SOGRAL sur 51 wilayas, géolocalisées avec superficies et rattachement commune/wilaya |
 | [`packages/ferroviaire`](packages/ferroviaire) | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & transport urbain — 692 nœuds train/tram/métro/téléphérique/télécabine (SNTF/SETRAM/SEMA), composite Wikidata + OSM, bilingue FR/AR |
 | [`packages/buses`](packages/buses) | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Réseaux de bus urbains — 50 lignes ETUSA (Alger) avec terminus, arrêts, communes & stations desservies (niveau ligne, v1) |
+| [`packages/industrie-pharmaceutique`](packages/industrie-pharmaceutique) | [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Fabricants pharmaceutiques — 171 fabricants agréés de médicaments (PP) & dispositifs médicaux (DM) du registre du Ministère de l'Industrie Pharmaceutique, bilingues, géolocalisés au centroïde commune/wilaya |
+| [`packages/pharmacies`](packages/pharmacies) | [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) — 3 790 géolocalisées sur 67 wilayas depuis OpenStreetMap, bilingues si nommées, avec téléphone/horaires/dispensing si renseignés & rattachement commune/wilaya |
+| [`packages/ooredoo`](packages/ooredoo) | [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Points de vente Ooredoo — 572 EO / City Shop / Espace Services avec coordonnées réelles & rattachement commune/wilaya (ooredoo.dz) ; complète le trio télécom |
 | [`packages/transport`](packages/transport) | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Parapluie — installe aviation + ferroviaire + gares-routieres + buses en une fois |
+| [`packages/pharma`](packages/pharma) | [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Parapluie — installe industrie-pharmaceutique + pharmacies en une fois |
 
 [Parcourir tous les paquets →](https://geoalgeria.com/data) · [Documentation API et référence des champs →](https://geoalgeria.com/data/docs)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ dz.getPostOfficesByCommune(1731); // real Algérie Poste offices
 | **Intercity bus stations** | 74 | SOGRAL gares routières across 51 wilayas — names, addresses, surface areas, coordinates — [`@geoalgeria/gares-routieres`](packages/gares-routieres) |
 | **Rail & urban transit** | 692 | train, tram, metro, aerial-tramway & gondola nodes (SNTF / SETRAM / SEMA) — Wikidata + OSM composite, bilingual, 50 wilayas — [`@geoalgeria/ferroviaire`](packages/ferroviaire) |
 | **Urban bus lines** | 50 | ETUSA (Alger) — termini, stop counts, communes & stations served — [`@geoalgeria/buses`](packages/buses) |
+| **Pharmacies** | 3,790 | officines geocoded from OpenStreetMap, bilingual where named, wilaya/commune-linked — [`@geoalgeria/pharmacies`](packages/pharmacies) |
+| **Pharma manufacturers** | 171 | approved medicine & medical-device makers from the Ministry of Pharmaceutical Industry register, geocoded — [`@geoalgeria/industrie-pharmaceutique`](packages/industrie-pharmaceutique) |
+| **Ooredoo stores** | 572 | Espaces Ooredoo, City Shops & Espaces Services with real coordinates, wilaya/commune-linked (ooredoo.dz) — [`@geoalgeria/ooredoo`](packages/ooredoo) |
 
 Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships JSON to stay light; CSV/GeoJSON/SQL ride in every [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -117,7 +120,11 @@ Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships 
 | [`packages/gares-routieres`](packages/gares-routieres) | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Intercity bus stations — 74 SOGRAL gares routières across 51 wilayas, geocoded with surfaces & commune/wilaya linkage |
 | [`packages/ferroviaire`](packages/ferroviaire) | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & urban transit — 692 train/tram/metro/aerial/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OSM composite, bilingual FR/AR |
 | [`packages/buses`](packages/buses) | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban bus networks — 50 ETUSA (Alger) lines with termini, stop counts, communes & stations served (line-level v1) |
+| [`packages/industrie-pharmaceutique`](packages/industrie-pharmaceutique) | [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Pharmaceutical manufacturers — 171 approved medicine (PP) & medical-device (DM) makers from the Ministry of Pharmaceutical Industry register, bilingual, geocoded to commune/wilaya centroid |
+| [`packages/pharmacies`](packages/pharmacies) | [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) — 3,790 geocoded across 67 wilayas from OpenStreetMap, bilingual where named, with phone/hours/dispensing where tagged & commune/wilaya linkage |
+| [`packages/ooredoo`](packages/ooredoo) | [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Ooredoo stores — 572 EO / City Shop / Espace Services with real coordinates & commune/wilaya linkage (ooredoo.dz); completes the telecom retail trio |
 | [`packages/transport`](packages/transport) | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Umbrella — installs aviation + ferroviaire + gares-routieres + buses in one step |
+| [`packages/pharma`](packages/pharma) | [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Umbrella — installs industrie-pharmaceutique + pharmacies in one step |
 
 [Browse all packages →](https://geoalgeria.com/data) · [API docs & field reference →](https://geoalgeria.com/data/docs)
 

--- a/packages/dataset/README.ar.md
+++ b/packages/dataset/README.ar.md
@@ -213,7 +213,11 @@ sqlite3 mydb.sqlite < full.sql
 | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | المحطات البرية — 74 محطة SOGRAL عبر 51 ولاية، بإحداثيات مع المساحات وربط بالبلدية/الولاية |
 | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | السكك والنقل الحضري — 692 عقدة قطار/ترام/مترو/تلفريك/قمرة (SNTF/SETRAM/SEMA)، تجميع Wikidata + OpenStreetMap، ثنائي اللغة |
 | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | شبكات الحافلات الحضرية — 50 خط ETUSA (الجزائر) مع المحطات الطرفية وعدد المواقف والبلديات والمحطات المخدومة (مستوى الخط v1) |
+| [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | مصنّعو الأدوية — 171 مصنّعًا معتمدًا للأدوية والأجهزة الطبية من وزارة الصناعة الصيدلانية، ثنائيو اللغة، مُحدَّدون جغرافيًا |
+| [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | الصيدليات (officines) — 3٬790 مُحدَّدة جغرافيًا عبر 67 ولاية من OpenStreetMap، ثنائية اللغة عند التسمية |
+| [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | نقاط بيع أوريدو — 572 فضاء أوريدو / متجر مدينة / فضاء خدمات بإحداثيات حقيقية؛ يُكمل ثلاثي الاتصالات |
 | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | مظلة النقل — تثبّت aviation + ferroviaire + gares-routieres + buses في خطوة واحدة |
+| [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | مظلة الصيدلة — تثبّت industrie-pharmaceutique + pharmacies دفعة واحدة |
 
 القائمة الكاملة والمستودع الأحادي: [github.com/yasserstudio/geoalgeria](https://github.com/yasserstudio/geoalgeria).
 

--- a/packages/dataset/README.fr.md
+++ b/packages/dataset/README.fr.md
@@ -213,7 +213,11 @@ Ce jeu de données utilise le [versionnement sémantique](https://semver.org/). 
 | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Gares routières — 74 gares SOGRAL sur 51 wilayas, géolocalisées avec surfaces et rattachement commune/wilaya |
 | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & transport urbain — 692 nœuds train/tram/métro/télécabine/gondole (SNTF/SETRAM/SEMA), composite Wikidata + OpenStreetMap, bilingue |
 | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Réseaux de bus urbains — 50 lignes ETUSA (Alger) avec terminus, nombre d'arrêts, communes et stations desservies (niveau ligne v1) |
+| [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Fabricants pharmaceutiques — 171 fabricants agréés de médicaments & dispositifs médicaux du Ministère de l'Industrie Pharmaceutique, bilingues, géolocalisés |
+| [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) — 3 790 géolocalisées sur 67 wilayas depuis OpenStreetMap, bilingues si nommées |
+| [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Points de vente Ooredoo — 572 EO / City Shop / Espace Services avec coordonnées réelles ; complète le trio télécom |
 | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Ombrelle transport — installe aviation + ferroviaire + gares-routieres + buses en une étape |
+| [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Parapluie pharma — installe industrie-pharmaceutique + pharmacies en une fois |
 
 Liste complète et monorepo : [github.com/yasserstudio/geoalgeria](https://github.com/yasserstudio/geoalgeria).
 

--- a/packages/dataset/README.md
+++ b/packages/dataset/README.md
@@ -213,7 +213,11 @@ This dataset uses [Semantic Versioning](https://semver.org/). See [CHANGELOG.md]
 | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Intercity bus stations — 74 SOGRAL gares routières across 51 wilayas, geocoded with surfaces & commune/wilaya linkage |
 | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & urban transit — 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OpenStreetMap composite, bilingual |
 | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban bus networks — 50 ETUSA (Alger) lines with termini, stop counts, communes & stations served (line-level v1) |
+| [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Pharmaceutical manufacturers — 171 approved medicine & medical-device makers from the Ministry of Pharmaceutical Industry register, bilingual, geocoded |
+| [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) — 3,790 geocoded across 67 wilayas from OpenStreetMap, bilingual where named |
+| [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Ooredoo stores — 572 EO / City Shop / Espace Services with real coordinates; completes the telecom retail trio |
 | [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Transport umbrella — installs aviation + ferroviaire + gares-routieres + buses in one step |
+| [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Pharma umbrella — installs industrie-pharmaceutique + pharmacies in one step |
 
 Full list and the monorepo: [github.com/yasserstudio/geoalgeria](https://github.com/yasserstudio/geoalgeria).
 


### PR DESCRIPTION
Adds the four packages shipped in #99 — `industrie-pharmaceutique`, `pharmacies`, `ooredoo` and the `pharma` umbrella — to every package list / count table so the docs match npm:

- Root `README` (What's-inside + Packages tables) — EN / FR / AR
- Flagship `packages/dataset` README family tables — EN / FR / AR
- `CONTRIBUTING.md` layout table
- A `1.9.0` entry in the project `CHANGELOG.md`

Docs-only; no code or data changes.