### PR TITLE
fix(announce): add pharma-era packages to allowlist

### DIFF
--- a/scripts/announce.js
+++ b/scripts/announce.js
@@ -34,6 +34,7 @@ const PACKAGES = {
   "@geoalgeria/formation-professionnelle": { dir: "packages/formation-professionnelle", label: "Algeria's vocational training establishments" },
   "@geoalgeria/sports": { dir: "packages/sports", label: "Algeria's sports infrastructure" },
   "@geoalgeria/djezzy": { dir: "packages/djezzy", label: "Djezzy boutiques" },
+  "@geoalgeria/ooredoo": { dir: "packages/ooredoo", label: "Ooredoo retail network (Espaces & City Shops)" },
   "@geoalgeria/mosquees": { dir: "packages/mosquees", label: "Algeria's mosques" },
   "@geoalgeria/sante": { dir: "packages/sante", label: "Algeria's public health establishments" },
   "@geoalgeria/culture": { dir: "packages/culture", label: "Algeria's cultural atlas" },
@@ -43,6 +44,9 @@ const PACKAGES = {
   "@geoalgeria/ferroviaire": { dir: "packages/ferroviaire", label: "Algeria's rail & urban transit (SNTF/SETRAM/SEMA)" },
   "@geoalgeria/buses": { dir: "packages/buses", label: "Algeria's urban bus networks (ETUSA)" },
   "@geoalgeria/transport": { dir: "packages/transport", label: "Algeria's transport sector (umbrella)" },
+  "@geoalgeria/pharmacies": { dir: "packages/pharmacies", label: "Algeria's pharmacies (officines)" },
+  "@geoalgeria/industrie-pharmaceutique": { dir: "packages/industrie-pharmaceutique", label: "Algeria's approved pharmaceutical manufacturers" },
+  "@geoalgeria/pharma": { dir: "packages/pharma", label: "Algeria's pharmaceutical sector (umbrella)" },
 };
 
 const tag = process.env.GEOALGERIA_TAG || process.argv[2];


### PR DESCRIPTION
The `scripts/announce.js` package allowlist was stale — it lacked `@geoalgeria/ooredoo`, `@geoalgeria/pharmacies`, `@geoalgeria/industrie-pharmaceutique`, and the `@geoalgeria/pharma` umbrella. Announce CI runs for those tags failed with `Unknown package "…" — expected one of: …`.

The allowlist now covers all 27 publishable packages (every `packages/` directory except the unpublished `schema`). Verified the three failing tags resolve and `scripts/release-notes.mjs` has no equivalent list (it reads a changelog path directly, nothing stale to fix).