### PR TITLE
docs(protection-civile): enumerate @geoalgeria/protection-civile in release + docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Dry-run publish
         run: |
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo packages/protection-civile; do
             PKG_NAME=$(node -p "require('./$pkg/package.json').name")
             PKG_VER=$(node -p "require('./$pkg/package.json').version")
             REGISTRY_VER=$(npm view "$PKG_NAME" version 2>/dev/null || echo "")
@@ -81,7 +81,7 @@ jobs:
           # releases; their per-package releases were backfilled 2026-07-05, so
           # future bumps flow through here normally — the tag-existence guard
           # below skips the already-released 1.0.0 tags.)
-          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo; do
+          for pkg in packages/dataset packages/poste packages/emploi packages/mobilis packages/telecom packages/aviation packages/banques packages/livraison packages/jeunesse packages/sports packages/enseignement-superieur packages/tourisme packages/formation-professionnelle packages/djezzy packages/mosquees packages/sante packages/culture packages/agriculture packages/ecoles packages/gares-routieres packages/ferroviaire packages/buses packages/industrie-pharmaceutique packages/pharmacies packages/ooredoo packages/protection-civile; do
             NAME=$(node -p "require('./$pkg/package.json').name")
             VER=$(node -p "require('./$pkg/package.json').version")
             TAG="$NAME@$VER"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-GeoAlgeria publishes twenty-seven packages to npm — **`geoalgeria`** (the dataset, kept
+GeoAlgeria publishes twenty-eight packages to npm — **`geoalgeria`** (the dataset, kept
 unscoped as the flagship) plus **`@geoalgeria/poste`**, **`@geoalgeria/emploi`**,
 **`@geoalgeria/mobilis`**, **`@geoalgeria/telecom`**, **`@geoalgeria/aviation`**,
 **`@geoalgeria/banques`**, **`@geoalgeria/livraison`**, **`@geoalgeria/jeunesse`**,
@@ -10,12 +10,13 @@ unscoped as the flagship) plus **`@geoalgeria/poste`**, **`@geoalgeria/emploi`**
 **`@geoalgeria/culture`**, **`@geoalgeria/agriculture`**, **`@geoalgeria/ecoles`**,
 **`@geoalgeria/gares-routieres`**, **`@geoalgeria/ferroviaire`**, **`@geoalgeria/buses`**,
 **`@geoalgeria/transport`**, **`@geoalgeria/industrie-pharmaceutique`**,
-**`@geoalgeria/pharmacies`**, **`@geoalgeria/ooredoo`** and **`@geoalgeria/pharma`**
+**`@geoalgeria/pharmacies`**, **`@geoalgeria/ooredoo`**,
+**`@geoalgeria/protection-civile`** and **`@geoalgeria/pharma`**
 (under the `@geoalgeria` org) — using
 [Changesets](https://github.com/changesets/changesets) with a **"Version
 Packages" PR** and **staged Trusted Publishing** (the same flow as the GPC
-monorepo). Of these, `release.yml`'s automated staging covers **25** — the flagship
-`geoalgeria`, `@geoalgeria/telecom` and the 23 sector packages; the two umbrellas
+monorepo). Of these, `release.yml`'s automated staging covers **26** — the flagship
+`geoalgeria`, `@geoalgeria/telecom` and the 24 sector packages; the two umbrellas
 **`@geoalgeria/transport`** and **`@geoalgeria/pharma`** carry `workspace:*` deps and are
 published **manually** with pnpm (see setup, step 2). `@geoalgeria/schema` is the v2 data
 contract every other package's generator depends on — a dev dependency, not a dataset, and
@@ -175,7 +176,7 @@ These are prerequisites the workflow can't do for you:
    > `cd packages/transport && pnpm publish --access public --no-git-checks`
    > (verify via `pnpm pack` that deps resolve to `^x.y.z`). These umbrellas need no
    > Trusted Publisher entry.
