### PR TITLE
chore: gitignore research source PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ build/
 out/
 *.min.json
 
+# === Research source PDFs (extract to .txt; never commit the PDF) ===
+research/**/*.pdf
+
 # === Logs ===
 *.log
 npm-debug.log*


### PR DESCRIPTION
The repo tracks extracted `.txt`/`.json` from research sources but never the source PDFs (0 PDFs currently tracked). This ignores `research/**/*.pdf` to keep that convention and stop untracked pharma-landscape PDFs from showing up in `git status`.

Config-only; no data or code changes.