### PR TITLE
docs: v2 data-contract section in root READMEs; fix telecom 5G count

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -130,6 +130,22 @@ dz.getPostOfficesByCommune(1731); // مكاتب بريد الجزائر الحق
 
 [تصفح جميع الحزم →](https://geoalgeria.com/data) · [توثيق API ومرجع الحقول →](https://geoalgeria.com/data/docs)
 
+## عقد البيانات
+
+منذ الإصدار **v2.0.0**، تتشارك جميع الحزم القطاعية عقد تسجيل مرجعيًا واحدًا، مُعرّفًا في الحزمة الداخلية [`@geoalgeria/schema`](packages/schema) — وهي تبعية تطوير (dev dependency) يستخدمها مولّد كل حزمة، وغير منشورة على npm إطلاقًا.
+
+كل سجل يتبع الشكل نفسه:
+
+- `wilaya_code` عبارة عن **سلسلة نصية** مُصفَّرة البادئة (`"16"`)؛ والربط بالبلدية يتم عبر `commune_code` + `commune`؛ والإحداثيات هي `lat` / `lng` (رقمان معًا، أو `null` معًا).
+- المعرّفات الخارجية مجمّعة تحت `refs` (`osm`، `wikidata`، …).
+- `geo_precision` يأخذ حصرًا القيم `exact | approximate | null` — و`null` فقط عند غياب الإحداثيات — مع طريقة الترميز الجغرافي في `geo_method`.
+
+تُرافقها أدوات قابلة للقراءة آليًا: فهرس جذري [`index.json`](index.json)، وواصف `schema.org/Dataset` (`dataset-metadata.json`) في كل حزمة، و69 مضلّع حدود للولايات في الحزمة الأساسية ضمن [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (بجودة العرض).
+
+حزمتان تسبقان العقد ولا تزالان تُصدِّران أشكال v1 — مجموعة البيانات الأساسية `geoalgeria` و[`@geoalgeria/telecom`](packages/telecom) (المميَّزتان بـ `schema_version: null` في الفهرس).
+
+هل تنقل حزمة؟ انظر [`packages/schema/MIGRATING.md`](packages/schema/MIGRATING.md).
+
 ## الاستخدام بدون npm
 
 ```html

--- a/README.fr.md
+++ b/README.fr.md
@@ -128,6 +128,22 @@ Formats : **JSON · CSV · GeoJSON · SQL · TypeScript**. Le paquet npm contien
 
 [Parcourir tous les paquets →](https://geoalgeria.com/data) · [Documentation API et référence des champs →](https://geoalgeria.com/data/docs)
 
+## Contrat de données
+
+Depuis la **v2.0.0**, tous les paquets sectoriels partagent un même contrat d'enregistrement canonique, défini par le paquet interne [`@geoalgeria/schema`](packages/schema) — une dépendance de développement utilisée par chaque générateur, jamais publiée sur npm.
+
+Chaque enregistrement suit la même forme :
+
+- `wilaya_code` est une **chaîne** complétée par des zéros (`"16"`) ; le rattachement à la commune se fait via `commune_code` + `commune` ; les coordonnées sont `lat` / `lng` (deux nombres, ou deux `null`).
+- Les identifiants externes sont regroupés sous `refs` (`osm`, `wikidata`, …).
+- `geo_precision` vaut strictement `exact | approximate | null` — `null` exactement lorsqu'il n'y a pas de coordonnée — avec la méthode de géocodage dans `geo_method`.
+
+Des artefacts lisibles par machine les accompagnent : un catalogue racine [`index.json`](index.json), un descripteur `schema.org/Dataset` (`dataset-metadata.json`) dans chaque paquet, et les 69 polygones de limites des wilayas dans le paquet principal, sous [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (qualité d'affichage).
+
+Deux paquets sont antérieurs au contrat et livrent encore des formes v1 — le jeu de données principal `geoalgeria` et [`@geoalgeria/telecom`](packages/telecom) (marqués `schema_version: null` dans le catalogue).
+
+Vous migrez un paquet ? Voir [`packages/schema/MIGRATING.md`](packages/schema/MIGRATING.md).
+
 ## Utilisation sans npm
 
 ```html

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ Formats: **JSON · CSV · GeoJSON · SQL · TypeScript**. The npm package ships 
 
 [Browse all packages →](https://geoalgeria.com/data) · [API docs & field reference →](https://geoalgeria.com/data/docs)
 
+## Data contract
+
+Since **v2.0.0**, every sector package shares one canonical record contract, defined by the internal [`@geoalgeria/schema`](packages/schema) package — a dev dependency used by each generator, never published to npm.
+
+Every record follows the same shape:
+
+- `wilaya_code` is a zero-padded **string** (`"16"`); commune linkage is `commune_code` + `commune`; coordinates are `lat` / `lng` (both numbers, or both `null`).
+- External ids live under `refs` (`osm`, `wikidata`, …).
+- `geo_precision` is strictly `exact | approximate | null` — `null` exactly when there is no coordinate — with the geocoding method in `geo_method`.
+
+Machine-readable artifacts ride alongside: a root [`index.json`](index.json) catalog, a `schema.org/Dataset` descriptor (`dataset-metadata.json`) in each package, and the 69 wilaya boundary polygons in the core package at [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (display-grade).
+
+Two packages predate the contract and still ship v1 shapes — the core `geoalgeria` dataset and [`@geoalgeria/telecom`](packages/telecom) (marked `schema_version: null` in the catalog).
+
+Migrating a package? See [`packages/schema/MIGRATING.md`](packages/schema/MIGRATING.md).
+
 ## Use without npm
 
 ```html

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,6 +60,8 @@ git push         # straight to main, or via a PR
 Bump rules (data semver): **major** = breaking schema change · **minor** = new
 data / format · **patch** = corrections to existing records.
 
+- **Docs parity:** the root READMEs (EN/FR/AR) and any affected package READMEs reflect every contract, artifact, licence, or count change shipping in this release — sweep before tagging, not after.
+
 On push to `main`, the **Release** workflow runs `changesets/action`. If
 unconsumed changesets exist, it opens (or updates) a **`chore: version
 packages`** PR. Review the version bumps and CHANGELOG entries there.

--- a/packages/telecom/package.json
+++ b/packages/telecom/package.json
@@ -2,7 +2,7 @@
   "name": "@geoalgeria/telecom",
   "version": "1.0.0",
   "type": "module",
-  "description": "Algeria mobile-network coverage as data — 1,681 5G coverage points from operator maps (Djezzy, Mobilis, Ooredoo), with wilaya/commune linkage. JSON, CSV, GeoJSON, TypeScript.",
+  "description": "Algeria mobile-network coverage as data — 2,798 5G coverage points from operator maps (Djezzy, Mobilis, Ooredoo), with wilaya/commune linkage. JSON, CSV, GeoJSON, TypeScript.",
   "main": "index.js",
   "types": "types/index.d.ts",
   "exports": {


### PR DESCRIPTION
Two documentation fixes.

**1. Stale count** — `packages/telecom/package.json` described "1,681 5G coverage points"; the data (`data/coverage/5g/sites.json`) and all READMEs already say **2,798**. Corrected the description only — no version bump (telecom is a v1 holdout).

**2. Missing v2 contract docs** — the root READMEs never documented the v2.0.0 record contract. Added a **Data contract** section to `README.md`, `README.fr.md`, and `README.ar.md` (section-level parity across all three) covering: the canonical shape defined by the internal `@geoalgeria/schema` dev dependency; key field rules (`wilaya_code`, `commune_code`/`commune`, `lat`/`lng`, `refs`, `geo_precision`/`geo_method`); the machine-readable artifacts (`index.json`, `dataset-metadata.json`, `wilaya-boundaries.geojson`); the two v1-holdout packages; and a link to `packages/schema/MIGRATING.md`.

Also adds a docs-parity gate to the pre-publish steps in `RELEASING.md` so a future release can't ship a contract/artifact/count change without the READMEs catching up.