### PR TITLE
docs(context): use lat/lng field names in Geocoded definition prose

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,7 +124,7 @@ Carrying both a French (`Fr`) and an Arabic (`Ar`) name for a record.
 _Avoid_: multilingual, translated, i18n
 
 **Geocoded**:
-Carrying real latitude/longitude coordinates for a record (as opposed to density-only or wilaya-linked-only).
+Carrying real `lat`/`lng` coordinates for a record (as opposed to density-only or wilaya-linked-only).
 _Avoid_: located, mapped, positioned
 
 ### Provenance


### PR DESCRIPTION
The `Geocoded` glossary entry described coordinates as "latitude/longitude" in loose prose, but the v2 contract field names are `lat`/`lng`. Reword that one spot so prose matches the contract vocabulary. The actual field definition later in the file already used `lat`/`lng` and is left unchanged.