-3. **Trusted Publisher per package** — for each of the **25** packages the workflow
+3. **Trusted Publisher per package** — for each of the **26** packages the workflow
    stages (`geoalgeria`, `@geoalgeria/poste`, `@geoalgeria/emploi`, `@geoalgeria/mobilis`,
    `@geoalgeria/telecom`, `@geoalgeria/aviation`, `@geoalgeria/banques`,
    `@geoalgeria/livraison`, `@geoalgeria/jeunesse`, `@geoalgeria/sports`,
@@ -184,7 +185,8 @@ These are prerequisites the workflow can't do for you:
    `@geoalgeria/sante`, `@geoalgeria/culture`, `@geoalgeria/agriculture`,
    `@geoalgeria/ecoles`, `@geoalgeria/gares-routieres`, `@geoalgeria/ferroviaire`,
    `@geoalgeria/buses`, `@geoalgeria/industrie-pharmaceutique`, `@geoalgeria/pharmacies`,
-   `@geoalgeria/ooredoo`). The umbrellas (`transport`, `pharma`) and the unpublished
+   `@geoalgeria/ooredoo`, `@geoalgeria/protection-civile`). The umbrellas (`transport`,
+   `pharma`) and the unpublished
    contract package (`@geoalgeria/schema`) get **no** entry. Manage entries with the npm
    CLI (npm ≥ 12) rather than the web UI:
    ```bash

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "private": true,
   "type": "module",
-  "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis, @geoalgeria/telecom, @geoalgeria/aviation, @geoalgeria/banques, @geoalgeria/livraison, @geoalgeria/jeunesse, @geoalgeria/sports, @geoalgeria/enseignement-superieur, @geoalgeria/tourisme, @geoalgeria/formation-professionnelle, @geoalgeria/djezzy, @geoalgeria/mosquees, @geoalgeria/sante, @geoalgeria/culture, @geoalgeria/agriculture, @geoalgeria/ecoles, @geoalgeria/gares-routieres, @geoalgeria/ferroviaire, @geoalgeria/buses, @geoalgeria/transport) published to npm",
+  "description": "GeoAlgeria data monorepo — open Algeria datasets (geoalgeria, @geoalgeria/poste, @geoalgeria/emploi, @geoalgeria/mobilis, @geoalgeria/telecom, @geoalgeria/aviation, @geoalgeria/banques, @geoalgeria/livraison, @geoalgeria/jeunesse, @geoalgeria/sports, @geoalgeria/enseignement-superieur, @geoalgeria/tourisme, @geoalgeria/formation-professionnelle, @geoalgeria/djezzy, @geoalgeria/mosquees, @geoalgeria/sante, @geoalgeria/culture, @geoalgeria/agriculture, @geoalgeria/ecoles, @geoalgeria/gares-routieres, @geoalgeria/ferroviaire, @geoalgeria/buses, @geoalgeria/industrie-pharmaceutique, @geoalgeria/pharmacies, @geoalgeria/ooredoo, @geoalgeria/protection-civile, @geoalgeria/transport, @geoalgeria/pharma) published to npm",
   "packageManager": "pnpm@11.3.0",
   "scripts": {
     "validate": "pnpm --filter ./packages/dataset validate && node scripts/validate-packages.mjs && node scripts/build-catalog.mjs --check && pnpm test",


### PR DESCRIPTION
Docs/config only — no flow-logic changes. Makes tomorrow's `@geoalgeria/protection-civile` 1.0.0 bootstrap publish turnkey.

- **release.yml**: add `packages/protection-civile` to the dry-run and GitHub-Releases publish loops.
- **RELEASING.md**: add `@geoalgeria/protection-civile` to the package list and the Trusted Publisher checklist; bump counts (27→28 total, 25→26 staged, 23→24 sector).
- **package.json**: bring the `description` enumeration current — it had pre-existing drift (missing industrie-pharmaceutique, pharmacies, ooredoo, pharma) plus the new protection-civile.

Package tables in README.md/.fr/.ar + AGENTS.md were already updated in the feature merge; swept for stale prose package counts — none exist.

Verified: `pnpm validate` green (120 tests, includes `catalog --check`).