### PR TITLE
docs: sweep em dashes from all repo docs (READMEs + changelog/agents/etc.)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file is the short version of how work flows here; deeper docs are linked.
 ## Domain vocabulary
 
 Before writing code, data, copy, package descriptions, or issue/PR titles, read
-[`CONTEXT.md`](CONTEXT.md) — the project's canonical glossary — and use its terms,
+[`CONTEXT.md`](CONTEXT.md), the project's canonical glossary, and use its terms,
 avoiding the synonyms each lists under `_Avoid_`. If a concept is missing or a
 term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's the
 `/domain-modeling` skill).
@@ -15,7 +15,7 @@ term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's th
 
 | Path | Package | Contents |
 | --- | --- | --- |
-| `packages/schema/` | `@geoalgeria/schema` | shared v2 contract — types, validator, canonical metadata/manifest builders, emit helpers; a dev dependency of every generator, not itself a dataset |
+| `packages/schema/` | `@geoalgeria/schema` | shared v2 contract – types, validator, canonical metadata/manifest builders, emit helpers; a dev dependency of every generator, not itself a dataset |
 | `packages/dataset/` | `geoalgeria` | wilayas, dairas, communes (+ mirrored postal data) |
 | `packages/poste/` | `@geoalgeria/poste` | post offices & ATMs (Algérie Poste) |
 | `packages/emploi/` | `@geoalgeria/emploi` | employment agencies (ANEM: AWEM + ALEM) |
@@ -25,27 +25,27 @@ term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's th
 | `packages/banques/` | `@geoalgeria/banques` | licensed banks, institutions & branches (RIB/SWIFT) |
 | `packages/livraison/` | `@geoalgeria/livraison` | delivery carriers & geocoded stop-desks |
 | `packages/jeunesse/` | `@geoalgeria/jeunesse` | youth establishments (Ministry of Youth and Sports) |
-| `packages/sports/` | `@geoalgeria/sports` | sports facilities — stadiums, pools, courts, tracks (Ministry of Youth and Sports) |
-| `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network — universities, grandes écoles, ENS, centres + private & other-ministry institutions (MESRS) |
-| `packages/tourisme/` | `@geoalgeria/tourisme` | tourism infrastructure — hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
-| `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training — CFPA, INSFP, DFEPs, private centers (MFEP / takwin.dz) |
-| `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques — geocoded retail stores with category & hours (djezzy.dz) |
-| `packages/ooredoo/` | `@geoalgeria/ooredoo` | Ooredoo stores — 572 EO/CSO/ESO with real coordinates & wilaya/commune linkage (ooredoo.dz locator API); completes the telecom retail trio |
-| `packages/mosquees/` | `@geoalgeria/mosquees` | mosques — Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
-| `packages/sante/` | `@geoalgeria/sante` | public health establishments — EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
-| `packages/protection-civile/` | `@geoalgeria/protection-civile` | civil protection (fire & rescue) units — 880 DGPC units nationwide, Arabic-named, address/phone/fax, status tier, geocoded, official-primary (dgpc.dz), post-2026-reform wilaya linkage |
-| `packages/culture/` | `@geoalgeria/culture` | cultural atlas — protected sites, museums, theatres, libraries + cultural establishments (Ministry of Culture), bilingual, fully geocoded |
-| `packages/agriculture/` | `@geoalgeria/agriculture` | agriculture-sector institutions — services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices & groups (Ministry of Agriculture), bilingual, geocoded |
-| `packages/industrie-pharmaceutique/` | `@geoalgeria/industrie-pharmaceutique` | approved pharmaceutical manufacturers — 171 medicine (PP) & medical-device (DM) makers from the Ministry of Pharmaceutical Industry (MIP) fabrication register, bilingual, typed by nature, geocoded to commune/wilaya centroid |
-| `packages/pharmacies/` | `@geoalgeria/pharmacies` | pharmacies (officines) — 3,790 geocoded across 67 wilayas, bilingual where named, phone/hours/dispensing where tagged, wilaya/commune-linked (OpenStreetMap, ODbL); honest ~half coverage |
-| `packages/pharma/` | `@geoalgeria/pharma` | pharma umbrella — re-exports industrie-pharmaceutique + pharmacies in one install |
-| `packages/ecoles/` | `@geoalgeria/ecoles` | schools — 11,830 primaires/CEM/lycées/préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap, ODbL) |
-| `packages/gares-routieres/` | `@geoalgeria/gares-routieres` | intercity bus stations — 74 SOGRAL gares routières, 51 wilayas, geocoded with surfaces (live.sogral.com) |
-| `packages/ferroviaire/` | `@geoalgeria/ferroviaire` | rail & urban transit — 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OSM composite, bilingual |
-| `packages/buses/` | `@geoalgeria/buses` | urban bus networks — 50 ETUSA (Alger) lines, line-level v1 (fr.wikipedia) |
-| `packages/transport/` | `@geoalgeria/transport` | transport umbrella — re-exports aviation + ferroviaire + gares-routieres + buses |
+| `packages/sports/` | `@geoalgeria/sports` | sports facilities – stadiums, pools, courts, tracks (Ministry of Youth and Sports) |
+| `packages/enseignement-superieur/` | `@geoalgeria/enseignement-superieur` | higher-education network – universities, grandes écoles, ENS, centres + private & other-ministry institutions (MESRS) |
+| `packages/tourisme/` | `@geoalgeria/tourisme` | tourism infrastructure – hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
+| `packages/formation-professionnelle/` | `@geoalgeria/formation-professionnelle` | vocational training – CFPA, INSFP, DFEPs, private centers (MFEP / takwin.dz) |
+| `packages/djezzy/` | `@geoalgeria/djezzy` | Djezzy boutiques – geocoded retail stores with category & hours (djezzy.dz) |
+| `packages/ooredoo/` | `@geoalgeria/ooredoo` | Ooredoo stores – 572 EO/CSO/ESO with real coordinates & wilaya/commune linkage (ooredoo.dz locator API); completes the telecom retail trio |
+| `packages/mosquees/` | `@geoalgeria/mosquees` | mosques – Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
+| `packages/sante/` | `@geoalgeria/sante` | public health establishments – EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
+| `packages/protection-civile/` | `@geoalgeria/protection-civile` | civil protection (fire & rescue) units – 880 DGPC units nationwide, Arabic-named, address/phone/fax, status tier, geocoded, official-primary (dgpc.dz), post-2026-reform wilaya linkage |
+| `packages/culture/` | `@geoalgeria/culture` | cultural atlas – protected sites, museums, theatres, libraries + cultural establishments (Ministry of Culture), bilingual, fully geocoded |
+| `packages/agriculture/` | `@geoalgeria/agriculture` | agriculture-sector institutions – services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices & groups (Ministry of Agriculture), bilingual, geocoded |
+| `packages/industrie-pharmaceutique/` | `@geoalgeria/industrie-pharmaceutique` | approved pharmaceutical manufacturers – 171 medicine (PP) & medical-device (DM) makers from the Ministry of Pharmaceutical Industry (MIP) fabrication register, bilingual, typed by nature, geocoded to commune/wilaya centroid |
+| `packages/pharmacies/` | `@geoalgeria/pharmacies` | pharmacies (officines) – 3,790 geocoded across 67 wilayas, bilingual where named, phone/hours/dispensing where tagged, wilaya/commune-linked (OpenStreetMap, ODbL); honest ~half coverage |
+| `packages/pharma/` | `@geoalgeria/pharma` | pharma umbrella – re-exports industrie-pharmaceutique + pharmacies in one install |
+| `packages/ecoles/` | `@geoalgeria/ecoles` | schools – 11,830 primaires/CEM/lycées/préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap, ODbL) |
+| `packages/gares-routieres/` | `@geoalgeria/gares-routieres` | intercity bus stations – 74 SOGRAL gares routières, 51 wilayas, geocoded with surfaces (live.sogral.com) |
+| `packages/ferroviaire/` | `@geoalgeria/ferroviaire` | rail & urban transit – 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OSM composite, bilingual |
+| `packages/buses/` | `@geoalgeria/buses` | urban bus networks – 50 ETUSA (Alger) lines, line-level v1 (fr.wikipedia) |
+| `packages/transport/` | `@geoalgeria/transport` | transport umbrella – re-exports aviation + ferroviaire + gares-routieres + buses |
 
-The postal data under `packages/dataset/data/poste/` is a **generated mirror** —
+The postal data under `packages/dataset/data/poste/` is a **generated mirror**;
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.
 
 ## The loop
@@ -53,7 +53,7 @@ edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mir
 1. **Branch** off `main`: `fix/commune-name`, `feat/emploi-coords`, `chore/ci`.
 2. **Edit data**, keeping the rules in [`CONTRIBUTING.md`](CONTRIBUTING.md):
    sorted, UTF-8, sourced (JORA / Algérie Poste / ONS), bilingual FR/AR.
-3. **`pnpm validate`** — schema + integrity checks. Must pass.
+3. **`pnpm validate`**: schema + integrity checks. Must pass.
 4. **Add a changeset** if a published package changed: `pnpm changeset`
    (data semver: **major** = breaking schema · **minor** = new data/format ·
    **patch** = corrections).
@@ -79,20 +79,20 @@ Full details and one-time setup: [`RELEASING.md`](RELEASING.md).
 
 ## Marketing & announcements
 
-- Strategy, positioning, and launch copy live in **`.agents/`** (gitignored —
+- Strategy, positioning, and launch copy live in **`.agents/`** (gitignored:
   local working files, not published): `product-marketing.md`, `launch-plan.md`,
   `launch-posts.md`, `launch-discussions.md`, `release-notes-templates.md`.
 - The **Announce** workflow turns each release into a Discussion + social drafts.
   Release-note structure: [`.github/RELEASE_TEMPLATE.md`](.github/RELEASE_TEMPLATE.md)
   (committed); the marketing copy built from it: `.agents/release-notes-templates.md`.
 - Publishing public content (social posts, seeded discussions) under the owner's
-  identity needs **explicit human go-ahead** — automation drafts, humans post.
+  identity needs **explicit human go-ahead**; automation drafts, humans post.
 
 ## Don't
 
 - Hand-edit generated mirrors (`packages/dataset/data/poste/`).
 - Push a bump without a changeset, or a changeset without a source for the data.
-- Commit anything from `.agents/` — it's intentionally local.
+- Commit anything from `.agents/`; it's intentionally local.
 
 ## Agent skills
 
@@ -108,4 +108,4 @@ The five canonical roles (`needs-triage`, `needs-info`, `ready-for-agent`, `read
 
 ### Domain docs
 
-Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/domain-modeling`). See `docs/agents/domain.md`.
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/domain-modeling`). See `docs/agents/domain.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# GeoAlgeria — project changelog
+# GeoAlgeria – project changelog
 
 Project-level (umbrella) versions for GeoAlgeria as a whole. Each entry is the
 state of the datasets at that tag (`vX.Y.Z`). Individual npm packages keep their
@@ -8,18 +8,18 @@ Bumps: **major** = breaking change to the project's shape (a package removed/ren
 schema break) · **minor** = a new dataset/package or a substantial data expansion ·
 **patch** = corrections and small refreshes.
 
-## 2.0.0 — 2026-07-21 — Data v2 (breaking schema overhaul)
+## 2.0.0 – 2026-07-21 – Data v2 (breaking schema overhaul)
 
 Unifies every sector package onto one record contract via a new
 `@geoalgeria/schema` dependency, replacing 26 hand-written, drifted
 `types/index.d.ts` shapes. This is a **breaking schema change** across 25
-packages — the 23 migrated sector packages plus the `@geoalgeria/transport`
+packages: the 23 migrated sector packages plus the `@geoalgeria/transport`
 and `@geoalgeria/pharma` umbrellas (whose `workspace:^` member deps now point
 at `2.0.0`). Consumers on `^1` are unaffected until they opt in; read
 [`packages/schema/MIGRATING.md`](packages/schema/MIGRATING.md) before bumping.
 The `@geoalgeria/schema` package itself stays a dev dependency and is not
 published. The core `geoalgeria` dataset and `@geoalgeria/telecom` are **not**
-part of this release — both predate the contract and stay on their v1 versions
+part of this release; both predate the contract and stay on their v1 versions
 (see below).
 
 - **Breaking record shape**: `wilaya_code` is now a zero-padded **string**
@@ -32,7 +32,7 @@ part of this release — both predate the contract and stay on their v1 versions
   **null if and only if** the record has no coordinate. The old method
   vocabulary (`osm_point`, `commune_centroid`, `campus`, `wilaya_centroid`, …)
   moved to a new `geo_method` field, under the same null-iff rule. `exact` now
-  requires ≥3 decimal places **and** a point unique within its file — 409
+  requires ≥3 decimal places **and** a point unique within its file; 409
   records across the migrated packages could not carry that claim and were
   downgraded to `approximate`.
 - **New `@geoalgeria/schema` package**: canonical TypeScript types, a
@@ -44,7 +44,7 @@ part of this release — both predate the contract and stay on their v1 versions
   descriptor (`dataset-metadata.json`) shipped in 24 packages; the 69 wilaya
   boundary polygons now ship in the core dataset package as
   `data/geojson/wilaya-boundaries.geojson` (OSM-derived, ODbL,
-  **display-grade** — median vertex gap 3.36 km, not survey-grade).
+  **display-grade**: median vertex gap 3.36 km, not survey-grade).
 - **Tourisme corrections**: 972 previously-dropped values restored (`address`,
   `phone`, `website`, `stars`, `rooms`, `description`, `heritage`,
   `heritage_status`, `refs.wikidata`/`refs.wikipedia`) and 115 records
@@ -54,7 +54,7 @@ part of this release — both predate the contract and stay on their v1 versions
   `lodging-`/`attraction-`/`historic-`/`thermal-spring-`/`park-`, keeping each
   merged multi-file collection (`.all()`, `.attractions()`, …) unique.
 - **Not included**: two packages predate this contract and are not part of the
-  migration — the core `geoalgeria` dataset package (wilayas/dairas/communes)
+  migration: the core `geoalgeria` dataset package (wilayas/dairas/communes)
   still ships the v1 shape (`wilaya_code` as an int, `latitude`/`longitude`,
   `code_commune`, CommonJS); `@geoalgeria/telecom` is close but incomplete
   (string `wilaya_code` and `lat`/`lng` already, but no `geo_precision` /
@@ -69,97 +69,97 @@ Packages: `@geoalgeria/schema` (new), `@geoalgeria/poste`, `/emploi`,
 `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`,
 `/agriculture`, `/ecoles`, `/gares-routieres`, `/ferroviaire`, `/buses`,
 `/transport`, `/industrie-pharmaceutique`, `/pharmacies`, `/ooredoo`,
-`/pharma`. Not `geoalgeria` (core dataset) or `/telecom` — both predate this
+`/pharma`. Not `geoalgeria` (core dataset) or `/telecom`; both predate this
 contract, see above.
 
-## 1.9.0 — 2026-07-05
+## 1.9.0 – 2026-07-05
 
-Added a new **Pharma sector** — pharmaceutical manufacturers and pharmacies — plus `@geoalgeria/ooredoo`, which completes the telecom retail trio, and a `@geoalgeria/pharma` umbrella.
+Added a new **Pharma sector** (pharmaceutical manufacturers and pharmacies) plus `@geoalgeria/ooredoo`, which completes the telecom retail trio, and a `@geoalgeria/pharma` umbrella.
 
-- **Pharmaceutical manufacturers** (`@geoalgeria/industrie-pharmaceutique`, new): 171 approved manufacturers (120 medicine/PP, 48 medical-device/DM, 3 mixte) from the Ministry of Pharmaceutical Industry fabrication register (updated 28/06/2026), bilingual, typed by nature, geocoded to commune/wilaya centroid across 25 wilayas. The register carries no coordinates; wilaya/commune are resolved from the 2023 MIP edition's wilaya column, place tokens in operator names, and a verified per-company research pass for makers absent from 2023 — never guessed. Multi-site firms (Saidal, GPA) are disambiguated by site; ~15 sous-traitance / unlocatable makers are omitted rather than placed speculatively.
+- **Pharmaceutical manufacturers** (`@geoalgeria/industrie-pharmaceutique`, new): 171 approved manufacturers (120 medicine/PP, 48 medical-device/DM, 3 mixte) from the Ministry of Pharmaceutical Industry fabrication register (updated 28/06/2026), bilingual, typed by nature, geocoded to commune/wilaya centroid across 25 wilayas. The register carries no coordinates; wilaya/commune are resolved from the 2023 MIP edition's wilaya column, place tokens in operator names, and a verified per-company research pass for makers absent from 2023, never guessed. Multi-site firms (Saidal, GPA) are disambiguated by site; ~15 sous-traitance / unlocatable makers are omitted rather than placed speculatively.
 - **Pharmacies** (`@geoalgeria/pharmacies`, new): 3,790 pharmacies (officines) across 67 wilayas from OpenStreetMap (ODbL), geocoded, bilingual FR/AR where named, with phone/opening-hours/`dispensing` where tagged and wilaya/commune linkage by nearest-centroid join. Honest partial coverage (~3.8k mapped vs an estimated ~11k officines nationally; no open official registry). A 1,769-record OpenStreetMap bulk-import artifact near Attatba (Tipaza) is detected and excluded.
 - **Ooredoo stores** (`@geoalgeria/ooredoo`, new): 572 stores (436 Espaces Services, 100 Espaces Ooredoo, 36 City Shops) with real coordinates from the operator locator API; wilaya/commune reconciled from the coordinates (legacy 48 → current 69 scheme). Completes the telecom retail trio with `mobilis` + `djezzy`.
 - **Pharma umbrella** (`@geoalgeria/pharma`, new): one install that re-exports `industrie-pharmaceutique` + `pharmacies`.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`, `/agriculture`, `/ecoles`, `/gares-routieres`, `/ferroviaire`, `/buses`, `/transport`, `/industrie-pharmaceutique`, `/pharmacies`, `/ooredoo`, `/pharma`.
 
-## 1.8.0 — 2026-07-03
+## 1.8.0 – 2026-07-03
 
 Added a new dataset: Algeria's schools, the largest openly-geocoded school layer for the country.
 
-- **Schools** (`@geoalgeria/ecoles`, new): 11,830 schools and kindergartens across all 69 wilayas, extracted from OpenStreetMap (ODbL) — classified by cycle (4,020 primaire, 2,377 moyen/CEM, 1,574 secondaire/lycée, 268 préscolaire; the rest `autre`), with bilingual French/Arabic names (8,640 named), a `sector` flag where the map signals it (313 public, 48 private), and commune/wilaya linkage by nearest-centroid join. Cycle is inferred from `isced:level` and the FR/AR name — a CEM names itself متوسطة/collège, a lycée ثانوية/lycée — with a bare "école"/"مدرسة" classified `primaire` by Algerian convention; 93% of named schools resolve to a specific cycle. Each record also carries an establishment `kind` (regular / langues / coranique / conduite / formation / special — so language institutes, Quranic & driving schools and training centres are a filterable category, not buried in `autre`), plus `isced_levels` and an `address` from OSM tags where present. Framed honestly as a partial OSM extract (~11.8k mapped against the ~28,000 of the national network), not an official registry.
+- **Schools** (`@geoalgeria/ecoles`, new): 11,830 schools and kindergartens across all 69 wilayas, extracted from OpenStreetMap (ODbL), classified by cycle (4,020 primaire, 2,377 moyen/CEM, 1,574 secondaire/lycée, 268 préscolaire; the rest `autre`), with bilingual French/Arabic names (8,640 named), a `sector` flag where the map signals it (313 public, 48 private), and commune/wilaya linkage by nearest-centroid join. Cycle is inferred from `isced:level` and the FR/AR name (a CEM names itself متوسطة/collège, a lycée ثانوية/lycée) with a bare "école"/"مدرسة" classified `primaire` by Algerian convention; 93% of named schools resolve to a specific cycle. Each record also carries an establishment `kind` (regular / langues / coranique / conduite / formation / special, so language institutes, Quranic & driving schools and training centres are a filterable category, not buried in `autre`), plus `isced_levels` and an `address` from OSM tags where present. Framed honestly as a partial OSM extract (~11.8k mapped against the ~28,000 of the national network), not an official registry.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`, `/agriculture`, `/ecoles`, `/gares-routieres`, `/ferroviaire`, `/buses`, `/transport`.
 
-## 1.7.0 — 2026-07-01
+## 1.7.0 – 2026-07-01
 
-Added a new **Transport** sector — four packages — plus `@geoalgeria/agriculture` (shipped since 1.6.0).
+Added a new **Transport** sector (four packages) plus `@geoalgeria/agriculture` (shipped since 1.6.0).
 
-- **Intercity bus stations** (`@geoalgeria/gares-routieres`, new): 74 SOGRAL gares routières across 51 wilayas — official names, addresses, surface areas and coordinates (74/74 geocoded; Touggourt and Djanet fixed via OpenStreetMap, Guelma via its commune centroid), with wilaya/commune linkage that reconciles SOGRAL's legacy 48-wilaya codes to the current 69-wilaya scheme (Law 26-06). Source: SOGRAL (`live.sogral.com`).
-- **Rail & urban transit** (`@geoalgeria/ferroviaire`, new): 692 nodes across 50 wilayas — 427 rail + 190 tram + 41 metro + 24 aerial-tramway + 10 gondola. A Wikidata (CC0) + OpenStreetMap (ODbL) composite with operators SNTF/SETRAM/SEMA, `line` membership, bilingual French/Arabic names and commune/wilaya linkage.
-- **Urban bus networks** (`@geoalgeria/buses`, new): 50 ETUSA (Alger) bus lines — termini, stop counts, and the communes and transit stations each line serves (line-level v1; from fr.wikipedia, CC BY-SA). Multi-operator design, ready to add more cities.
+- **Intercity bus stations** (`@geoalgeria/gares-routieres`, new): 74 SOGRAL gares routières across 51 wilayas: official names, addresses, surface areas and coordinates (74/74 geocoded; Touggourt and Djanet fixed via OpenStreetMap, Guelma via its commune centroid), with wilaya/commune linkage that reconciles SOGRAL's legacy 48-wilaya codes to the current 69-wilaya scheme (Law 26-06). Source: SOGRAL (`live.sogral.com`).
+- **Rail & urban transit** (`@geoalgeria/ferroviaire`, new): 692 nodes across 50 wilayas: 427 rail + 190 tram + 41 metro + 24 aerial-tramway + 10 gondola. A Wikidata (CC0) + OpenStreetMap (ODbL) composite with operators SNTF/SETRAM/SEMA, `line` membership, bilingual French/Arabic names and commune/wilaya linkage.
+- **Urban bus networks** (`@geoalgeria/buses`, new): 50 ETUSA (Alger) bus lines: termini, stop counts, and the communes and transit stations each line serves (line-level v1; from fr.wikipedia, CC BY-SA). Multi-operator design, ready to add more cities.
 - **Transport umbrella** (`@geoalgeria/transport`, new): one install that re-exports `aviation` + `ferroviaire` + `gares-routieres` + `buses`.
-- **Agriculture institutions** (`@geoalgeria/agriculture`, new since 1.6.0): 196 institutions across 58 wilayas from the Ministry of Agriculture (MADR) — services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices and groups; bilingual, geocoded to commune/wilaya centroid.
+- **Agriculture institutions** (`@geoalgeria/agriculture`, new since 1.6.0): 196 institutions across 58 wilayas from the Ministry of Agriculture (MADR): services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices and groups; bilingual, geocoded to commune/wilaya centroid.
 
-Transport packages are domain-named — the operator is the *source* (in `keywords`/`metadata`), not the package name (ANAC's airports ship as `aviation`, not `anac`).
+Transport packages are domain-named: the operator is the *source* (in `keywords`/`metadata`), not the package name (ANAC's airports ship as `aviation`, not `anac`).
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`, `/agriculture`, `/gares-routieres`, `/ferroviaire`, `/buses`, `/transport`.
 
-## 1.6.0 — 2026-06-29
+## 1.6.0 – 2026-06-29
 
 Added a new dataset: Algeria's cultural atlas from the Ministry of Culture.
 
-- **Cultural places** (`@geoalgeria/culture`, new): 1,083 cultural places across 66 of Algeria's 69 wilayas — protected cultural property (580), libraries (257), museums (48), theatres (45) and museums of the Moudjahid (13), plus cultural establishments: maisons de culture (51), culture directorates (33), cinemas (20), cultural centres (15), arts schools (15) and palais de culture (6). From the Ministry of Culture's *Cartes du Patrimoine Culturel Algérien* portal, 100% bilingual French/Arabic, every place geocoded (`geo_precision: source_point`), with a `has_virtual_tour` flag (22 places) and commune/wilaya linkage. Places the portal still files under pre-2019 wilaya codes are rescoped to the current 69-wilaya scheme (Law 26-06) by nearest-commune geography.
+- **Cultural places** (`@geoalgeria/culture`, new): 1,083 cultural places across 66 of Algeria's 69 wilayas: protected cultural property (580), libraries (257), museums (48), theatres (45) and museums of the Moudjahid (13), plus cultural establishments: maisons de culture (51), culture directorates (33), cinemas (20), cultural centres (15), arts schools (15) and palais de culture (6). From the Ministry of Culture's *Cartes du Patrimoine Culturel Algérien* portal, 100% bilingual French/Arabic, every place geocoded (`geo_precision: source_point`), with a `has_virtual_tour` flag (22 places) and commune/wilaya linkage. Places the portal still files under pre-2019 wilaya codes are rescoped to the current 69-wilaya scheme (Law 26-06) by nearest-commune geography.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`, `/culture`.
 
-## 1.5.0 — 2026-06-27
+## 1.5.0 – 2026-06-27
 
 Added a new dataset: Algeria's public health establishments from the Ministry of Health.
 
-- **Health establishments** (`@geoalgeria/sante`, new): 695 public health establishments across the 58 wilayas with health directorates — 270 EPH (public hospitals), 292 EPSP (proximity-health), 108 EHS (specialized hospitals), 20 CHU (university hospitals) and 5 other public hospitals, from the Ministry of Health registry (sante.gov.dz). Bilingual French/Arabic (563 with both names), official `type` and `sector`, with commune/wilaya linkage. 600 geocoded via OpenStreetMap (121) and Wikidata (3), the rest to commune centroid; every record labelled with `source` and `geo_precision`. Names + type + wilaya are official; coordinates are best-effort.
+- **Health establishments** (`@geoalgeria/sante`, new): 695 public health establishments across the 58 wilayas with health directorates: 270 EPH (public hospitals), 292 EPSP (proximity-health), 108 EHS (specialized hospitals), 20 CHU (university hospitals) and 5 other public hospitals, from the Ministry of Health registry (sante.gov.dz). Bilingual French/Arabic (563 with both names), official `type` and `sector`, with commune/wilaya linkage. 600 geocoded via OpenStreetMap (121) and Wikidata (3), the rest to commune centroid; every record labelled with `source` and `geo_precision`. Names + type + wilaya are official; coordinates are best-effort.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`, `/sante`.
 
-## 1.4.0 — 2026-06-25
+## 1.4.0 – 2026-06-25
 
 Added two new datasets: Algeria's mosques (a Wikidata + OpenStreetMap composite) and the Djezzy boutique network.
 
-- **Mosques** (`@geoalgeria/mosquees`, new): 20,759 mosques across all 69 wilayas — a Wikidata (CC0) + OpenStreetMap (ODbL) composite giving near-complete national coverage against the ~18,449 counted by the Ministry of Religious Affairs. Per-record provenance (`source`, `wikidata` QID, `osm_id`): 13,200 Wikidata-only, 5,897 matched in both, 1,662 OpenStreetMap-only; 15,138 Arabic and 7,874 French names, denomination where known, and commune/wilaya linkage.
-- **Djezzy boutiques** (`@geoalgeria/djezzy`, new): 128 Djezzy (Optimum Telecom Algérie) boutiques across 63 wilayas from the Djezzy store locator — each geocoded, with store code, category, address, opening hours, opening code and commune/wilaya linkage.
+- **Mosques** (`@geoalgeria/mosquees`, new): 20,759 mosques across all 69 wilayas, a Wikidata (CC0) + OpenStreetMap (ODbL) composite giving near-complete national coverage against the ~18,449 counted by the Ministry of Religious Affairs. Per-record provenance (`source`, `wikidata` QID, `osm_id`): 13,200 Wikidata-only, 5,897 matched in both, 1,662 OpenStreetMap-only; 15,138 Arabic and 7,874 French names, denomination where known, and commune/wilaya linkage.
+- **Djezzy boutiques** (`@geoalgeria/djezzy`, new): 128 Djezzy (Optimum Telecom Algérie) boutiques across 63 wilayas from the Djezzy store locator, each geocoded, with store code, category, address, opening hours, opening code and commune/wilaya linkage.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`, `/djezzy`, `/mosquees`.
 
-## 1.3.0 — 2026-06-23
+## 1.3.0 – 2026-06-23
 
 Added a new sports dataset and substantially expanded two existing ones, all from official ministries.
 
-- **Sports facilities** (`@geoalgeria/sports`, new): 5,141 facilities across 58 wilayas — stadiums, pools, proximity fields, athletics tracks, courts and more (27 types) from the Ministry of Youth and Sports GIS, each with capacity, PMR accessibility, operational status, built/land area and coordinates.
-- **Youth establishments** (`@geoalgeria/jeunesse` 2.0.0): rebuilt from that same official GIS — 2,334 establishments (was 2,076) across 58 wilayas, now with French and Arabic names plus capacity, address, surfaces, year and operational status. Breaking: names are now French (read `name_ar` for the Arabic name).
-- **Higher education** (`@geoalgeria/enseignement-superieur` 1.1.0): 110 → 177 institutions — added the 19 licensed private and 48 other-ministry establishments MESRS supervises pedagogically (from the ministry's Arabic listing), with new `name_ar`, `sector` and `supervisory_ministry` fields.
+- **Sports facilities** (`@geoalgeria/sports`, new): 5,141 facilities across 58 wilayas: stadiums, pools, proximity fields, athletics tracks, courts and more (27 types) from the Ministry of Youth and Sports GIS, each with capacity, PMR accessibility, operational status, built/land area and coordinates.
+- **Youth establishments** (`@geoalgeria/jeunesse` 2.0.0): rebuilt from that same official GIS: 2,334 establishments (was 2,076) across 58 wilayas, now with French and Arabic names plus capacity, address, surfaces, year and operational status. Breaking: names are now French (read `name_ar` for the Arabic name).
+- **Higher education** (`@geoalgeria/enseignement-superieur` 1.1.0): 110 → 177 institutions: added the 19 licensed private and 48 other-ministry establishments MESRS supervises pedagogically (from the ministry's Arabic listing), with new `name_ar`, `sector` and `supervisory_ministry` fields.
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/sports`, `/enseignement-superieur`, `/tourisme`, `/formation-professionnelle`.
 
-## 1.2.0 — 2026-06-20
+## 1.2.0 – 2026-06-20
 
 Added two new datasets/packages since 1.1.0.
 
-- **Youth & sports institutions** (`@geoalgeria/jeunesse`): 2,076 institutions across 50 wilayas — maisons de jeunes, complexes sportifs, salles polyvalentes, auberges de jeunes, cultural centers and more (Ministry of Youth and Sports), each with its Arabic name, type, commune/daïra/wilaya and coordinates.
-- **Higher education** (`@geoalgeria/enseignement-superieur`): 110 institutions across 51 wilayas — 58 universities, 35 grandes écoles, 12 écoles normales supérieures and 5 centres universitaires (MESRS), each with its official website, type, and wilaya/commune linkage. Coordinates are OpenStreetMap-derived (ODbL) and labelled per record (`geo_precision`).
+- **Youth & sports institutions** (`@geoalgeria/jeunesse`): 2,076 institutions across 50 wilayas: maisons de jeunes, complexes sportifs, salles polyvalentes, auberges de jeunes, cultural centers and more (Ministry of Youth and Sports), each with its Arabic name, type, commune/daïra/wilaya and coordinates.
+- **Higher education** (`@geoalgeria/enseignement-superieur`): 110 institutions across 51 wilayas: 58 universities, 35 grandes écoles, 12 écoles normales supérieures and 5 centres universitaires (MESRS), each with its official website, type, and wilaya/commune linkage. Coordinates are OpenStreetMap-derived (ODbL) and labelled per record (`geo_precision`).
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`, `/jeunesse`, `/enseignement-superieur`.
 
-## 1.1.0 — 2026-06-18
+## 1.1.0 – 2026-06-18
 
 Added a new dataset/package since 1.0.0.
 
-- **Delivery carriers** (`@geoalgeria/livraison`): a 16-carrier registry, 411 geocoded stop-desks across 61 wilayas, and per-carrier coverage. Stop-desks come from the carriers that publish open agency data — the Yalidine + Guepex relay plus the Anderson, Noest and Maystro networks (each geocoded from its agency cards' Google Maps links).
+- **Delivery carriers** (`@geoalgeria/livraison`): a 16-carrier registry, 411 geocoded stop-desks across 61 wilayas, and per-carrier coverage. Stop-desks come from the carriers that publish open agency data: the Yalidine + Guepex relay plus the Anderson, Noest and Maystro networks (each geocoded from its agency cards' Google Maps links).
 
 Packages: `geoalgeria`, `@geoalgeria/poste`, `/emploi`, `/mobilis`, `/telecom`, `/aviation`, `/banques`, `/livraison`.
 
-## 1.0.0 — 2026-06-16
+## 1.0.0 – 2026-06-16
 
-First tagged release of the project as a whole — the state of every dataset today.
+First tagged release of the project as a whole: the state of every dataset today.
 
 - Administrative divisions: 69 wilayas, 564 dairas, 1,541 communes (bilingual FR/AR, postal codes, coordinates), current to Law 26-06 (JO n° 25, 5 April 2026) and the 2019 reform (Law 19-12).
 - Algérie Poste: 3,908 post offices, 2,026 ATMs.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,31 +1,31 @@
 # Disclaimer
 
 GeoAlgeria is an independent, community open-data project by Yasser's Studio.
-Please read this before relying on any dataset in this repository — especially
+Please read this before relying on any dataset in this repository, especially
 the bank/financial, postal, employment, telecom, and aviation data.
 
 ## Not official, not affiliated
 
 GeoAlgeria is **not affiliated with, endorsed by, sponsored by, or connected to**
-any government body, regulator, operator, or institution whose data it references —
+any government body, regulator, operator, or institution whose data it references,
 including, without limitation, the **Banque d'Algérie**, any bank or financial
 institution listed, **Algérie Poste**, **ANEM**, **ANAC**, **MFEP**, **Mobilis**,
 **Djezzy**, or **Ooredoo**, or their parent groups. All product, company, and institution names,
 acronyms, logos, **SWIFT/BIC** and bank codes are the property of their respective
-owners and are used here for **identification (nominative) purposes only** — not to
+owners and are used here for **identification (nominative) purposes only**, not to
 imply any association or endorsement.
 
 ## Sources & how the data is made
 
-The datasets are **compiled from publicly available sources** — official regulatory
+The datasets are **compiled from publicly available sources**, official regulatory
 listings (e.g. the Banque d'Algérie's published list of licensed institutions in the
-*Journal Officiel*) and each organisation's own **public** website or locator — and
+*Journal Officiel*) and each organisation's own **public** website or locator, and
 are **redistributed for reference**. Factual information such as names, addresses,
 postal codes, and identifiers is not, in itself, subject to copyright. Where a data
 point could not be confirmed against an official source, it is left empty rather than
 guessed.
 
-## No warranty — verify before you rely on it
+## No warranty – verify before you rely on it
 
 The data and software are provided **"as is", without warranty of any kind**, express
 or implied, including (without limitation) accuracy, completeness, currentness, or
@@ -49,7 +49,7 @@ distributed.
 
 ## Corrections & takedown
 
-Spotted an error — or do you represent an institution and want a record corrected or
+Spotted an error, or do you represent an institution and want a record corrected or
 removed? **[Open an issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose)**
 (or email the address on https://yasser.studio). Corrections and good-faith removal
 requests are handled promptly.

--- a/README.ar.md
+++ b/README.ar.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [Français](README.fr.md) | **العربية**
 
-<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="جيو الجزائر — GeoAlgeria" width="280"></picture></a>
+<a href="https://geoalgeria.com"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/brand/logo/geoalgeria-logo-horizontal-white.png"><img src="./assets/brand/logo/geoalgeria-logo-horizontal.png" alt="جيو الجزائر – GeoAlgeria" width="280"></picture></a>
 
 <sub>من</sub><br>
 <a href="https://yasser.studio"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/yasser-studio-logo-white.svg"><img src="./assets/yasser-studio-logo.svg" alt="Yasser's Studio" height="28"></picture></a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-GeoAlgeria ships **data**, not a running service — the main risks are a
+GeoAlgeria ships **data**, not a running service; the main risks are a
 malformed package, a compromised release, or a dependency issue in the tooling.
 
 ## Reporting a Vulnerability
@@ -30,7 +30,7 @@ new release rather than as patches to old versions.
 ## Supply-chain practices
 
 - **No `NPM_TOKEN`.** Publishing uses npm **Trusted Publishing** (OIDC) from the
-  release workflow — there is no long-lived token to leak. See `RELEASING.md`.
+  release workflow; there is no long-lived token to leak. See `RELEASING.md`.
 - **Staged publishing.** Every release is staged on npm and requires a manual
   2FA approval before it goes live, so a rogue push can't auto-publish.
 - **Provenance.** Published packages carry npm provenance attestations.
@@ -40,6 +40,6 @@ new release rather than as patches to old versions.
 ## Data accuracy ≠ security
 
 Wrong or outdated data (a misspelled commune, a stale postal code) is a **data
-correction**, not a security issue — please
+correction**, not a security issue; please
 [open a normal issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose)
 for those.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -5,14 +5,14 @@ How the engineering skills should consume this repo's domain documentation when 
 ## Before exploring, read these
 
 - **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+- **`CONTEXT-MAP.md`** at the repo root if it exists – it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** – read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 
-This repo is **single-context** — one `CONTEXT.md` + `docs/adr/` at the repo root:
+This repo is **single-context** – one `CONTEXT.md` + `docs/adr/` at the repo root:
 
 ```
 /
@@ -29,10 +29,10 @@ If the repo later warrants per-package domain docs, switch to a multi-context la
 
 When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
 
 ## Flag ADR conflicts
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0007 (example decision) — but worth reopening because…_
+> _Contradicts ADR-0007 (example decision), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,7 +6,7 @@ Issues and specs (you may know a spec as a PRD) for this repo live as markdown f
 
 - One feature per directory: `.scratch/<feature-slug>/`
 - The spec is `.scratch/<feature-slug>/spec.md`
-- Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` — never a single combined tickets file
+- Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`, never a single combined tickets file
 - Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
 - Comments and conversation history append to the bottom of the file under a `## Comments` heading
 
@@ -22,7 +22,7 @@ Read the file at the referenced path. The user will normally pass the path or th
 
 Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
 
-- **Map**: `.scratch/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
+- **Map**: `.scratch/<effort>/map.md` – the Notes / Decisions-so-far / Fog body.
 - **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
 - **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
 - **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number wins.

--- a/packages/agriculture/README.md
+++ b/packages/agriculture/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/agriculture
 
-**Algeria's agriculture-sector institutions — as data you can install.**
+**Algeria's agriculture-sector institutions, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/agriculture)](https://www.npmjs.com/package/@geoalgeria/agriculture)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/agriculture)](https://www.npmjs.com/package/@geoalgeria/agriculture)
@@ -14,7 +14,7 @@
 
 # Overview
 
-196 agriculture-sector institutions from the **Ministry of Agriculture, Rural Development and Fisheries (MADR)** institutional directory — agricultural-services directorates, forest conservations, technical & research institutes, training centres, chambers of agriculture, public offices and groups — bilingual (FR/AR), typed, with wilaya/commune linkage and coordinates.
+196 agriculture-sector institutions from the **Ministry of Agriculture, Rural Development and Fisheries (MADR)** institutional directory, agricultural-services directorates, forest conservations, technical & research institutes, training centres, chambers of agriculture, public offices and groups, bilingual (FR/AR), typed, with wilaya/commune linkage and coordinates.
 
 ## Installation
 
@@ -77,14 +77,14 @@ metadata().wilayas_covered; // 58
 | `commune_centroid` | 89 | Address matched a commune; centroid of that commune |
 | `wilaya_centroid` | 107 | No commune in the address; centroid of the wilaya chief town |
 
-> DSA covers all **58 wilayas**. Conservations des Forêts (48) and Chambres d'Agriculture (49) use the pre-2019 **48-wilaya** division — the southern wilayas fold into their parents there.
+> DSA covers all **58 wilayas**. Conservations des Forêts (48) and Chambres d'Agriculture (49) use the pre-2019 **48-wilaya** division, the southern wilayas fold into their parents there.
 
 ## Formats
 
-- `data/agriculture.json` — full array (typed by `types/index.d.ts`)
-- `data/csv/agriculture.csv` — flat CSV
-- `data/geojson/agriculture.geojson` — `FeatureCollection` (all records)
-- `data/metadata.json` — counts, sources, generated date
+- `data/agriculture.json` – full array (typed by `types/index.d.ts`)
+- `data/csv/agriculture.csv` – flat CSV
+- `data/geojson/agriculture.geojson` – `FeatureCollection` (all records)
+- `data/metadata.json` – counts, sources, generated date
 
 ```js
 import data from "@geoalgeria/agriculture/data/agriculture.json" with { type: "json" };
@@ -96,15 +96,15 @@ import type { AgricultureInstitution } from "@geoalgeria/agriculture";
 
 ## How the data is built
 
-Extracted from the MADR directory (`madr.gov.dz/contact/دليل-الهاتف/`, Arabic — the up-to-date side; `fr.madr.gov.dz/contact/annuaire/` for the bilingual category labels), normalized to official wilaya codes, then geocoded against the geoalgeria commune set. See `research/agriculture/` in the monorepo for the full pipeline (`parse.py` → `normalize.py` → `geocode.py`).
+Extracted from the MADR directory (`madr.gov.dz/contact/دليل-الهاتف/`, Arabic, the up-to-date side; `fr.madr.gov.dz/contact/annuaire/` for the bilingual category labels), normalized to official wilaya codes, then geocoded against the geoalgeria commune set. See `research/agriculture/` in the monorepo for the full pipeline (`parse.py` → `normalize.py` → `geocode.py`).
 
 ## On accuracy
 
-> Names, wilaya, address and phone/fax are **official** (from the MADR directory). The directory carries **no coordinates**: each record is placed at the centroid of the commune named in its address, or — when the address has no recognizable commune — at the centroid of the wilaya chief town (see `geo_method`; `geo_precision` is `"approximate"` for every record here — none of these are surveyed points). These are approximate locations for the *wilaya/commune*, not surveyed building points. Some source rows have minor typos that have been normalized.
+> Names, wilaya, address and phone/fax are **official** (from the MADR directory). The directory carries **no coordinates**: each record is placed at the centroid of the commune named in its address, or, when the address has no recognizable commune, at the centroid of the wilaya chief town (see `geo_method`; `geo_precision` is `"approximate"` for every record here, none of these are surveyed points). These are approximate locations for the *wilaya/commune*, not surveyed building points. Some source rows have minor typos that have been normalized.
 
 ## Source & license
 
-Data from the **Ministry of Agriculture, Rural Development and Fisheries (MADR)** — a factual public-sector listing, redistributed for reference. Wilaya/commune linkage uses the geoalgeria base dataset. Package code under MIT (see [LICENSE](LICENSE)).
+Data from the **Ministry of Agriculture, Rural Development and Fisheries (MADR)**, a factual public-sector listing, redistributed for reference. Wilaya/commune linkage uses the geoalgeria base dataset. Package code under MIT (see [LICENSE](LICENSE)).
 
 ## Questions?
 

--- a/packages/aviation/README.md
+++ b/packages/aviation/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/aviation
 
-**Every civil airport in Algeria — as data you can install.**
+**Every civil airport in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/aviation)](https://www.npmjs.com/package/@geoalgeria/aviation)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/aviation)](https://www.npmjs.com/package/@geoalgeria/aviation)
@@ -12,7 +12,7 @@
 
 </div>
 
-33 civil airports across Algeria — with official names, **ICAO (OACI) codes**, postal
+33 civil airports across Algeria, with official names, **ICAO (OACI) codes**, postal
 addresses, phone numbers, websites, GPS coordinates, and wilaya linkage. Sourced from
 ANAC (the Autorité Nationale de l'Aviation Civile), shipped as JSON, CSV, and GeoJSON.
 Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -28,15 +28,15 @@ const all = aviation.airports();                 // 33
 const algiers = aviation.airportByIcao("DAAG");  // Houari Boumediene
 const inOran = aviation.airportsByWilaya(31);     // airports in wilaya 31
 
-// Everything has lat/lng — distance-sort, map, or nearest-airport in a few lines.
+// Everything has lat/lng – distance-sort, map, or nearest-airport in a few lines.
 ```
 
 ## What you can build
 
-- **Nearest-airport lookups** — coordinates on every record, ready for distance sorting.
-- **ICAO ↔ airport resolution** — map flight-data ICAO codes to names, contacts, and location.
-- **Travel & logistics** — match a wilaya or a point to its serving airport.
-- **Maps** — drop-in GeoJSON point layer for the whole civil-airport network.
+- **Nearest-airport lookups** – coordinates on every record, ready for distance sorting.
+- **ICAO ↔ airport resolution** – map flight-data ICAO codes to names, contacts, and location.
+- **Travel & logistics** – match a wilaya or a point to its serving airport.
+- **Maps** – drop-in GeoJSON point layer for the whole civil-airport network.
 
 ## What's inside
 
@@ -57,7 +57,7 @@ import airports from "@geoalgeria/aviation/data/airports.json" with { type: "jso
 // https://cdn.jsdelivr.net/npm/@geoalgeria/aviation/data/airports.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import aviation, { type Airport } from "@geoalgeria/aviation";
@@ -98,25 +98,25 @@ data/
 }
 ```
 
-`id` is the ICAO code lowercased. `icao` always matches `DA[A-Z]{2}`. `iata` is `null` — ANAC
+`id` is the ICAO code lowercased. `icao` always matches `DA[A-Z]{2}`. `iata` is `null`, ANAC
 publishes only ICAO codes (the slot is reserved for later enrichment). `wilaya_code` is
 zero-padded to two digits and joins GeoAlgeria's wilayas; this dataset is wilaya-level only, so
 `commune_code` and `commune` are always `null`. Every point comes straight from ANAC's own
 published map, so `geo_precision` is always `"exact"` and `geo_method` is always
-`"source_point"` — nothing here is a fallback or a downgrade. `source` is a short key resolved
+`"source_point"`, nothing here is a fallback or a downgrade. `source` is a short key resolved
 in `metadata.sources[]` (always `"anac"`), and `refs.icao` duplicates the top-level `icao`. One
 record (`dabs`, Tébessa) has a `null` `phone` where ANAC lists none.
 
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 69-wilaya division dataset that `wilaya_code` here links to. Use `@geoalgeria/aviation`
 when you *only* need airport data.
 
 ## Source
 
-Data comes from **ANAC — Autorité Nationale de l'Aviation Civile**, via the public
+Data comes from **ANAC – Autorité Nationale de l'Aviation Civile**, via the public
 airports map (<https://www.anac.dz/en/carte-des-aeroports-3/>). Run `npm run fetch` to
 regenerate every output from the live map; the build follows the map's iframe so an ANAC
 version bump doesn't break it, and it fails loudly if the airport count or ICAO format

--- a/packages/banques/README.md
+++ b/packages/banques/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/banques
 
-**Every bank in Algeria — as data you can install.**
+**Every bank in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/banques)](https://www.npmjs.com/package/@geoalgeria/banques)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -12,7 +12,7 @@
 </div>
 
 The **21 banks** and **8 financial institutions** licensed (_agréés_) by the Banque
-d'Algérie — with FR/AR names, the 3-digit RIB **`bank_code`**, ownership
+d'Algérie, with FR/AR names, the 3-digit RIB **`bank_code`**, ownership
 (public / foreign / domestic) + controlling **parent group**, **SWIFT/BIC**,
 website, head-office address, and wilaya linkage. Compiled from the
 official Banque d'Algérie list (Journal Officiel n° 9, 6 February 2026) and each
@@ -35,9 +35,9 @@ banques.byId("BNA");          // → Banque Nationale d'Algérie (by id or acron
 
 | Dataset | Count | Notes |
 | --- | --- | --- |
-| Banks | **21** | 7 public · 14 foreign-owned — RIB bank code, name FR/AR, ownership + parent, country, SWIFT/BIC, HQ |
+| Banks | **21** | 7 public · 14 foreign-owned – RIB bank code, name FR/AR, ownership + parent, country, SWIFT/BIC, HQ |
 | Financial institutions | **8** | leasing, refinancing & mutual-credit entities (non-deposit) |
-| Branch locations | **1,704** | **all 21 banks** — name, address, phone, wilaya, coordinates; 1,213 geocoded; **67/69 wilayas** |
+| Branch locations | **1,704** | **all 21 banks** – name, address, phone, wilaya, coordinates; 1,213 geocoded; **67/69 wilayas** |
 
 Every record carries `wilaya_code` (head office) linked to the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) 69-wilaya model.
@@ -47,12 +47,12 @@ Every record carries `wilaya_code` (head office) linked to the
 - **Roster** is the current Banque d'Algérie _agréé_ list, verified at 21 banks + 8
   institutions (Ziraat Bankası, approved Jan 2025, is the newest bank).
 - Fields that could not be confirmed from an official source are **`null`**, never
-  guessed — most foreign banks publish no Arabic name; financial institutions carry
+  guessed, most foreign banks publish no Arabic name; financial institutions carry
   no SWIFT/BIC; a few head-office addresses are best-effort and may be refined.
 - SWIFT/BIC values are head-office (`…XXX`) variants.
 - **Branch coordinates** are kept only when they fall inside Algeria (and, for
   banks whose locator merely geocodes addresses, agree with the branch's stated
-  wilaya); otherwise the point is dropped and the wilaya kept — never a guessed
+  wilaya); otherwise the point is dropped and the wilaya kept, never a guessed
   coordinate. Locator pages are fetched with TLS verification disabled
   (`curl -k`) because several `.dz` bank hosts serve broken certificates.
 - **Address-only banks** (BNH, HBTF, Fransabank, BEA, SGA) publish no coordinates,
@@ -63,7 +63,7 @@ Every record carries `wilaya_code` (head office) linked to the
   **BDL** and **Trust Bank** come from each bank's published Google My Maps (KML);
   **Citibank**, **HSBC** and **Ziraat** are their single Algiers offices.
 - **`bank_code`** is the 3-digit RIB _code banque_ (IBAN positions 5–7), verified
-  against independent code-banque tables — no single official public register
+  against independent code-banque tables, no single official public register
   exists. BNH and Ziraat (both newly licensed) have no published code yet →
   `null`. Financial institutions are non-deposit, so they carry no `bank_code`.
 
@@ -71,15 +71,15 @@ Every record carries `wilaya_code` (head office) linked to the
 
 The registry is layer one; **branch locations** now cover **all 21 banks /
 1,704 branches** (67/69 wilayas). Each bank publishes its network through a
-different locator — Joomla `com_mymaplocations`, WordPress store-locator / map
+different locator, Joomla `com_mymaplocations`, WordPress store-locator / map
 plugins, a Vite SPA bundle, ASP.NET/TYPO3 pages, inline map JSON, Google My Maps
-KML — so banks are added one extractor at a time (see `scripts/fetch.mjs`).
+KML, so banks are added one extractor at a time (see `scripts/fetch.mjs`).
 Address-only locators ship with `lat`/`lng` `null` (wilaya resolved from the
 address); where a source's coordinates disagree with the branch's stated wilaya,
 the coordinates are dropped rather than shipped wrong. Still to come behind the
 same `@geoalgeria/banques`:
 
-- **ATMs (DAB/GAB)** — where individual banks publish locators; honest about
+- **ATMs (DAB/GAB)** – where individual banks publish locators; honest about
   completeness, since Algeria has no single public ATM directory.
 
 ## Formats
@@ -95,7 +95,7 @@ record shapes are fully **typed**.
 with, endorsed by, or connected to** the Banque d'Algérie or any bank or
 institution listed; their names, acronyms, and **SWIFT/BIC** codes belong to their
 respective owners and are used for identification only. The data is compiled from
-public sources and provided **"as is", without warranty** — it may be incomplete or
+public sources and provided **"as is", without warranty**, it may be incomplete or
 outdated. **Verify `bank_code` / SWIFT-BIC and branch details against the official
 source before any financial, payment, KYC, or compliance use.** Nothing here is
 financial or legal advice. To report an error or request a correction/removal,

--- a/packages/buses/README.md
+++ b/packages/buses/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/buses
 
-**Algeria's urban bus networks — as data you can install.**
+**Algeria's urban bus networks, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/buses)](https://www.npmjs.com/package/@geoalgeria/buses)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/buses)](https://www.npmjs.com/package/@geoalgeria/buses)
@@ -12,11 +12,11 @@
 
 </div>
 
-Urban bus **lines** across Algeria — termini, stop counts, and the communes and transit
+Urban bus **lines** across Algeria, termini, stop counts, and the communes and transit
 stations each line serves. A **multi-operator** dataset; v1 ships **50 ETUSA lines**
 (Alger). Shipped as JSON and CSV. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
 
-> **Operator (source):** ETUSA — Établissement de transport urbain et suburbain d'Alger.
+> **Operator (source):** ETUSA – Établissement de transport urbain et suburbain d'Alger.
 > More cities/operators will be added under the same schema. For intercity coach stations
 > see [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres);
 > for rail/tram/metro see [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire).
@@ -37,10 +37,10 @@ const l1 = buses.lineById("etusa-1");          // El Harrach ↔ Place Aïssat I
 
 | Dataset | Count | Notes |
 | --- | --- | --- |
-| Urban bus lines | **50** | ETUSA (Alger) — termini, stop count, communes & stations served |
+| Urban bus lines | **50** | ETUSA (Alger) – termini, stop count, communes & stations served |
 
 > **Scope (v1):** line-level attributes only. Per-stop and per-line **geometry**
-> (OSM `route=bus`) is deferred to **v1.1** — ETUSA-tagged OSM route coverage is
+> (OSM `route=bus`) is deferred to **v1.1**, ETUSA-tagged OSM route coverage is
 > currently thin. This covers 50 of ~122 ETUSA passenger lines. `wilaya_code` is `16`
 > (Alger) and joins the [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) model.
 
@@ -49,7 +49,7 @@ const l1 = buses.lineById("etusa-1");          // El Harrach ↔ Place Aïssat I
 ```json
 {
   "id": "etusa-1",
-  "name": "Ligne 1 — El Harrach ↔ Place Aïssat Idir, via Haï El Badr",
+  "name": "Ligne 1 – El Harrach ↔ Place Aïssat Idir, via Haï El Badr",
   "wilaya_code": "16",
   "commune_code": null,
   "commune": null,
@@ -70,16 +70,16 @@ const l1 = buses.lineById("etusa-1");          // El Harrach ↔ Place Aïssat I
 }
 ```
 
-`commune_code` and `commune` are always `null` for this dataset — a line spans several
+`commune_code` and `commune` are always `null` for this dataset, a line spans several
 communes (see `communes_served`), so no single commune applies. `lat`/`lng`/`geo_precision`/
 `geo_method` are always `null` too: these are line records with no per-line geometry (see
 Scope below).
 
 ## Source & license
 
-Line data comes from **fr.wikipedia** (the ETUSA line articles) — licensed
+Line data comes from **fr.wikipedia** (the ETUSA line articles), licensed
 **CC BY-SA 4.0** (attribution + share-alike). Operator: **ETUSA**. Package code is
-[MIT](LICENSE); the line data inherits Wikipedia's CC BY-SA — keep attribution and
+[MIT](LICENSE); the line data inherits Wikipedia's CC BY-SA, keep attribution and
 share-alike if you redistribute. Verify with ETUSA for authoritative, current lines.
 
 [Browse all packages →](https://geoalgeria.com/data)

--- a/packages/culture/README.md
+++ b/packages/culture/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/culture
 
-**Algeria's cultural atlas — as data you can install.**
+**Algeria's cultural atlas, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/culture)](https://www.npmjs.com/package/@geoalgeria/culture)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/culture)](https://www.npmjs.com/package/@geoalgeria/culture)
@@ -12,7 +12,7 @@
 
 </div>
 
-**1,083 cultural places** across **66 of Algeria's 69 wilayas** — protected
+**1,083 cultural places** across **66 of Algeria's 69 wilayas**, protected
 heritage sites, museums, theatres, libraries and cultural establishments (maisons
 & palais de la culture, cinemas, culture directorates, arts schools) from the
 **Ministry of Culture's** *Cartes du Patrimoine Culturel Algérien* atlas,
@@ -41,11 +41,11 @@ const tours = all.filter((p) => p.has_virtual_tour);
 
 ## What you can build
 
-- **Cultural maps & nearest-place search** — every one of the 1,083 places has
+- **Cultural maps & nearest-place search** – every one of the 1,083 places has
   coordinates, ready for a map or a "what's near me" feature.
-- **Bilingual cultural directories** — French and Arabic names, official type and
+- **Bilingual cultural directories** – French and Arabic names, official type and
   wilaya for every place; filter heritage vs. operating establishments.
-- **Heritage & tourism apps** — protected sites, museums and 360° virtual tours,
+- **Heritage & tourism apps** – protected sites, museums and 360° virtual tours,
   linked to commune/wilaya for routing and coverage analysis.
 
 ## What's inside
@@ -65,16 +65,16 @@ const tours = all.filter((p) => p.has_virtual_tour);
 
 | Type | Count | Meaning |
 | --- | --- | --- |
-| `protected-cultural-property` | 580 | Bien culturel protégé — protected monument/site |
-| `library` | 257 | Bibliothèque — public reading library |
-| `museum` | 48 | Musée — museum |
-| `theatre` | 45 | Théâtre — theatre |
-| `museum-moudjahid` | 13 | Musée du Moudjahid — museum of the war of independence |
+| `protected-cultural-property` | 580 | Bien culturel protégé – protected monument/site |
+| `library` | 257 | Bibliothèque – public reading library |
+| `museum` | 48 | Musée – museum |
+| `theatre` | 45 | Théâtre – theatre |
+| `museum-moudjahid` | 13 | Musée du Moudjahid – museum of the war of independence |
 | `cultural-house` | 51 | Maison de la culture |
-| `cultural-directorate` | 33 | Direction de la culture — wilaya culture directorate/office |
-| `cinema` | 20 | Salle de cinéma — cinema / cinematheque |
-| `cultural-center` | 15 | Centre culturel — cultural / research centre |
-| `arts-school` | 15 | École d'art — fine-arts school / conservatory |
+| `cultural-directorate` | 33 | Direction de la culture – wilaya culture directorate/office |
+| `cinema` | 20 | Salle de cinéma – cinema / cinematheque |
+| `cultural-center` | 15 | Centre culturel – cultural / research centre |
+| `arts-school` | 15 | École d'art – fine-arts school / conservatory |
 | `cultural-palace` | 6 | Palais de la culture |
 
 > **The atlas is official; treat the coordinates as best-effort.** Names, type,
@@ -92,7 +92,7 @@ import culture from "@geoalgeria/culture/data/culture.json" with { type: "json" 
 // https://cdn.jsdelivr.net/npm/@geoalgeria/culture/data/culture.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import culture, { type CulturalSite } from "@geoalgeria/culture";
@@ -140,11 +140,11 @@ data/
 ```
 
 `id` is a stable `{wilaya_code}-{type_code}-{seq}` key, unique within this
-file — treat it as opaque. `name` is the French name where available, else
+file, treat it as opaque. `name` is the French name where available, else
 Arabic. `type` is the place's layer on the portal; `category` groups the 11
 types into `heritage` vs. `establishment`. `has_virtual_tour` is true for the
 22 places with a 360° tour. `geo_precision` is `"exact"` for 1,067 records and
-`"approximate"` for 16 — every place has a coordinate, but 16 don't meet the
+`"approximate"` for 16, every place has a coordinate, but 16 don't meet the
 precision bar for `"exact"`. `geo_method` is `"source_point"` for every
 record: the coordinate is the portal's own published point, not a derived
 centroid. `refs.patrimoine` is the place's node id on the portal.
@@ -159,7 +159,7 @@ centroid. `refs.patrimoine` is the place's node id on the portal.
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a place's `commune_code` into a polygon or centroid. Use
 `@geoalgeria/culture` when you *only* need the cultural places.
 
@@ -168,7 +168,7 @@ you turn a place's `commune_code` into a polygon or centroid. Use
 Run `npm run fetch` to regenerate every output. It:
 
 1. reads the curated, bilingual cultural atlas (assembled and translated from the
-   Ministry of Culture's `cartes.patrimoineculturelalgerien.org` portal — the
+   Ministry of Culture's `cartes.patrimoineculturelalgerien.org` portal, the
    portal's French and Arabic catalogs are disjoint node sets, unioned by
    coordinate proximity and translated to fill the bilingual gaps);
 2. **rescopes** each place to the current 69-wilaya scheme and attaches a

--- a/packages/dataset/README.md
+++ b/packages/dataset/README.md
@@ -2,9 +2,9 @@
 
 # GeoAlgeria
 
-> The Algerian geodata package — 69 wilayas, 555 dairas, 1,528 communes. One `npm install` away.
+> The Algerian geodata package, 69 wilayas, 555 dairas, 1,528 communes. One `npm install` away.
 
-Still copy-pasting wilaya lists from PDFs? Still using datasets stuck at 48 wilayas? GeoAlgeria is the first CI-validated, npm-installable Algerian geodata — updated for the 2026 reform. JSON, CSV, GeoJSON, SQL, TypeScript.
+Still copy-pasting wilaya lists from PDFs? Still using datasets stuck at 48 wilayas? GeoAlgeria is the first CI-validated, npm-installable Algerian geodata, updated for the 2026 reform. JSON, CSV, GeoJSON, SQL, TypeScript.
 
 [![CI](https://github.com/yasserstudio/geoalgeria/actions/workflows/ci.yml/badge.svg)](https://github.com/yasserstudio/geoalgeria/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/geoalgeria)](https://www.npmjs.com/package/geoalgeria)
@@ -46,12 +46,12 @@ Also referred to as: Algerian provinces (wilayas), districts (dairas), municipal
 
 ## Who's This For?
 
-- **E-commerce devs** — address forms, shipping zone config, postal code validation
-- **Backend engineers** — seed your DB with one SQL file
-- **Frontend devs** — cascading dropdowns (wilaya → daira → commune)
-- **GIS / data analysts** — GeoJSON with 1,528 point features
-- **Civic tech builders** — government apps, citizen portals
-- **Students & researchers** — clean, structured, well-documented data
+- **E-commerce devs** – address forms, shipping zone config, postal code validation
+- **Backend engineers** – seed your DB with one SQL file
+- **Frontend devs** – cascading dropdowns (wilaya → daira → commune)
+- **GIS / data analysts** – GeoJSON with 1,528 point features
+- **Civic tech builders** – government apps, citizen portals
+- **Students & researchers** – clean, structured, well-documented data
 
 ---
 
@@ -81,7 +81,7 @@ dz.getPostOfficesByCommune(1731); // post offices in a commune (by code_commune)
 
 TypeScript types included out of the box.
 
-**Using this in production?** [Tell us about it](https://github.com/yasserstudio/geoalgeria/discussions) — we feature community projects in the README.
+**Using this in production?** [Tell us about it](https://github.com/yasserstudio/geoalgeria/discussions), we feature community projects in the README.
 
 ---
 
@@ -99,7 +99,7 @@ TypeScript types included out of the box.
 
 ### E-commerce / address forms
 
-Grab `data/ecommerce/communes.json` — flat, denormalized, no joins:
+Grab `data/ecommerce/communes.json`, flat, denormalized, no joins:
 
 ```json
 {
@@ -131,7 +131,7 @@ sqlite3 mydb.sqlite < full.sql
 
 ### GIS / Mapping
 
-Download `data/geojson/communes.geojson` from this repo — standard GeoJSON, works with Leaflet, Mapbox, QGIS, etc.
+Download `data/geojson/communes.geojson` from this repo, standard GeoJSON, works with Leaflet, Mapbox, QGIS, etc.
 
 > **Note:** the npm package ships JSON only (to stay lightweight). The **CSV, GeoJSON, and SQL** exports live in the repo under `data/` and are bundled as a zip on every [GitHub Release](https://github.com/yasserstudio/geoalgeria/releases).
 
@@ -156,7 +156,7 @@ Download `data/geojson/communes.geojson` from this repo — standard GeoJSON, wo
 | `data/delivery/*.json` | JSON | 69 per provider | Shipping zone calculation |
 | `data/poste/postoffices.json` | JSON | 3,908 | Post offices (real codes, coords) |
 | `data/poste/atms.json` | JSON | 2,026 | ATM locations |
-| `data/poste/csv/*`, `data/poste/geojson/*` | CSV/GeoJSON | — | Postal data for spreadsheets / maps |
+| `data/poste/csv/*`, `data/poste/geojson/*` | CSV/GeoJSON | – | Postal data for spreadsheets / maps |
 
 > `data/poste/` is sourced from [Algérie Poste](https://baridimap.poste.dz). `commune_code` joins to each commune's `code_commune`.
 
@@ -176,7 +176,7 @@ See [CONTRIBUTING.md](https://github.com/yasserstudio/geoalgeria/blob/main/CONTR
 - New export formats (XML, YAML, PHP arrays, etc.)
 - Translations and transliteration fixes
 
-**First time contributing?** Look for issues labeled `good first issue` — many just need adding coordinates for a single commune.
+**First time contributing?** Look for issues labeled `good first issue`, many just need adding coordinates for a single commune.
 
 ---
 
@@ -200,25 +200,25 @@ This dataset uses [Semantic Versioning](https://semver.org/). See [CHANGELOG.md]
 | [`@geoalgeria/banques`](https://www.npmjs.com/package/@geoalgeria/banques) | Licensed banks, institutions & branches (RIB/SWIFT) |
 | [`@geoalgeria/livraison`](https://www.npmjs.com/package/@geoalgeria/livraison) | Delivery carriers & geocoded stop-desks |
 | [`@geoalgeria/jeunesse`](https://www.npmjs.com/package/@geoalgeria/jeunesse) | Youth & sports institutions (Ministry of Youth and Sports) |
-| [`@geoalgeria/enseignement-superieur`](https://www.npmjs.com/package/@geoalgeria/enseignement-superieur) | Higher-education network — universities, grandes écoles, ENS, centres (MESRS) |
-| [`@geoalgeria/tourisme`](https://www.npmjs.com/package/@geoalgeria/tourisme) | Tourism infrastructure — hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
-| [`@geoalgeria/formation-professionnelle`](https://www.npmjs.com/package/@geoalgeria/formation-professionnelle) | Vocational training — CFPA, INSFP, IFEP, private centers (MFEP / takwin.dz) |
-| [`@geoalgeria/sports`](https://www.npmjs.com/package/@geoalgeria/sports) | Sports facilities — stadiums, pools, courts, tracks (Ministry of Youth and Sports) |
-| [`@geoalgeria/djezzy`](https://www.npmjs.com/package/@geoalgeria/djezzy) | Djezzy boutiques — geocoded retail stores with category & hours (djezzy.dz) |
-| [`@geoalgeria/mosquees`](https://www.npmjs.com/package/@geoalgeria/mosquees) | Mosques — Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
-| [`@geoalgeria/sante`](https://www.npmjs.com/package/@geoalgeria/sante) | Public health establishments — EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
-| [`@geoalgeria/culture`](https://www.npmjs.com/package/@geoalgeria/culture) | Cultural atlas — protected sites, museums, theatres, libraries + cultural establishments (Ministry of Culture), bilingual, fully geocoded |
-| [`@geoalgeria/agriculture`](https://www.npmjs.com/package/@geoalgeria/agriculture) | Agriculture-sector institutions — services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices & groups (Ministry of Agriculture), bilingual, geocoded |
-| [`@geoalgeria/ecoles`](https://www.npmjs.com/package/@geoalgeria/ecoles) | Schools — 11,830 primaires, CEM, lycées & préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap) |
-| [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Intercity bus stations — 74 SOGRAL gares routières across 51 wilayas, geocoded with surfaces & commune/wilaya linkage |
-| [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & urban transit — 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OpenStreetMap composite, bilingual |
-| [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban bus networks — 50 ETUSA (Alger) lines with termini, stop counts, communes & stations served (line-level v1) |
-| [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Pharmaceutical manufacturers — 171 approved medicine & medical-device makers from the Ministry of Pharmaceutical Industry register, bilingual, geocoded |
-| [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) — 3,790 geocoded across 67 wilayas from OpenStreetMap, bilingual where named |
-| [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Ooredoo stores — 572 EO / City Shop / Espace Services with real coordinates; completes the telecom retail trio |
-| [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Transport umbrella — installs aviation + ferroviaire + gares-routieres + buses in one step |
-| [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Pharma umbrella — installs industrie-pharmaceutique + pharmacies in one step |
-| [`@geoalgeria/protection-civile`](https://www.npmjs.com/package/@geoalgeria/protection-civile) | Civil protection / fire & rescue units — 880 DGPC units across all wilayas with Arabic names, address/phone/fax & a status tier, geocoded, post-2026-reform wilaya linkage |
+| [`@geoalgeria/enseignement-superieur`](https://www.npmjs.com/package/@geoalgeria/enseignement-superieur) | Higher-education network – universities, grandes écoles, ENS, centres (MESRS) |
+| [`@geoalgeria/tourisme`](https://www.npmjs.com/package/@geoalgeria/tourisme) | Tourism infrastructure – hotels, attractions, historic sites, thermal springs, parks (ASAL, OSM, Wikidata) |
+| [`@geoalgeria/formation-professionnelle`](https://www.npmjs.com/package/@geoalgeria/formation-professionnelle) | Vocational training – CFPA, INSFP, IFEP, private centers (MFEP / takwin.dz) |
+| [`@geoalgeria/sports`](https://www.npmjs.com/package/@geoalgeria/sports) | Sports facilities – stadiums, pools, courts, tracks (Ministry of Youth and Sports) |
+| [`@geoalgeria/djezzy`](https://www.npmjs.com/package/@geoalgeria/djezzy) | Djezzy boutiques – geocoded retail stores with category & hours (djezzy.dz) |
+| [`@geoalgeria/mosquees`](https://www.npmjs.com/package/@geoalgeria/mosquees) | Mosques – Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
+| [`@geoalgeria/sante`](https://www.npmjs.com/package/@geoalgeria/sante) | Public health establishments – EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
+| [`@geoalgeria/culture`](https://www.npmjs.com/package/@geoalgeria/culture) | Cultural atlas – protected sites, museums, theatres, libraries + cultural establishments (Ministry of Culture), bilingual, fully geocoded |
+| [`@geoalgeria/agriculture`](https://www.npmjs.com/package/@geoalgeria/agriculture) | Agriculture-sector institutions – services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices & groups (Ministry of Agriculture), bilingual, geocoded |
+| [`@geoalgeria/ecoles`](https://www.npmjs.com/package/@geoalgeria/ecoles) | Schools – 11,830 primaires, CEM, lycées & préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap) |
+| [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Intercity bus stations – 74 SOGRAL gares routières across 51 wilayas, geocoded with surfaces & commune/wilaya linkage |
+| [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail & urban transit – 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OpenStreetMap composite, bilingual |
+| [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban bus networks – 50 ETUSA (Alger) lines with termini, stop counts, communes & stations served (line-level v1) |
+| [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Pharmaceutical manufacturers – 171 approved medicine & medical-device makers from the Ministry of Pharmaceutical Industry register, bilingual, geocoded |
+| [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies (officines) – 3,790 geocoded across 67 wilayas from OpenStreetMap, bilingual where named |
+| [`@geoalgeria/ooredoo`](https://www.npmjs.com/package/@geoalgeria/ooredoo) | Ooredoo stores – 572 EO / City Shop / Espace Services with real coordinates; completes the telecom retail trio |
+| [`@geoalgeria/transport`](https://www.npmjs.com/package/@geoalgeria/transport) | Transport umbrella – installs aviation + ferroviaire + gares-routieres + buses in one step |
+| [`@geoalgeria/pharma`](https://www.npmjs.com/package/@geoalgeria/pharma) | Pharma umbrella – installs industrie-pharmaceutique + pharmacies in one step |
+| [`@geoalgeria/protection-civile`](https://www.npmjs.com/package/@geoalgeria/protection-civile) | Civil protection / fire & rescue units – 880 DGPC units across all wilayas with Arabic names, address/phone/fax & a status tier, geocoded, post-2026-reform wilaya linkage |
 
 Full list and the monorepo: [github.com/yasserstudio/geoalgeria](https://github.com/yasserstudio/geoalgeria).
 
@@ -234,13 +234,13 @@ Using geoalgeria in your project? [Open a discussion](https://github.com/yassers
 
 Every star helps the next Algerian developer find clean data instead of broken PDFs. **[Star this repo](https://github.com/yasserstudio/geoalgeria)** if it saved you time.
 
-Found wrong data? [Open an issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose) — we fix it within 48h, guaranteed.
+Found wrong data? [Open an issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose), we fix it within 48h, guaranteed.
 
 ---
 
 ## Sponsor
 
-GeoAlgeria is free and MIT. If it saves you time, [**sponsor its maintenance**](https://github.com/sponsors/yasserstudio) — sponsorships fund keeping the data current through every reform and expanding GeoAlgeria toward *all* kinds of open Algeria data.
+GeoAlgeria is free and MIT. If it saves you time, [**sponsor its maintenance**](https://github.com/sponsors/yasserstudio), sponsorships fund keeping the data current through every reform and expanding GeoAlgeria toward *all* kinds of open Algeria data.
 
 ---
 
@@ -256,25 +256,25 @@ View all 69 wilayas on a map: [`algeria.geojson`](algeria.geojson) (GitHub rende
 69. The original 48, plus 10 added in 2019 (Law 19-12), plus 11 made official in April 2026 ([Law n° 26-06, *Journal Officiel* n° 25 of 5 April 2026](https://www.joradp.dz/FTP/jo-francais/2026/F2026040.pdf)). Transition period ends December 31, 2026; full autonomy from January 1, 2027.
 
 **Where can I find a list of all Algerian communes in JSON?**
-Right here — `data/ecommerce/communes.json` has all 1,528 communes in a flat, ready-to-use format.
+Right here, `data/ecommerce/communes.json` has all 1,528 communes in a flat, ready-to-use format.
 
 **What are the new wilayas added in 2026?**
 Wilayas 59-69 (numbered by mother wilaya code order): 59 Aflou (from Laghouat), 60 Barika (from Batna), 61 El Kantara (from Biskra), 62 Bir El Ater (from Tébessa), 63 El Aricha (from Tlemcen), 64 Ksar Chellala (from Tiaret), 65 Aïn Oussara (from Djelfa), 66 Messaad (from Djelfa), 67 Ksar El Boukhari (from Médéa), 68 Bou Saâda (from M'sila), 69 El Abiodh Sidi Cheikh (from El Bayadh).
 
 **How can I get Algeria postal codes in JSON format?**
-Install `geoalgeria` via npm or download `data/ecommerce/communes.json` directly — it includes all 1,528 postal codes mapped to commune names in French and Arabic.
+Install `geoalgeria` via npm or download `data/ecommerce/communes.json` directly, it includes all 1,528 postal codes mapped to commune names in French and Arabic.
 
 **What is the best Algeria geodata package for developers?**
-GeoAlgeria is the most complete option as of 2026 — it is the only npm package with all 69 wilayas, postal codes, coordinates, dairas, and delivery zone templates in one install. CI-validated on every commit.
+GeoAlgeria is the most complete option as of 2026, it is the only npm package with all 69 wilayas, postal codes, coordinates, dairas, and delivery zone templates in one install. CI-validated on every commit.
 
-**Liste des wilayas d'Algérie 2026 — où trouver?**
+**Liste des wilayas d'Algérie 2026, où trouver?**
 GeoAlgeria contient les 69 wilayas avec noms en français et arabe, codes postaux, et coordonnées GPS. Disponible en JSON, CSV, GeoJSON, et SQL. `npm install geoalgeria`
 
 ---
 
 ## License
 
-MIT — free for personal and commercial use.
+MIT, free for personal and commercial use.
 
 Made with care by [Yasser's Studio](https://yasser.studio) | [geoalgeria.com](https://geoalgeria.com)
 

--- a/packages/djezzy/README.md
+++ b/packages/djezzy/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/djezzy
 
-**The Djezzy boutique network in Algeria — as data you can install.**
+**The Djezzy boutique network in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/djezzy)](https://www.npmjs.com/package/@geoalgeria/djezzy)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/djezzy)](https://www.npmjs.com/package/@geoalgeria/djezzy)
@@ -13,7 +13,7 @@
 </div>
 
 The **128 boutiques** of **Djezzy** (Optimum Telecom Algérie), one of Algeria's
-three mobile operators — every store geocoded, with its category, address,
+three mobile operators, every store geocoded, with its category, address,
 opening hours, opening code, and commune/wilaya linkage. Shipped as JSON, CSV,
 GeoJSON, and TypeScript. Part of
 [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -36,11 +36,11 @@ const flagships = boutiques.filter((b) => b.category === "A");
 
 ## What you can build
 
-- **Store locators** — coordinates on every one of the 128 boutiques, ready for
+- **Store locators** – coordinates on every one of the 128 boutiques, ready for
   distance sorting or a map.
-- **Coverage by wilaya** — each boutique is tagged with its commune and wilaya,
+- **Coverage by wilaya** – each boutique is tagged with its commune and wilaya,
   so you can count or rank Djezzy presence across the country's 63 covered wilayas.
-- **Operator comparisons** — join against
+- **Operator comparisons** – join against
   [`@geoalgeria/mobilis`](https://www.npmjs.com/package/@geoalgeria/mobilis) on
   `wilaya_code` to compare retail footprints operator by operator.
 
@@ -60,7 +60,7 @@ import boutiques from "@geoalgeria/djezzy/data/boutiques.json" with { type: "jso
 // https://cdn.jsdelivr.net/npm/@geoalgeria/djezzy/data/boutiques.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import djezzy, { type Boutique } from "@geoalgeria/djezzy";
@@ -106,7 +106,7 @@ data/
 `id` is a stable `{wilaya_code}-{seq}` key synthesized by GeoAlgeria (seq ordered
 by the source code), unique within this dataset. Djezzy's own store code is kept
 as `refs.djezzy`. `wilaya_code` joins to GeoAlgeria's `wilaya_code`. `geo_precision`
-is always `"exact"` and `geo_method` always `"operator_point"` — every boutique
+is always `"exact"` and `geo_method` always `"operator_point"`, every boutique
 carries a real Djezzy-published coordinate.
 
 > **Commune/wilaya linkage is derived, not from the source.** Djezzy publishes a
@@ -119,7 +119,7 @@ carries a real Djezzy-published coordinate.
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a boutique's `commune_code` into a polygon or centroid. Use
 `@geoalgeria/djezzy` when you *only* need the Djezzy network.
 
@@ -127,7 +127,7 @@ you turn a boutique's `commune_code` into a polygon or centroid. Use
 
 Data comes from the **Djezzy** store locator
 (<https://www.djezzy.dz/nos-boutiques/>). The page ships the full boutique list
-inline as an HTML-entity-encoded JSON array — there is no separate API. Run
+inline as an HTML-entity-encoded JSON array, there is no separate API. Run
 `npm run fetch` to regenerate every output: it parses the inline store objects,
 validates the coordinates fall inside Algeria, and attaches the administrative
 linkage by nearest commune centroid.
@@ -137,7 +137,7 @@ linkage by nearest commune centroid.
 Code is [MIT](LICENSE). The underlying data is © **Optimum Telecom Algérie
 (Djezzy)**, redistributed for reference and to power
 [GeoAlgeria](https://geoalgeria.com). Verify against Djezzy for authoritative,
-real-time information. The boutique list changes as stores open and close — each
+real-time information. The boutique list changes as stores open and close, each
 rebuild reflects whatever the locator currently shows.
 
 [API docs & field reference →](https://geoalgeria.com/data/docs/djezzy) · [Browse all packages →](https://geoalgeria.com/data)

--- a/packages/ecoles/README.md
+++ b/packages/ecoles/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/ecoles
 
-**The schools of Algeria — as data you can install.**
+**The schools of Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/ecoles)](https://www.npmjs.com/package/@geoalgeria/ecoles)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/ecoles)](https://www.npmjs.com/package/@geoalgeria/ecoles)
@@ -12,7 +12,7 @@
 
 </div>
 
-**11,830 geocoded schools** across all **69 wilayas** of Algeria — every one with
+**11,830 geocoded schools** across all **69 wilayas** of Algeria, every one with
 coordinates, classified by **cycle** (primaire · moyen/CEM · secondaire/lycée ·
 préscolaire), most with Arabic and/or French names, and commune/wilaya linkage.
 Extracted from **OpenStreetMap** and framed honestly against the ~28,000
@@ -37,11 +37,11 @@ const named = all.filter((e) => e.name_fr);
 
 ## What you can build
 
-- **School maps & locators** — coordinates on all 11,830 records, ready for a map
+- **School maps & locators** – coordinates on all 11,830 records, ready for a map
   or nearest-school distance sorting.
-- **Cycle breakdowns** — filter primaire / moyen / secondaire / préscolaire, or
+- **Cycle breakdowns** – filter primaire / moyen / secondaire / préscolaire, or
   rank school density per commune/wilaya across the country.
-- **Bilingual directories** — thousands of Arabic and French names, side by side.
+- **Bilingual directories** – thousands of Arabic and French names, side by side.
 
 ## What's inside
 
@@ -60,18 +60,18 @@ const named = all.filter((e) => e.name_fr);
 | `autre` | 3,591 | school of undetermined cycle (unnamed, or a name with no cycle word) |
 
 > **This is an OpenStreetMap extract, not an official registry.** Coverage is
-> partial and uneven by wilaya — ~11.8k schools mapped against the ~28,000 in the
+> partial and uneven by wilaya, ~11.8k schools mapped against the ~28,000 in the
 > national network (primaire + moyen + secondaire, Ministry of National
 > Education, approximate). Counts move as OpenStreetMap is edited; each rebuild
 > reflects the current state of the map.
 
-**Cycle is inferred.** It comes from `isced:level` and the French/Arabic name — a
+**Cycle is inferred.** It comes from `isced:level` and the French/Arabic name, a
 CEM always names itself متوسطة/collège, a lycée ثانوية/lycée, a maternelle
 روضة/préscolaire. A bare "école"/"مدرسة" with no cycle word is classified
 `primaire` by Algerian convention (a standalone school is a primary school);
 anything unresolved is `autre`. 93% of *named* schools resolve to a specific cycle.
 
-**By kind** — `kind` is the establishment type, *orthogonal* to cycle, so you can
+**By kind** – `kind` is the establishment type, *orthogonal* to cycle, so you can
 filter out (or in) the special-purpose places OSM files under `amenity=school`:
 
 | Kind | Count | Meaning | Cycle |
@@ -84,12 +84,12 @@ filter out (or in) the special-purpose places OSM files under `amenity=school`:
 | `conduite` | 5 | driving school (auto-école) | `autre` |
 
 The four non-K-12 kinds (`formation`/`coranique`/`langues`/`conduite`) carry
-cycle `autre` — they're *not* primary schools even though their name contains
+cycle `autre`, they're *not* primary schools even though their name contains
 "école"; `kind` is what makes them findable instead of buried in `autre`.
 
 **Also on each record:** `isced_levels` (the OSM `isced:level` served, normalized
-to a sorted list like `"1;2"` — on 2,037 records), `address` (from OSM `addr:*`
-tags — on 2,625), and `sector` (`public`/`private` where the map signals it).
+to a sorted list like `"1;2"`, on 2,037 records), `address` (from OSM `addr:*`
+tags, on 2,625), and `sector` (`public`/`private` where the map signals it).
 
 ## Formats
 
@@ -101,7 +101,7 @@ import ecoles from "@geoalgeria/ecoles/data/ecoles.json" with { type: "json" };
 // https://cdn.jsdelivr.net/npm/@geoalgeria/ecoles/data/ecoles.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import ecoles, { type Ecole } from "@geoalgeria/ecoles";
@@ -157,7 +157,7 @@ education level and `kind` the establishment type (see above), each with
 bilingual labels. `isced_levels` and `address` come straight from OSM (`null`
 when the tags are absent). `sector` is `"public"`/`"private"` only when the map
 carries an explicit signal, else `null`. `geo_precision` is `"exact"` for a
-surveyed OSM node or `"approximate"` for a building/area centroid — `geo_method`
+surveyed OSM node or `"approximate"` for a building/area centroid, `geo_method`
 records which (`osm_node`/`osm_centroid`). `wilaya_code` joins to GeoAlgeria's
 `wilaya_code`.
 
@@ -171,7 +171,7 @@ records which (`osm_node`/`osm_centroid`). `wilaya_code` joins to GeoAlgeria's
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a school's `commune_code` into a polygon or centroid. Use
 `@geoalgeria/ecoles` when you *only* need the schools.
 
@@ -190,7 +190,7 @@ Raw source pulls are cached under
 
 ## License & attribution
 
-Package **code** is [MIT](LICENSE). The **data** is from **OpenStreetMap** —
+Package **code** is [MIT](LICENSE). The **data** is from **OpenStreetMap**:
 **© OpenStreetMap contributors**, licensed under the
 **[ODbL 1.0](https://www.openstreetmap.org/copyright)**. If you use or
 redistribute this dataset, you must **attribute OpenStreetMap contributors** and

--- a/packages/emploi/README.md
+++ b/packages/emploi/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/emploi
 
-**Every public employment agency in Algeria — as data you can install.**
+**Every public employment agency in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/emploi)](https://www.npmjs.com/package/@geoalgeria/emploi)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/emploi)](https://www.npmjs.com/package/@geoalgeria/emploi)
@@ -13,7 +13,7 @@
 </div>
 
 The **58 AWEM** (wilaya employment agencies) and **273 ALEM** (local employment
-agencies) of Algeria's national employment agency, **ANEM** — each with address,
+agencies) of Algeria's national employment agency, **ANEM**, each with address,
 phone, fax, email, manager, and GPS coordinates. Shipped
 as JSON, CSV, and GeoJSON. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
 
@@ -37,9 +37,9 @@ const reggane = alem.filter((a) => a.name.includes("REGGANE"));
 
 ## What you can build
 
-- **Agency locators** — coordinates on (almost) every record, ready for distance sorting or a map.
-- **Contact directories** — phone, fax, email, and manager per agency.
-- **Maps** — drop-in GeoJSON point layers for the whole employment network.
+- **Agency locators** – coordinates on (almost) every record, ready for distance sorting or a map.
+- **Contact directories** – phone, fax, email, and manager per agency.
+- **Maps** – drop-in GeoJSON point layers for the whole employment network.
 
 ## What's inside
 
@@ -58,7 +58,7 @@ import alem from "@geoalgeria/emploi/data/alem.json" with { type: "json" };
 // https://cdn.jsdelivr.net/npm/@geoalgeria/emploi/data/alem.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import emploi, { type Awem, type Alem } from "@geoalgeria/emploi";
@@ -79,7 +79,7 @@ data/
   geojson/alem.geojson
 ```
 
-> GeoJSON includes only records that have coordinates — 2 ALEM report no
+> GeoJSON includes only records that have coordinates, 2 ALEM report no
 > `lat`/`lng` and are omitted there (but remain in JSON/CSV).
 
 ## Record shapes
@@ -110,12 +110,12 @@ data/
 
 `id` is a stable `{wilaya_code}-{seq}` key synthesized by GeoAlgeria, unique
 across the merged `agencies()` set (AWEM ids never contain a dash, ALEM ids
-always do) — ANEM's own `code` is kept too but is missing on some records and
+always do), ANEM's own `code` is kept too but is missing on some records and
 not unique, so prefer `id`. `commune_code`/`commune` are currently `null` on
-every record — ANEM's source resolves to wilaya only, not commune. `wilaya_code`
+every record, ANEM's source resolves to wilaya only, not commune. `wilaya_code`
 joins to GeoAlgeria's `wilaya_code`.
 
-**AWEM (wilaya agency)** — same shape, `id` = the 2-digit `wilaya_code`, keyed by
+**AWEM (wilaya agency)** – same shape, `id` = the 2-digit `wilaya_code`, keyed by
 `name` / `address` / `phone` / `manager` with `lat`/`lng`.
 
 ## Need the administrative divisions too?
@@ -127,7 +127,7 @@ For wilayas, dairas, and communes (and postal data), use the main
 ## Source
 
 Data comes from **ANEM** (National Employment Agency) via its cartographic
-portal (<https://www.anem.dz/#/portail-carto>). There is no public API — the
+portal (<https://www.anem.dz/#/portail-carto>). There is no public API, the
 agencies are embedded in the portal's JavaScript bundle. Run `npm run fetch` to
 regenerate every output: it rediscovers the current bundle, extracts both
 datasets, fixes the source's `X`=lat / `Y`=lng inversion, and normalizes wilaya
@@ -141,7 +141,7 @@ reference and to power [GeoAlgeria](https://geoalgeria.com). Verify against ANEM
 for authoritative, real-time information.
 
 The `manager` field is the agency head's name as published, verbatim, on ANEM's
-own public portal — it is not private data. Each rebuild reflects whatever ANEM
+own public portal, it is not private data. Each rebuild reflects whatever ANEM
 currently shows; if they remove it, it drops out here too.
 
 [API docs & field reference →](https://geoalgeria.com/data/docs/emploi) · [Browse all packages →](https://geoalgeria.com/data)

--- a/packages/enseignement-superieur/README.md
+++ b/packages/enseignement-superieur/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/enseignement-superieur
 
-**Every higher-education institution in Algeria — as data you can install.**
+**Every higher-education institution in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/enseignement-superieur)](https://www.npmjs.com/package/@geoalgeria/enseignement-superieur)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/enseignement-superieur)](https://www.npmjs.com/package/@geoalgeria/enseignement-superieur)
@@ -12,9 +12,9 @@
 
 </div>
 
-177 higher-education institutions across Algeria — **universities**, grandes écoles, écoles
+177 higher-education institutions across Algeria, **universities**, grandes écoles, écoles
 normales supérieures, centres universitaires, the **licensed private institutions**, and the
-establishments **under other ministries** (Défense, Santé, Culture…) that MESRS supervises —
+establishments **under other ministries** (Défense, Santé, Culture…) that MESRS supervises,
 each with its name (French and/or Arabic), institution **type**, **sector**, supervising
 ministry, its own **website**, wilaya / commune linkage and coordinates. Sourced from the
 **Ministry of Higher Education and Scientific Research (MESRS)**, shipped as
@@ -32,15 +32,15 @@ const inAlgiers = es.institutionsByWilaya(16);   // institutions in wilaya 16
 const universities = es.institutionsByType("universite"); // every university
 const privates = es.institutionsBySector("private");      // the 19 private institutions
 
-// Everything has lat/lng — distance-sort, map, or nearest-campus in a few lines.
+// Everything has lat/lng – distance-sort, map, or nearest-campus in a few lines.
 ```
 
 ## What you can build
 
-- **"Nearest university" lookups** — coordinates on every record, ready for distance sorting.
-- **Student & civic apps** — map the higher-education network per wilaya, split public vs private, link straight to each institution's site.
-- **Maps** — drop-in GeoJSON point layer for the whole higher-education network.
-- **Research & planning** — institution counts by type, sector, supervising ministry and wilaya across the country.
+- **"Nearest university" lookups** – coordinates on every record, ready for distance sorting.
+- **Student & civic apps** – map the higher-education network per wilaya, split public vs private, link straight to each institution's site.
+- **Maps** – drop-in GeoJSON point layer for the whole higher-education network.
+- **Research & planning** – institution counts by type, sector, supervising ministry and wilaya across the country.
 
 ## What's inside
 
@@ -53,7 +53,7 @@ const privates = es.institutionsBySector("private");      // the 19 private inst
 | **Total** | | **177** |
 
 By **sector**: 158 public · 19 licensed private. Of the public institutions, 48 are
-establishments **under other ministries** that MESRS supervises pedagogically — read
+establishments **under other ministries** that MESRS supervises pedagogically, read
 `supervisory_ministry` (e.g. `"Ministère de la Santé"` for the 25 paramedical institutes,
 `"Ministère de la Défense nationale"` for the 16 military schools), which is `null` for the
 MESRS network itself.
@@ -61,12 +61,12 @@ MESRS network itself.
 Spanning **51 wilayas**. `wilaya_code` is linked against the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) wilaya model (69-wilaya scheme).
 
-## Names and coordinates — provenance
+## Names and coordinates: provenance
 
 The **identity** of every record is 100% MESRS. The public network's `name` (French) and
 `website` come from the ministry's listing; the private and other-ministry institutions are
 published in Arabic only, so they carry `name_ar` with `name: null`. `name_ar` is also
-**backfilled** for the public network (joined on website) — present on ~93% of all records.
+**backfilled** for the public network (joined on website), present on ~93% of all records.
 
 The ministry's page carries **no coordinates and no address**, so the **geography is supplied
 here** and labelled honestly on every record via `geo_method` (detail) and `geo_precision`
@@ -75,12 +75,12 @@ here** and labelled honestly on every record via `geo_method` (detail) and `geo_
 | `geo_method` | Count | `geo_precision` | What the coordinate is |
 | --- | --- | --- | --- |
 | `campus` | 61 | `exact` | An OpenStreetMap geocode of the named campus, cross-checked: a geocode that lands in a different wilaya than the institution's name is rejected. |
-| `commune` | 16 | `approximate` | The centroid of the institution's commune (city), from the `geoalgeria` flagship — used where OSM can't find the campus by name. |
-| `wilaya` | 100 | `approximate` | The centroid of the institution's wilaya — the fallback when only the wilaya is known. Every private/other-ministry institution lands here, as the source publishes no address for them. |
+| `commune` | 16 | `approximate` | The centroid of the institution's commune (city), from the `geoalgeria` flagship – used where OSM can't find the campus by name. |
+| `wilaya` | 100 | `approximate` | The centroid of the institution's wilaya – the fallback when only the wilaya is known. Every private/other-ministry institution lands here, as the source publishes no address for them. |
 
 `wilaya_code` and `commune` are always reconciled to the `geoalgeria` flagship dataset, so they
 are authoritative and in the 69-wilaya scheme (`commune_code` is currently `null` on every
-record — MESRS gives no commune code). Coordinates are an enrichment layer — accurate to the
+record, MESRS gives no commune code). Coordinates are an enrichment layer, accurate to the
 labelled precision, not a surveyed campus position. Regenerate them with `npm run geocode`
 (OpenStreetMap Nominatim), then `npm run fetch`.
 
@@ -94,7 +94,7 @@ import institutions from "@geoalgeria/enseignement-superieur/data/institutions.j
 // https://cdn.jsdelivr.net/npm/@geoalgeria/enseignement-superieur/data/institutions.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import es, { type Institution } from "@geoalgeria/enseignement-superieur";
@@ -137,31 +137,31 @@ data/
 
 `id` is a stable zero-padded string assigned by GeoAlgeria (the MESRS source publishes none),
 unique within this dataset. `name` is French (the MESRS network) or `null` for the Arabic-only
-private/other-ministry institutions — use `name ?? name_ar` for a display label. For Arabic
+private/other-ministry institutions, use `name ?? name_ar` for a display label. For Arabic
 wilaya and commune names, join `wilaya_code` against the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) dataset. `wilaya_code` is zero-padded
 to two digits; `commune_code` is currently `null` on every record. `geo_precision` is `"exact"`
-for a real campus point or `"approximate"` for a commune/wilaya centroid — `geo_method` records
-which. `source` is a fixed provenance key (`"mesrs"`) into `metadata.sources[]`, not a URL — see
+for a real campus point or `"approximate"` for a commune/wilaya centroid, `geo_method` records
+which. `source` is a fixed provenance key (`"mesrs"`) into `metadata.sources[]`, not a URL, see
 **Source** below for the actual listing pages.
 
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full wilaya
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full wilaya
 division dataset that `wilaya_code` here links to. Use `@geoalgeria/enseignement-superieur` when
 you *only* need higher-education institution data.
 
 ## Source
 
-Institution identity comes from the **MESRS**, via the public university-network page — the
+Institution identity comes from the **MESRS**, via the public university-network page, the
 [English listing](https://www.mesrs.dz/en/university-network/) for the network's French names
 and the [Arabic listing](https://www.mesrs.dz/reseau-universitaire-ar/) for Arabic names and the
 private + other-ministry institutions the English page omits. Run `npm run fetch` to regenerate
 every output from the live listings; it reconciles each record's wilaya/commune to the flagship
 dataset and attaches the coordinate seed (`scripts/seeds/coordinates.json`, refreshed with `npm
 run geocode`). It fails loudly if the institution count collapses. Coordinates are
-OpenStreetMap-derived — see **Names and coordinates** above.
+OpenStreetMap-derived, see **Names and coordinates** above.
 
 ## License & attribution
 

--- a/packages/ferroviaire/README.md
+++ b/packages/ferroviaire/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/ferroviaire
 
-**Algeria's rail & urban transit — every station and stop, as data you can install.**
+**Algeria's rail & urban transit, every station and stop, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/ferroviaire)](https://www.npmjs.com/package/@geoalgeria/ferroviaire)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/ferroviaire)](https://www.npmjs.com/package/@geoalgeria/ferroviaire)
@@ -12,8 +12,8 @@
 
 </div>
 
-692 rail and urban-transit nodes across Algeria — **train stations, tram stops, metro
-stations, aerial tramways and gondolas** — with bilingual FR/AR names, operator
+692 rail and urban-transit nodes across Algeria, **train stations, tram stops, metro
+stations, aerial tramways and gondolas**, with bilingual FR/AR names, operator
 (SNTF / SETRAM / SEMA), line membership, GPS coordinates, and wilaya/commune linkage.
 A Wikidata + OpenStreetMap composite, shipped as JSON, CSV, and GeoJSON. Part of
 [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -35,10 +35,10 @@ const inAlger = ferroviaire.stationsByWilaya(16);  // rail + metro + tram in Alg
 
 ## What you can build
 
-- **Multimodal maps** — one GeoJSON layer with train, tram, metro, and cable-transit nodes.
-- **Nearest-station lookups** — coordinates on every record.
-- **Network views** — filter by `type`, `operator`, or `network` (tram cities, Métro d'Alger).
-- **Bilingual UIs** — French and Arabic names on most records.
+- **Multimodal maps** – one GeoJSON layer with train, tram, metro, and cable-transit nodes.
+- **Nearest-station lookups** – coordinates on every record.
+- **Network views** – filter by `type`, `operator`, or `network` (tram cities, Métro d'Alger).
+- **Bilingual UIs** – French and Arabic names on most records.
 
 ## What's inside
 
@@ -46,9 +46,9 @@ const inAlger = ferroviaire.stationsByWilaya(16);  // rail + metro + tram in Alg
 | --- | --- | --- |
 | Rail (train) | **427** | SNTF |
 | Tram | **190** | SETRAM (7 city networks) |
-| Metro | **41** | SEMA — Métro d'Alger |
-| Aerial tramway | **24** | — |
-| Gondola | **10** | — |
+| Metro | **41** | SEMA – Métro d'Alger |
+| Aerial tramway | **24** | – |
+| Gondola | **10** | – |
 
 Spanning **50 wilayas**, every node geocoded. `wilaya_code` is linked against the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) 69-wilaya model.
@@ -112,7 +112,7 @@ data/
 is `wikidata`, `osm`, or `wikidata+osm` (matched within ~150 m). `name` may be `null`
 for a few OSM-only stops (23 records). `wilaya_code`/`commune` come from a
 nearest-centroid join against `geoalgeria`. `id` is an opaque string, unique within
-`stations.json` — don't parse it. `geo_precision` is `exact` or `approximate` (all 692
+`stations.json`, don't parse it. `geo_precision` is `exact` or `approximate` (all 692
 records are geocoded, so `null` doesn't occur here); `geo_method` records how the
 coordinate was sourced (e.g. `osm_node`, `wikidata`). External ids live under `refs`.
 
@@ -120,7 +120,7 @@ coordinate was sourced (e.g. `osm_node`, `wikidata`). External ids live under `r
 
 A composite of **Wikidata** (CC0) and **OpenStreetMap** (© OpenStreetMap contributors,
 ODbL 1.0), with operators from **SNTF**, **SETRAM**, and **SEMA/EMA**. Code is
-[MIT](LICENSE); OSM-derived data remains under ODbL — keep attribution. Run
+[MIT](LICENSE); OSM-derived data remains under ODbL, keep attribution. Run
 `npm run fetch` to regenerate. For authoritative, real-time information, verify with the
 operators.
 

--- a/packages/formation-professionnelle/README.md
+++ b/packages/formation-professionnelle/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/formation-professionnelle
 
-**Every vocational training establishment in Algeria — as data you can install.**
+**Every vocational training establishment in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/formation-professionnelle)](https://www.npmjs.com/package/@geoalgeria/formation-professionnelle)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/formation-professionnelle)](https://www.npmjs.com/package/@geoalgeria/formation-professionnelle)
@@ -12,8 +12,8 @@
 
 </div>
 
-1,932 vocational training establishments across Algeria — **CFPA**, **INSFP**, **IFEP**,
-**IEP**, **DFEP** and private accredited centers — each with its official name (Arabic,
+1,932 vocational training establishments across Algeria, **CFPA**, **INSFP**, **IFEP**,
+**IEP**, **DFEP** and private accredited centers, each with its official name (Arabic,
 with French where available), establishment **type**, **capacity**, **boarding** info, rich
 **contact details** (phone, fax, email, website, Facebook), and GPS coordinates. Sourced
 from the **Ministere de la Formation et de l'Enseignement Professionnels (MFEP)** via
@@ -32,16 +32,16 @@ const byWilaya = fp.establishmentsByWilaya(16);     // establishments in wilaya 
 const cfpas = fp.establishmentsByType("cfpa");      // every CFPA
 const one = fp.establishmentById("00001");          // single record by id
 
-// 1,375 records have lat/lng — distance-sort, map, or nearest center in a few lines.
+// 1,375 records have lat/lng – distance-sort, map, or nearest center in a few lines.
 ```
 
 ## What you can build
 
-- **"Nearest training center" lookups** — 1,375 geocoded records, ready for distance sorting.
-- **Vocational training directories** — bilingual names, type, capacity and full contact info on every record.
-- **Maps** — drop-in GeoJSON point layer for the vocational training network (71% geocoded).
-- **Capacity planning** — theoretical and realized capacities, boarding availability and surface area.
-- **Sector analysis** — 1,209 public vs 723 private establishments across 58 wilayas.
+- **"Nearest training center" lookups** – 1,375 geocoded records, ready for distance sorting.
+- **Vocational training directories** – bilingual names, type, capacity and full contact info on every record.
+- **Maps** – drop-in GeoJSON point layer for the vocational training network (71% geocoded).
+- **Capacity planning** – theoretical and realized capacities, boarding availability and surface area.
+- **Sector analysis** – 1,209 public vs 723 private establishments across 58 wilayas.
 
 ## What's inside
 
@@ -60,7 +60,7 @@ const one = fp.establishmentById("00001");          // single record by id
 | **Total** | | **1,932** |
 
 Spanning **58 wilayas** (pre-reform scheme). 1,375 of 1,932 establishments are geocoded
-(71%) — `lat`/`lng` is `null` for the remaining 557. `wilaya_code` uses the 58-wilaya
+(71%), `lat`/`lng` is `null` for the remaining 557. `wilaya_code` uses the 58-wilaya
 scheme as published by the source.
 
 ## Formats
@@ -73,7 +73,7 @@ import establishments from "@geoalgeria/formation-professionnelle/data/establish
 // https://cdn.jsdelivr.net/npm/@geoalgeria/formation-professionnelle/data/establishments.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import fp, { type Establishment } from "@geoalgeria/formation-professionnelle";
@@ -128,7 +128,7 @@ data/
 ```
 
 `id` is an opaque, zero-padded sequence string (e.g. `"00001"`), unique within
-`establishments.json` — don't parse it. Names are bilingual — `name` is Arabic (always present),
+`establishments.json`, don't parse it. Names are bilingual, `name` is Arabic (always present),
 `name_fr` is French (may be `null`). `type` is a slug matching one of the ten establishment
 types listed above. `secteur` is `"public"` or `"prive"`. `wilaya_code` is zero-padded to two
 digits in the 58-wilaya scheme; `commune_code` is currently always `null` for this source (no
@@ -142,13 +142,13 @@ specialization strings when available.
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 69-wilaya division dataset. Use `@geoalgeria/formation-professionnelle` when you *only*
 need vocational training data.
 
 ## Source
 
-Data comes from the **MFEP — Ministere de la Formation et de l'Enseignement Professionnels**,
+Data comes from the **MFEP – Ministere de la Formation et de l'Enseignement Professionnels**,
 via [takwin.dz](https://takwin.dz). The source uses the pre-reform **58-wilaya scheme**.
 Run `npm run fetch` to regenerate every output from the live site. Names, types, contacts,
 capacities and coordinates are as published by the ministry.

--- a/packages/gares-routieres/README.md
+++ b/packages/gares-routieres/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/gares-routieres
 
-**Every intercity bus station in Algeria — as data you can install.**
+**Every intercity bus station in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/gares-routieres)](https://www.npmjs.com/package/@geoalgeria/gares-routieres)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/gares-routieres)](https://www.npmjs.com/package/@geoalgeria/gares-routieres)
@@ -12,7 +12,7 @@
 
 </div>
 
-74 intercity bus stations (**gares routières**) across Algeria — with official names,
+74 intercity bus stations (**gares routières**) across Algeria, with official names,
 postal addresses, GPS coordinates, surface areas, and wilaya/commune linkage. Sourced
 from **SOGRAL** (the state operator of Algeria's coach stations), shipped as JSON, CSV,
 and GeoJSON. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -28,18 +28,18 @@ npm install @geoalgeria/gares-routieres
 import gares from "@geoalgeria/gares-routieres";
 
 const all = gares.stations();                 // 74
-const alger = gares.stationById("16-01");      // Alger — Grands Invalides
+const alger = gares.stationById("16-01");      // Alger – Grands Invalides
 const inSetif = gares.stationsByWilaya(19);    // stations in wilaya 19
 
-// Every station has lat/lng — distance-sort, map, or nearest-station in a few lines.
+// Every station has lat/lng – distance-sort, map, or nearest-station in a few lines.
 ```
 
 ## What you can build
 
-- **Nearest-station lookups** — coordinates on every record, ready for distance sorting.
-- **Travel & logistics** — match a wilaya or a point to its serving coach station.
-- **Maps** — drop-in GeoJSON point layer for the national gare-routière network.
-- **Capacity views** — total/built surface areas per station.
+- **Nearest-station lookups** – coordinates on every record, ready for distance sorting.
+- **Travel & logistics** – match a wilaya or a point to its serving coach station.
+- **Maps** – drop-in GeoJSON point layer for the national gare-routière network.
+- **Capacity views** – total/built surface areas per station.
 
 ## What's inside
 
@@ -102,7 +102,7 @@ data/
 }
 ```
 
-`id` is an opaque string, `{wilaya_code}-{seq}`-shaped but unique within `stations.json` —
+`id` is an opaque string, `{wilaya_code}-{seq}`-shaped but unique within `stations.json`,
 don't parse it. `wilaya_code`/`commune` come from a nearest-centroid join against
 `geoalgeria` (which also reconciles SOGRAL's legacy 48-wilaya codes). 71 of 74 stations
 are `geo_precision: "exact"`; 3 are `"approximate"` (Guelma, Illizi, Aïn Oussara). The
@@ -111,12 +111,12 @@ SOGRAL location code lives under `refs.sogral`.
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 69-wilaya division dataset that `wilaya_code` here links to.
 
 ## Source
 
-Data comes from **SOGRAL — EPE SOGRAL Spa** (Société de Gestion des Gares Routières
+Data comes from **SOGRAL – EPE SOGRAL Spa** (Société de Gestion des Gares Routières
 d'Algérie), via its live departures registry (<https://live.sogral.com>). Run
 `npm run fetch` to regenerate every output. `wilaya_code`/`commune` are resolved by
 nearest commune centroid from the `geoalgeria` dataset.

--- a/packages/industrie-pharmaceutique/README.md
+++ b/packages/industrie-pharmaceutique/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/industrie-pharmaceutique
 
-**Algeria's approved pharmaceutical manufacturers — as data you can install.**
+**Algeria's approved pharmaceutical manufacturers, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/industrie-pharmaceutique)](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/industrie-pharmaceutique)](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique)
@@ -14,7 +14,7 @@
 
 # Overview
 
-171 approved pharmaceutical **manufacturers** from the **Ministry of Pharmaceutical Industry (MIP)** fabrication register (`agrément de fabrication`, updated 28/06/2026) — medicine makers (PP), medical-device makers (DM) and mixed producers — bilingual (FR/AR), typed by nature, with wilaya/commune linkage and coordinates.
+171 approved pharmaceutical **manufacturers** from the **Ministry of Pharmaceutical Industry (MIP)** fabrication register (`agrément de fabrication`, updated 28/06/2026), medicine makers (PP), medical-device makers (DM) and mixed producers, bilingual (FR/AR), typed by nature, with wilaya/commune linkage and coordinates.
 
 ## Installation
 
@@ -62,11 +62,11 @@ metadata().wilayas_covered; // 25
 
 | Nature | Count | Meaning |
 | --- | --- | --- |
-| `pp` | 120 | Produits Pharmaceutiques — medicine manufacturers |
-| `dm` | 48 | Dispositifs Médicaux — medical-device manufacturers |
+| `pp` | 120 | Produits Pharmaceutiques – medicine manufacturers |
+| `dm` | 48 | Dispositifs Médicaux – medical-device manufacturers |
 | `mixte` | 3 | Both (PP + DM) |
 
-**By geocoding method** (`geo_method`) — all 171 records carry `geo_precision: "approximate"`
+**By geocoding method** (`geo_method`), all 171 records carry `geo_precision: "approximate"`
 (the register has no real coordinates; every point is a centroid, never exact):
 
 | Value | Count | Meaning |
@@ -76,10 +76,10 @@ metadata().wilayas_covered; // 25
 
 ## Formats
 
-- `data/industrie-pharmaceutique.json` — full array (typed by `types/index.d.ts`)
-- `data/csv/industrie-pharmaceutique.csv` — flat CSV
-- `data/geojson/industrie-pharmaceutique.geojson` — `FeatureCollection` (all records)
-- `data/metadata.json` — counts, sources, generated date
+- `data/industrie-pharmaceutique.json` – full array (typed by `types/index.d.ts`)
+- `data/csv/industrie-pharmaceutique.csv` – flat CSV
+- `data/geojson/industrie-pharmaceutique.geojson` – `FeatureCollection` (all records)
+- `data/metadata.json` – counts, sources, generated date
 
 ```js
 import data from "@geoalgeria/industrie-pharmaceutique/data/industrie-pharmaceutique.json" with { type: "json" };
@@ -91,17 +91,17 @@ import type { PharmaManufacturer } from "@geoalgeria/industrie-pharmaceutique";
 
 ## How the data is built
 
-The operator names and PP/DM nature come from the current MIP fabrication register (`miph.gov.dz`), which carries **no coordinates**. Each maker's wilaya/commune is resolved from the MIP register's earlier (2023) edition — which did carry a wilaya column — a place token in the operator name, or a per-company research pass (company websites, the CACI/El Mouchir directory, press) for makers absent from the 2023 edition. Locations are then placed at the commune (or wilaya) centroid. See `research/_pharma-landscape/` in the monorepo for the full pipeline (`build.py`).
+The operator names and PP/DM nature come from the current MIP fabrication register (`miph.gov.dz`), which carries **no coordinates**. Each maker's wilaya/commune is resolved from the MIP register's earlier (2023) edition, which did carry a wilaya column, a place token in the operator name, or a per-company research pass (company websites, the CACI/El Mouchir directory, press) for makers absent from the 2023 edition. Locations are then placed at the commune (or wilaya) centroid. See `research/_pharma-landscape/` in the monorepo for the full pipeline (`build.py`).
 
 ## On accuracy
 
-> Operator names and the PP/DM nature are **official** (the MIP register). The register carries **no coordinates**: each record is placed at the centroid of its resolved commune, or — when only the wilaya is known — at the wilaya centroid (see `geo_method`; `geo_precision` is `"approximate"` for every record). These are approximate locations for the *wilaya/commune*, not surveyed factory points.
+> Operator names and the PP/DM nature are **official** (the MIP register). The register carries **no coordinates**: each record is placed at the centroid of its resolved commune, or, when only the wilaya is known, at the wilaya centroid (see `geo_method`; `geo_precision` is `"approximate"` for every record). These are approximate locations for the *wilaya/commune*, not surveyed factory points.
 >
-> **Coverage:** 171 of the ~186 approved manufacturing establishments are geocoded here. The rest are contract manufacturers listed as *sous-traitance* (no own site) or a few very small device makers with no locatable address — omitted rather than placed speculatively. **Importers, wholesalers, exploitation and promotion** are separate MIP registers, not part of this manufacturers layer.
+> **Coverage:** 171 of the ~186 approved manufacturing establishments are geocoded here. The rest are contract manufacturers listed as *sous-traitance* (no own site) or a few very small device makers with no locatable address, omitted rather than placed speculatively. **Importers, wholesalers, exploitation and promotion** are separate MIP registers, not part of this manufacturers layer.
 
 ## Source & license
 
-Data from the **Ministry of Pharmaceutical Industry (MIP)** fabrication register — a factual public-sector listing, redistributed for reference. Wilaya/commune linkage uses the geoalgeria base dataset. Package code under MIT (see [LICENSE](LICENSE)).
+Data from the **Ministry of Pharmaceutical Industry (MIP)** fabrication register, a factual public-sector listing, redistributed for reference. Wilaya/commune linkage uses the geoalgeria base dataset. Package code under MIT (see [LICENSE](LICENSE)).
 
 ## Questions?
 

--- a/packages/jeunesse/README.md
+++ b/packages/jeunesse/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/jeunesse
 
-**Every youth establishment in Algeria — as data you can install.**
+**Every youth establishment in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/jeunesse)](https://www.npmjs.com/package/@geoalgeria/jeunesse)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/jeunesse)](https://www.npmjs.com/package/@geoalgeria/jeunesse)
@@ -12,11 +12,11 @@
 
 </div>
 
-2,334 youth establishments across Algeria — **maisons de jeunes**, complexes sportifs de
+2,334 youth establishments across Algeria, **maisons de jeunes**, complexes sportifs de
 proximité, salles polyvalentes, auberges de jeunes, science & cultural centers, youth camps
-and more — each with its name, **type**, address, capacity, operational status, PMR
+and more, each with its name, **type**, address, capacity, operational status, PMR
 accessibility, built/land area, commune / daïra / wilaya, and GPS coordinates. Sourced from
-the **Ministry of Youth and Sports GIS (sig.mjs.gov.dz)** — the same official
+the **Ministry of Youth and Sports GIS (sig.mjs.gov.dz)**, the same official
 system behind [`@geoalgeria/sports`](https://www.npmjs.com/package/@geoalgeria/sports).
 Shipped as JSON, CSV, and GeoJSON. Part of
 [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -32,15 +32,15 @@ const all = jeunesse.institutions();                 // 2,334
 const inAlgiers = jeunesse.institutionsByWilaya(16);  // establishments in wilaya 16
 const houses = jeunesse.institutionsByType("MJ");     // every maison de jeunes
 
-// Everything has lat/lng — distance-sort, map, or nearest-establishment in a few lines.
+// Everything has lat/lng – distance-sort, map, or nearest-establishment in a few lines.
 ```
 
 ## What you can build
 
-- **"Nearest youth center" lookups** — coordinates on every record, ready for distance sorting.
-- **Civic & youth apps** — map maisons de jeunes, sports complexes and cultural centers per wilaya, filtered by capacity or operational status.
-- **Maps** — drop-in GeoJSON point layer for the whole youth-establishment network.
-- **Research & planning** — establishment density by type and wilaya, capacity analysis, PMR-accessibility and operational-status audits.
+- **"Nearest youth center" lookups** – coordinates on every record, ready for distance sorting.
+- **Civic & youth apps** – map maisons de jeunes, sports complexes and cultural centers per wilaya, filtered by capacity or operational status.
+- **Maps** – drop-in GeoJSON point layer for the whole youth-establishment network.
+- **Research & planning** – establishment density by type and wilaya, capacity analysis, PMR-accessibility and operational-status audits.
 
 ## What's inside
 
@@ -70,7 +70,7 @@ import institutions from "@geoalgeria/jeunesse/data/institutions.json" with { ty
 // https://cdn.jsdelivr.net/npm/@geoalgeria/jeunesse/data/institutions.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import jeunesse, { type Institution } from "@geoalgeria/jeunesse";
@@ -117,10 +117,10 @@ data/
 }
 ```
 
-`id` is an opaque, zero-padded sequence string, unique within `institutions.json` — don't
+`id` is an opaque, zero-padded sequence string, unique within `institutions.json`, don't
 parse it. The GIS publishes names in **French**; `name_ar` is the Arabic name **backfilled**
 from the ministry's legacy public map by nearest-neighbour geo-match (≤ 200 m, and
-type-checked so a different kind of facility's name is never grafted on) — present on ~59% of
+type-checked so a different kind of facility's name is never grafted on), present on ~59% of
 records, `null` where no confident match exists (as above). `name` is `null` for the ~5% the
 source leaves blank; `commune` and `daira` are French (uppercase, as published); `commune_code`
 is currently always `null` (the MJS GIS gives a commune name only). For the full French
@@ -142,7 +142,7 @@ infrastructure.
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 wilaya division dataset that `wilaya_code` here links to.
 
 ## Source

--- a/packages/livraison/README.md
+++ b/packages/livraison/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/livraison
 
-**Algeria's delivery carriers and their stop-desks — as data you can install.**
+**Algeria's delivery carriers and their stop-desks, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/livraison)](https://www.npmjs.com/package/@geoalgeria/livraison)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/livraison)](https://www.npmjs.com/package/@geoalgeria/livraison)
@@ -30,23 +30,23 @@ const inAlgiers = livraison.stopdesksByWilaya(16);    // stop-desks in wilaya 16
 const guepexDesks = livraison.stopdesksByCarrier("guepex");
 const reach = livraison.coverageByCarrier("yalidine"); // wilayas it serves
 
-// Every stop-desk has lat/lng — nearest-desk, map, or distance-sort in a few lines.
+// Every stop-desk has lat/lng – nearest-desk, map, or distance-sort in a few lines.
 ```
 
 ## What you can build
 
-- **Nearest stop-desk** — coordinates on every stop-desk, ready for distance sorting.
-- **Checkout drop-off pickers** — list a carrier's desks in the buyer's wilaya.
-- **Carrier comparison** — registry of who operates, their model (stop-desk vs home), and COD support.
-- **Maps** — drop-in GeoJSON point layer for the whole open stop-desk network.
+- **Nearest stop-desk** – coordinates on every stop-desk, ready for distance sorting.
+- **Checkout drop-off pickers** – list a carrier's desks in the buyer's wilaya.
+- **Carrier comparison** – registry of who operates, their model (stop-desk vs home), and COD support.
+- **Maps** – drop-in GeoJSON point layer for the whole open stop-desk network.
 
 ## What's inside
 
 | Dataset | Count | Geocoded | Notes |
 | --- | --- | --- | --- |
-| Carriers (`carriers.json`) | **16** | — | registry: name, website, model, COD, scope, data openness, API |
+| Carriers (`carriers.json`) | **16** | – | registry: name, website, model, COD, scope, data openness, API |
 | Stop-desks (`stopdesks.json`) | **411** | ✅ all | id, operator, name, address, commune, `wilaya_code`, lat/lng |
-| Coverage (`coverage.json`) | **9** | — | per-carrier wilaya/commune stop-desk presence |
+| Coverage (`coverage.json`) | **9** | – | per-carrier wilaya/commune stop-desk presence |
 
 Stop-desks span **61 wilayas**, every one geocoded. `wilaya_code` links against the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) 69-wilaya model.
@@ -57,7 +57,7 @@ Algeria has 90+ delivery companies, but only a few publish their agency location
 openly. The **registry** covers the field (the major carriers and what each is); the
 **geocoded layer** covers the carriers that publish locations openly:
 
-- the **Yalidine + Guepex relay ecosystem** — Yalidine, Guepex, and the operators that
+- the **Yalidine + Guepex relay ecosystem** – Yalidine, Guepex, and the operators that
   ride their shared network (EasyAndSpeed, WeCanServices, SpeedMail, Zimou Express);
 - **Anderson**, **Noest** and **Maystro**, three independent networks, each geocoded from
   the Google Maps link on its agency cards (agencies whose links are missing, unresolvable,
@@ -78,7 +78,7 @@ import carriers from "@geoalgeria/livraison/data/carriers.json" with { type: "js
 // https://cdn.jsdelivr.net/npm/@geoalgeria/livraison/data/stopdesks.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import livraison, { type StopDesk } from "@geoalgeria/livraison";
@@ -140,15 +140,15 @@ data/
 }
 ```
 
-`operator` on a stop-desk joins `carriers[].id`. `commune_code` is always `null` — carrier
+`operator` on a stop-desk joins `carriers[].id`. `commune_code` is always `null`, carrier
 relay feeds publish a commune name only, never an ONS code. `wilaya_code` joins GeoAlgeria's
-wilayas. `sources` lists which open feeds carry the desk — `["yalidine","guepex"]` when
+wilayas. `sources` lists which open feeds carry the desk, `["yalidine","guepex"]` when
 the relay maps agree, or `["anderson"]` for an Anderson agency.
 
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 69-wilaya division dataset that `wilaya_code` here links to. Use `@geoalgeria/livraison`
 when you *only* need delivery data.
 

--- a/packages/mobilis/README.md
+++ b/packages/mobilis/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/mobilis
 
-**The Mobilis sales network in Algeria — as data you can install.**
+**The Mobilis sales network in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/mobilis)](https://www.npmjs.com/package/@geoalgeria/mobilis)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/mobilis)](https://www.npmjs.com/package/@geoalgeria/mobilis)
@@ -39,11 +39,11 @@ const inBabEzzouar = pdv.filter((p) => p.commune === "BAB EZZOUAR");
 
 ## What you can build
 
-- **Agency locators** — coordinates on every one of the 165 agencies, ready for
+- **Agency locators** – coordinates on every one of the 165 agencies, ready for
   distance sorting or a map.
-- **Coverage by commune** — the points of sale are tagged with their commune, so
+- **Coverage by commune** – the points of sale are tagged with their commune, so
   you can count or rank Mobilis presence per commune/wilaya.
-- **Bilingual directories** — agency name and address in both French and Arabic.
+- **Bilingual directories** – agency name and address in both French and Arabic.
 
 ## What's inside
 
@@ -52,7 +52,7 @@ const inBabEzzouar = pdv.filter((p) => p.commune === "BAB EZZOUAR");
 | Agencies (*Agence Mobilis*) | **165** | ✅ all 165 | bilingual FR/AR, 56/58 wilayas |
 | Approved points of sale | **12,180** | ❌ none | FR name + address + commune |
 
-> The points of sale are a **commune-level directory** — the source carries no
+> The points of sale are a **commune-level directory**, the source carries no
 > coordinates for them. To map them, aggregate to commune centroids (join
 > `commune` to the [`geoalgeria`](https://www.npmjs.com/package/geoalgeria)
 > communes) or geocode the addresses yourself.
@@ -67,7 +67,7 @@ import agences from "@geoalgeria/mobilis/data/agences.json" with { type: "json" 
 // https://cdn.jsdelivr.net/npm/@geoalgeria/mobilis/data/agences.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import mobilis, { type Agence, type Pdv } from "@geoalgeria/mobilis";
@@ -133,20 +133,20 @@ it stays unique across the merged `all()` collection. Mobilis' own id is kept as
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a point of sale's `commune` into a polygon or centroid. Use
 `@geoalgeria/mobilis` when you *only* need the Mobilis network.
 
 ## Source
 
 Data comes from the **Mobilis** store locator
-(<https://mobilis.dz/mapagence>). There is no documented API — the locator calls
+(<https://mobilis.dz/mapagence>). There is no documented API, the locator calls
 a handful of JSON endpoints behind an `X-Requested-With` header, and the site
 sits behind a WAF. Run `npm run fetch` to regenerate every output: it primes a
 session, walks all 58 wilayas for both categories, parses the `"lat, lng"`
 coordinate strings (handling the comma-decimal rows), and normalizes wilaya
 codes. Mobilis files records under the **58-wilaya scheme**, so new wilayas
-59–69 currently appear under their mother wilaya — same as the Algérie Poste and
+59–69 currently appear under their mother wilaya, same as the Algérie Poste and
 ANEM data.
 
 ## License & attribution
@@ -154,7 +154,7 @@ ANEM data.
 Code is [MIT](LICENSE). The underlying data is © **ATM Mobilis**, redistributed
 for reference and to power [GeoAlgeria](https://geoalgeria.com). Verify against
 Mobilis for authoritative, real-time information. The points-of-sale list churns
-as resellers come and go — each rebuild reflects whatever the locator currently
+as resellers come and go, each rebuild reflects whatever the locator currently
 shows.
 
 [API docs & field reference →](https://geoalgeria.com/data/docs/mobilis) · [Browse all packages →](https://geoalgeria.com/data)

--- a/packages/mosquees/README.md
+++ b/packages/mosquees/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/mosquees
 
-**The mosques of Algeria — as data you can install.**
+**The mosques of Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/mosquees)](https://www.npmjs.com/package/@geoalgeria/mosquees)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/mosquees)](https://www.npmjs.com/package/@geoalgeria/mosquees)
@@ -12,7 +12,7 @@
 
 </div>
 
-**20,759 geocoded mosques** across all **69 wilayas** of Algeria — every one with
+**20,759 geocoded mosques** across all **69 wilayas** of Algeria, every one with
 coordinates, most with Arabic and/or French names, and commune/wilaya linkage.
 A community-maintained **composite of Wikidata and OpenStreetMap**, framed
 honestly against the Ministry of Religious Affairs (MARW) national count of
@@ -37,10 +37,10 @@ const named = all.filter((m) => m.name_fr);
 
 ## What you can build
 
-- **Mosque maps & locators** — coordinates on all 20,759 records, ready for a map
+- **Mosque maps & locators** – coordinates on all 20,759 records, ready for a map
   or distance sorting.
-- **Bilingual directories** — 15k+ Arabic names and 7k+ French names, side by side.
-- **Coverage analysis** — count or rank mosque density per commune/wilaya across
+- **Bilingual directories** – 15k+ Arabic names and 7k+ French names, side by side.
+- **Coverage analysis** – count or rank mosque density per commune/wilaya across
   the whole country.
 
 ## What's inside
@@ -60,7 +60,7 @@ const named = all.filter((m) => m.name_fr);
 > **This is a composite, not an official registry.** Wikidata gives near-complete
 > national coverage (~19k geocoded mosques, close to the MARW figure of ~18,449);
 > OpenStreetMap adds precise coordinates, French names, denomination, and mosques
-> Wikidata lacks. Counts move as both projects are edited — each rebuild reflects
+> Wikidata lacks. Counts move as both projects are edited, each rebuild reflects
 > the current state of the sources.
 
 ## Formats
@@ -73,7 +73,7 @@ import mosquees from "@geoalgeria/mosquees/data/mosquees.json" with { type: "jso
 // https://cdn.jsdelivr.net/npm/@geoalgeria/mosquees/data/mosquees.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import mosquees, { type Mosquee } from "@geoalgeria/mosquees";
@@ -131,7 +131,7 @@ GeoAlgeria's `wilaya_code`.
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a mosque's `commune_code` into a polygon or centroid. Use
 `@geoalgeria/mosquees` when you *only* need the mosques.
 
@@ -140,11 +140,11 @@ you turn a mosque's `commune_code` into a polygon or centroid. Use
 Run `npm run fetch` to regenerate every output. It:
 
 1. queries **Wikidata** (SPARQL) for every item that is an instance of a subclass
-   of *mosque* (Q32815) located in Algeria (P17 = Q262) with a coordinate (P625)
-   — the comprehensive base;
+   of *mosque* (Q32815) located in Algeria (P17 = Q262) with a coordinate (P625),
+   the comprehensive base;
 2. queries **OpenStreetMap** (Overpass) for `amenity=place_of_worship` +
    `religion=muslim` inside Algeria;
-3. **merges** them — an OSM mosque within ~150 m of a Wikidata mosque is folded
+3. **merges** them, an OSM mosque within ~150 m of a Wikidata mosque is folded
    into that record (lending its French name, denomination, and `refs.osm`); OSM
    mosques with no match become their own records;
 4. attaches commune/wilaya by nearest commune centroid.

--- a/packages/ooredoo/README.md
+++ b/packages/ooredoo/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/ooredoo
 
-**Ooredoo Algérie's retail network — as data you can install.**
+**Ooredoo Algérie's retail network, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/ooredoo)](https://www.npmjs.com/package/@geoalgeria/ooredoo)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/ooredoo)](https://www.npmjs.com/package/@geoalgeria/ooredoo)
@@ -14,7 +14,7 @@
 
 # Overview
 
-572 Ooredoo stores across **63 wilayas** — Espaces Ooredoo (EO), City Shops (CSO) and Espaces Services (ESO) — from the operator's own locator API, each with **real coordinates** and wilaya/commune linkage. Completes the telecom retail trio with [`@geoalgeria/mobilis`](https://www.npmjs.com/package/@geoalgeria/mobilis) and [`@geoalgeria/djezzy`](https://www.npmjs.com/package/@geoalgeria/djezzy).
+572 Ooredoo stores across **63 wilayas**, Espaces Ooredoo (EO), City Shops (CSO) and Espaces Services (ESO), from the operator's own locator API, each with **real coordinates** and wilaya/commune linkage. Completes the telecom retail trio with [`@geoalgeria/mobilis`](https://www.npmjs.com/package/@geoalgeria/mobilis) and [`@geoalgeria/djezzy`](https://www.npmjs.com/package/@geoalgeria/djezzy).
 
 ## Installation
 
@@ -68,10 +68,10 @@ metadata().wilayas_covered; // 63
 
 ## Formats
 
-- `data/stores.json` — full array (typed by `types/index.d.ts`)
-- `data/csv/stores.csv` — flat CSV
-- `data/geojson/stores.geojson` — `FeatureCollection` (all records)
-- `data/metadata.json` — counts, sources, generated date
+- `data/stores.json` – full array (typed by `types/index.d.ts`)
+- `data/csv/stores.csv` – flat CSV
+- `data/geojson/stores.geojson` – `FeatureCollection` (all records)
+- `data/metadata.json` – counts, sources, generated date
 
 ```js
 import data from "@geoalgeria/ooredoo/data/stores.json" with { type: "json" };
@@ -83,11 +83,11 @@ import type { OoredooStore } from "@geoalgeria/ooredoo";
 
 ## How the data is built
 
-Pulled from Ooredoo Algérie's public *Trouvez-nous* locator API (a Liferay Headless "Objects" endpoint behind `ooredoo.dz`), which returns a real `latitude`/`longitude` per store. Because the API files stores under the legacy 48-wilaya scheme, wilaya/commune are re-derived from the coordinates by nearest-centroid join against the geoalgeria commune set (current 69-wilaya scheme) — the operator's own declared wilaya is kept as `operator_wilaya`. Rebuild with `npm run fetch` (or `--cache`). See `research/ooredoo/` in the monorepo.
+Pulled from Ooredoo Algérie's public *Trouvez-nous* locator API (a Liferay Headless "Objects" endpoint behind `ooredoo.dz`), which returns a real `latitude`/`longitude` per store. Because the API files stores under the legacy 48-wilaya scheme, wilaya/commune are re-derived from the coordinates by nearest-centroid join against the geoalgeria commune set (current 69-wilaya scheme), the operator's own declared wilaya is kept as `operator_wilaya`. Rebuild with `npm run fetch` (or `--cache`). See `research/ooredoo/` in the monorepo.
 
 ## On accuracy
 
-> Store names, types and coordinates are **from the operator** (`geo_method: "operator_api"`). Coordinates are `geo_precision: "exact"` for 553 stores and `"approximate"` for 19 whose source coordinate has fewer than 3 decimal places. Wilaya is effectively exact (from the operator point); commune is a nearest-centroid best-effort. A **few** operator points carry inaccurate coordinates in the source, so their derived wilaya/commune can be wrong — the `operator_wilaya` field preserves Ooredoo's own declared wilaya in those cases. This is Ooredoo's own store directory as exposed by its locator; a store may occasionally be a partner point rather than a company-owned space.
+> Store names, types and coordinates are **from the operator** (`geo_method: "operator_api"`). Coordinates are `geo_precision: "exact"` for 553 stores and `"approximate"` for 19 whose source coordinate has fewer than 3 decimal places. Wilaya is effectively exact (from the operator point); commune is a nearest-centroid best-effort. A **few** operator points carry inaccurate coordinates in the source, so their derived wilaya/commune can be wrong, the `operator_wilaya` field preserves Ooredoo's own declared wilaya in those cases. This is Ooredoo's own store directory as exposed by its locator; a store may occasionally be a partner point rather than a company-owned space.
 
 ## Source & license
 

--- a/packages/pharma/README.md
+++ b/packages/pharma/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/pharma
 
-**Algeria's pharmaceutical sector — one install.**
+**Algeria's pharmaceutical sector, one install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/pharma)](https://www.npmjs.com/package/@geoalgeria/pharma)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -32,14 +32,14 @@ import { pharmacies } from "@geoalgeria/pharma";
 
 | Namespace | Package | What |
 | --- | --- | --- |
-| `industrie` | [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Approved pharmaceutical manufacturers — medicine (PP) & medical-device (DM) makers (Ministry of Pharmaceutical Industry) |
+| `industrie` | [`@geoalgeria/industrie-pharmaceutique`](https://www.npmjs.com/package/@geoalgeria/industrie-pharmaceutique) | Approved pharmaceutical manufacturers – medicine (PP) & medical-device (DM) makers (Ministry of Pharmaceutical Industry) |
 | `pharmacies` | [`@geoalgeria/pharmacies`](https://www.npmjs.com/package/@geoalgeria/pharmacies) | Pharmacies / officines (OpenStreetMap) |
 
 > More of the sector may join over time (e.g. a medical-laboratories layer once open coverage is adequate). Installing `@geoalgeria/pharma` keeps you on the full set.
 
 ## Source & license
 
-Each member carries its own source and attribution (see its README) — MIP register for `industrie`, OpenStreetMap (ODbL) for `pharmacies`. Package code under MIT (see [LICENSE](LICENSE)).
+Each member carries its own source and attribution (see its README), MIP register for `industrie`, OpenStreetMap (ODbL) for `pharmacies`. Package code under MIT (see [LICENSE](LICENSE)).
 
 ## Questions?
 

--- a/packages/pharmacies/README.md
+++ b/packages/pharmacies/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/pharmacies
 
-**Algeria's pharmacies — as data you can install.**
+**Algeria's pharmacies, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/pharmacies)](https://www.npmjs.com/package/@geoalgeria/pharmacies)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/pharmacies)](https://www.npmjs.com/package/@geoalgeria/pharmacies)
@@ -14,7 +14,7 @@
 
 # Overview
 
-3,790 pharmacies (officines) across **67 wilayas**, from **OpenStreetMap** — every record geocoded, bilingual (FR/AR) where named, with phone, opening hours and a `dispensing` flag where OSM has them, plus wilaya/commune linkage.
+3,790 pharmacies (officines) across **67 wilayas**, from **OpenStreetMap**, every record geocoded, bilingual (FR/AR) where named, with phone, opening hours and a `dispensing` flag where OSM has them, plus wilaya/commune linkage.
 
 ## Installation
 
@@ -58,10 +58,10 @@ metadata().wilayas_covered; // 67
 
 ## Formats
 
-- `data/pharmacies.json` — full array (typed by `types/index.d.ts`)
-- `data/csv/pharmacies.csv` — flat CSV
-- `data/geojson/pharmacies.geojson` — `FeatureCollection` (all records)
-- `data/metadata.json` — counts, sources, generated date
+- `data/pharmacies.json` – full array (typed by `types/index.d.ts`)
+- `data/csv/pharmacies.csv` – flat CSV
+- `data/geojson/pharmacies.geojson` – `FeatureCollection` (all records)
+- `data/metadata.json` – counts, sources, generated date
 
 ```js
 import data from "@geoalgeria/pharmacies/data/pharmacies.json" with { type: "json" };
@@ -73,11 +73,11 @@ import type { Pharmacy } from "@geoalgeria/pharmacies";
 
 ## How the data is built
 
-Extracted from OpenStreetMap via Overpass (`amenity=pharmacy` across Algeria), de-duplicated (same-name-within-40 m and coincident points), then linked to wilaya/commune by nearest-centroid join against the geoalgeria commune set. Names are routed strictly by script so `name_ar` is always Arabic and `name_fr` always Latin, even when OSM mis-tags them. A bulk-import artifact — 1,769 unnamed, consecutive-id pharmacy *ways* dumped into one small area near Attatba (Tipaza) — is detected and excluded (it is not real officines). Rebuild with `npm run fetch` (or `--cache` to rebuild from the cached pull). See `research/pharmacies/` in the monorepo.
+Extracted from OpenStreetMap via Overpass (`amenity=pharmacy` across Algeria), de-duplicated (same-name-within-40 m and coincident points), then linked to wilaya/commune by nearest-centroid join against the geoalgeria commune set. Names are routed strictly by script so `name_ar` is always Arabic and `name_fr` always Latin, even when OSM mis-tags them. A bulk-import artifact, 1,769 unnamed, consecutive-id pharmacy *ways* dumped into one small area near Attatba (Tipaza), is detected and excluded (it is not real officines). Rebuild with `npm run fetch` (or `--cache` to rebuild from the cached pull). See `research/pharmacies/` in the monorepo.
 
 ## On accuracy & coverage
 
-> **Coverage is partial.** 3,790 pharmacies are mapped in OpenStreetMap against an estimated **~11,000 officines** nationally (an order-of-magnitude reference — there is no open official registry; the Ordre National des Pharmaciens portal is down). Coverage is uneven by wilaya and denser in the north — this is a community-maintained extract, **not an official registry**.
+> **Coverage is partial.** 3,790 pharmacies are mapped in OpenStreetMap against an estimated **~11,000 officines** nationally (an order-of-magnitude reference, there is no open official registry; the Ordre National des Pharmaciens portal is down). Coverage is uneven by wilaya and denser in the north, this is a community-maintained extract, **not an official registry**.
 >
 > Coordinates are OSM node points (surveyed) or building-outline centroids (`geo_method`). Commune is a nearest-centroid best-effort; wilaya is effectively exact. Names, phones and hours are only present where an OSM contributor tagged them.
 

--- a/packages/poste/README.md
+++ b/packages/poste/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/poste
 
-**Every Algérie Poste office and ATM — as data you can install.**
+**Every Algérie Poste office and ATM, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/poste)](https://www.npmjs.com/package/@geoalgeria/poste)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/poste)](https://www.npmjs.com/package/@geoalgeria/poste)
@@ -12,7 +12,7 @@
 
 </div>
 
-3,908 post offices and 2,026 ATMs across Algeria — with **real postal codes**, bilingual (French / Arabic) names, GPS coordinates, and commune/wilaya linkage. Sourced from Algérie Poste, shipped as JSON, CSV, and GeoJSON. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
+3,908 post offices and 2,026 ATMs across Algeria, with **real postal codes**, bilingual (French / Arabic) names, GPS coordinates, and commune/wilaya linkage. Sourced from Algérie Poste, shipped as JSON, CSV, and GeoJSON. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
 
 ```bash
 npm install @geoalgeria/poste
@@ -32,10 +32,10 @@ const inAdrar = offices.filter((o) => o.commune_code === "0101");
 
 ## What you can build
 
-- **Postal-code validation & lookup** — every office carries its real `postal_code`.
-- **Branch / ATM locators** — coordinates on (almost) every record, ready for distance sorting or a map.
-- **Fintech & logistics** — match addresses to the nearest post office or GAB.
-- **Maps** — drop-in GeoJSON point layers for the whole postal network.
+- **Postal-code validation & lookup** – every office carries its real `postal_code`.
+- **Branch / ATM locators** – coordinates on (almost) every record, ready for distance sorting or a map.
+- **Fintech & logistics** – match addresses to the nearest post office or GAB.
+- **Maps** – drop-in GeoJSON point layers for the whole postal network.
 
 ## What's inside
 
@@ -54,7 +54,7 @@ import offices from "@geoalgeria/poste/data/postoffices.json" with { type: "json
 // https://cdn.jsdelivr.net/npm/@geoalgeria/poste/data/postoffices.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import poste, { type PostOffice, type Atm } from "@geoalgeria/poste";
@@ -75,7 +75,7 @@ data/
   geojson/atms.geojson
 ```
 
-> GeoJSON includes only records that have coordinates — 16 offices and 5 ATMs
+> GeoJSON includes only records that have coordinates, 16 offices and 5 ATMs
 > report no `lat`/`lng` and are omitted there (but remain in JSON/CSV, with
 > `geo_precision`/`geo_method` both `null`). ATM records carry `commune_code`
 > as `null` (the source API doesn't resolve ATMs to a commune code).
@@ -110,7 +110,7 @@ Algérie Poste's 4-digit commune code, which joins to GeoAlgeria's `code_commune
 `geo_precision` is `"exact"` (or `null` alongside `lat`/`lng` when the office
 isn't geocoded); `geo_method` names how the point was obtained.
 
-**ATM** — same shape, keyed by `id`/`name`/`wilaya_code`/`postal_code` with
+**ATM** – same shape, keyed by `id`/`name`/`wilaya_code`/`postal_code` with
 `lat`/`lng`, plus a `status` field (`"OPEN"`, `"CLOSED (OFFLINE)"`, or the
 undocumented source value `"1"`); `commune_code` and `address` are always
 `null` (the source doesn't resolve them for ATMs).
@@ -118,7 +118,7 @@ undocumented source value `"1"`); `commune_code` and `address` are always
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it mirrors
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it mirrors
 this postal data in and exposes `postOffices` / `atms` alongside the full
 division dataset. Use `@geoalgeria/poste` when you *only* need postal/banking data.
 
@@ -127,8 +127,8 @@ division dataset. Use `@geoalgeria/poste` when you *only* need postal/banking da
 Data comes from **Algérie Poste** via the public BaridiMap API
 (<https://baridimap.poste.dz>). Run `npm run fetch` to regenerate every output
 from the live API; the same run mirrors the data into the `geoalgeria` package so
-the two never drift (this package is the canonical source). Re-fetch periodically
-— BaridiMap still files offices under the 58-wilaya scheme, so new wilayas 59–69
+the two never drift (this package is the canonical source). Re-fetch periodically.
+BaridiMap still files offices under the 58-wilaya scheme, so new wilayas 59–69
 currently appear under their mother wilaya.
 
 ## License & attribution

--- a/packages/sante/README.md
+++ b/packages/sante/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/sante
 
-**Algeria's public health establishments — as data you can install.**
+**Algeria's public health establishments, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/sante)](https://www.npmjs.com/package/@geoalgeria/sante)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/sante)](https://www.npmjs.com/package/@geoalgeria/sante)
@@ -13,7 +13,7 @@
 </div>
 
 **695 public health establishments** across all **58 wilayas** with health
-directorates — public hospitals (EPH), proximity-health establishments (EPSP),
+directorates, public hospitals (EPH), proximity-health establishments (EPSP),
 specialized hospitals (EHS) and university hospitals (CHU) from the **Ministry of Health (MoH)**, bilingual French/Arabic, **600 geocoded** (124 to a precise
 OpenStreetMap/Wikidata point, 476 to a commune centroid) with commune/wilaya
 linkage. Shipped as JSON, CSV, GeoJSON, and
@@ -37,11 +37,11 @@ const mappable = all.filter((e) => e.lat != null);
 
 ## What you can build
 
-- **Hospital & clinic locators** — coordinates on 600 of 695 records, ready for a
+- **Hospital & clinic locators** – coordinates on 600 of 695 records, ready for a
   map or nearest-facility search.
-- **Bilingual health directories** — French and Arabic names, official type and
+- **Bilingual health directories** – French and Arabic names, official type and
   wilaya for every establishment.
-- **Coverage & planning analysis** — count establishments by type per
+- **Coverage & planning analysis** – count establishments by type per
   commune/wilaya across the whole country.
 
 ## What's inside
@@ -54,10 +54,10 @@ const mappable = all.filter((e) => e.lat != null);
 
 | Type | Count | Meaning |
 | --- | --- | --- |
-| `eph` | 270 | Établissement Public Hospitalier — public hospital |
-| `epsp` | 292 | Établissement Public de Santé de Proximité — proximity health |
-| `ehs` | 108 | Établissement Hospitalier Spécialisé — specialized hospital |
-| `chu` | 20 | Centre Hospitalo-Universitaire — university hospital |
+| `eph` | 270 | Établissement Public Hospitalier – public hospital |
+| `epsp` | 292 | Établissement Public de Santé de Proximité – proximity health |
+| `ehs` | 108 | Établissement Hospitalier Spécialisé – specialized hospital |
+| `chu` | 20 | Centre Hospitalo-Universitaire – university hospital |
 | `hopital` | 5 | other public hospital |
 
 **By coordinate precision** (`geo_precision`)
@@ -66,7 +66,7 @@ const mappable = all.filter((e) => e.lat != null);
 | --- | --- | --- |
 | `exact` | 124 | precise point from an OSM or Wikidata facility in the commune |
 | `approximate` | 476 | the establishment's commune centroid |
-| `null` | 95 | locality not resolved to a commune — no coordinates (`lat`/`lng` also `null`) |
+| `null` | 95 | locality not resolved to a commune – no coordinates (`lat`/`lng` also `null`) |
 
 **By coordinate method** (`geo_method`)
 
@@ -75,11 +75,11 @@ const mappable = all.filter((e) => e.lat != null);
 | `osm_point` | 121 | precise point from an OpenStreetMap facility in the commune |
 | `wikidata_point` | 3 | precise point from a Wikidata facility in the commune |
 | `commune_centroid` | 476 | the establishment's commune centroid (approximate) |
-| `null` | 95 | no method — record has no coordinate |
+| `null` | 95 | no method – record has no coordinate |
 
 > **The registry is official; the coordinates are best-effort.** Names, type and
 > wilaya come from the Ministry of Health. The MoH publishes no coordinates,
-> so GeoAlgeria derives them — see *Source & method* below. Counts move as the
+> so GeoAlgeria derives them, see *Source & method* below. Counts move as the
 > MoH, OpenStreetMap and Wikidata are edited; each rebuild reflects their current
 > state.
 
@@ -93,7 +93,7 @@ import sante from "@geoalgeria/sante/data/sante.json" with { type: "json" };
 // https://cdn.jsdelivr.net/npm/@geoalgeria/sante/data/sante.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import sante, { type HealthEstablishment } from "@geoalgeria/sante";
@@ -140,12 +140,12 @@ data/
 ```
 
 `id` is a stable `{wilaya_code}-{type}-{seq}` key synthesized by GeoAlgeria (the
-MoH publishes no establishment code) — opaque, unique within `sante.json`.
+MoH publishes no establishment code), opaque, unique within `sante.json`.
 `name` is the French name where available, else Arabic. `type` is derived from
 the establishment's title; `wilaya_code` from the MoH's wilaya tag. `sector` is
 `"public"` for the whole MoH registry (private clinics, when added, will carry
 `"private"`). `source` is always `"msp"` (the Ministry of Health registry);
-`refs` carries the per-provenance ids that contributed the record — `msp`
+`refs` carries the per-provenance ids that contributed the record, `msp`
 always, plus `osm` or `wikidata` when the coordinate was upgraded to a precise
 point. `geo_precision` is `"exact"`, `"approximate"`, or `null`; `geo_method`
 names how the coordinate was obtained (`osm_point`, `wikidata_point`,
@@ -164,7 +164,7 @@ commune.
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn an establishment's `commune_code` into a polygon or centroid. Use
 `@geoalgeria/sante` when you *only* need the health establishments.
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,13 +1,13 @@
 # @geoalgeria/schema
 
-> The canonical data contract every GeoAlgeria dataset conforms to — one shared schema, one validator, one metadata shape.
+> The canonical data contract every GeoAlgeria dataset conforms to, one shared schema, one validator, one metadata shape.
 
 This package is the single source of truth for the shape of GeoAlgeria's open datasets (schema **v2**). It ships:
 
-- **TypeScript types** — `GeoRecord`, `DatasetMetadata`, `SourceRef`, `Manifest`, `Refs`, `GeoPrecision`. Each `@geoalgeria/*` dataset's records are a `GeoRecord` plus domain-specific extra fields.
-- **A zero-dependency runtime validator** — `validateRecords` / `validateMetadata`. Enforces the contract (string `wilaya_code`, string ONS `commune_code`, `geo_precision: exact|approximate|null` and `geo_method` — each null if and only if the record has no coordinate, `lat`/`lng`, `refs`), an always-on **Algeria-bbox coordinate guard** that catches lat/lng swaps and sign flips, and an optional **point-in-wilaya** check when you supply boundary polygons.
-- **Canonical builders** — `buildMetadata` (counts, precision breakdown, honest `estimated_universe` coverage, `bbox`), `buildManifest` (the repo catalog / `index.json`), and `buildDcat` (a schema.org `Dataset` descriptor for Google Dataset Search / AI answer engines).
-- **Emit helpers** — `toCSV`, `toGeoJSON`, `wcode`, `round6`, `haversine`, `bbox`.
+- **TypeScript types** – `GeoRecord`, `DatasetMetadata`, `SourceRef`, `Manifest`, `Refs`, `GeoPrecision`. Each `@geoalgeria/*` dataset's records are a `GeoRecord` plus domain-specific extra fields.
+- **A zero-dependency runtime validator** – `validateRecords` / `validateMetadata`. Enforces the contract (string `wilaya_code`, string ONS `commune_code`, `geo_precision: exact|approximate|null` and `geo_method`, each null if and only if the record has no coordinate, `lat`/`lng`, `refs`), an always-on **Algeria-bbox coordinate guard** that catches lat/lng swaps and sign flips, and an optional **point-in-wilaya** check when you supply boundary polygons.
+- **Canonical builders** – `buildMetadata` (counts, precision breakdown, honest `estimated_universe` coverage, `bbox`), `buildManifest` (the repo catalog / `index.json`), and `buildDcat` (a schema.org `Dataset` descriptor for Google Dataset Search / AI answer engines).
+- **Emit helpers** – `toCSV`, `toGeoJSON`, `wcode`, `round6`, `haversine`, `bbox`.
 
 ## Usage
 
@@ -31,7 +31,7 @@ const meta = buildMetadata({
 
 | field | type | notes |
 |---|---|---|
-| `id` | `string` | opaque, unique **within its file** — not globally unique, not unique across files even within one package |
+| `id` | `string` | opaque, unique **within its file** – not globally unique, not unique across files even within one package |
 | `name` / `name_fr` / `name_ar` | `string \| null` | domain-default `name`; localized variants optional |
 | `wilaya_code` | `string` | zero-padded `"01".."69"` |
 | `commune_code` | `string \| null` | ONS code; first 2 digits === `wilaya_code` |
@@ -44,7 +44,7 @@ const meta = buildMetadata({
 
 `validateRecords` runs the point-in-wilaya check only when you pass `boundaries` (built with `loadBoundaries(featureCollection)`), so the package ships no polygons. Without them, the Algeria-bbox guard still catches gross coordinate errors. This repo's polygons live in `packages/dataset/data/geojson/wilaya-boundaries.geojson` (69 wilayas, OSM/ODbL; published in the `geoalgeria` npm package under `data/geojson/`).
 
-`loadBoundaries` **throws** rather than returning an empty or partial index — on no usable features, on any feature it cannot index, and on a duplicate wilaya code. `pointInWilaya` reports a code it has no polygon for as *inside* ("can't disprove, don't flag"), so a degraded index does not weaken the check, it silently switches it off; a load-time throw is the only outcome that cannot be mistaken for a clean run.
+`loadBoundaries` **throws** rather than returning an empty or partial index, on no usable features, on any feature it cannot index, and on a duplicate wilaya code. `pointInWilaya` reports a code it has no polygon for as *inside* ("can't disprove, don't flag"), so a degraded index does not weaken the check, it silently switches it off; a load-time throw is the only outcome that cannot be mistaken for a clean run.
 
 ## License
 

--- a/packages/sports/README.md
+++ b/packages/sports/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/sports
 
-**Every sports facility in Algeria — as data you can install.**
+**Every sports facility in Algeria, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/sports)](https://www.npmjs.com/package/@geoalgeria/sports)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/sports)](https://www.npmjs.com/package/@geoalgeria/sports)
@@ -12,9 +12,9 @@
 
 </div>
 
-5,141 sports facilities across Algeria — **proximity fields**, stadiums, swimming pools,
+5,141 sports facilities across Algeria, **proximity fields**, stadiums, swimming pools,
 specialized halls, athletics tracks, tennis courts, equestrian centers, nautical bases and
-more — each with its name, facility **type**, address, commune / daïra / wilaya, capacity,
+more, each with its name, facility **type**, address, commune / daïra / wilaya, capacity,
 operational status, PMR accessibility, built and land area, year of reception, and geographic
 coordinates. Sourced from the **Ministry of Youth and Sports GIS
 (sig.mjs.gov.dz)**, shipped as JSON, CSV, and GeoJSON. Part of
@@ -31,15 +31,15 @@ const all = sports.facilities();                    // 5,141
 const inOran = sports.facilitiesByWilaya(31);       // facilities in wilaya 31
 const pools = sports.facilitiesByType("P25");       // every 25 m pool
 
-// Everything has lat/lng — distance-sort, map, or nearest-facility in a few lines.
+// Everything has lat/lng – distance-sort, map, or nearest-facility in a few lines.
 ```
 
 ## What you can build
 
-- **"Nearest pool / stadium" lookups** — coordinates on every record, ready for distance sorting.
-- **Sports & civic apps** — map stadiums, pools and courts per wilaya, filter by type or status.
-- **Maps** — drop-in GeoJSON point layer for the entire sports infrastructure network.
-- **Research & planning** — facility density by type, capacity analysis, operational status audits.
+- **"Nearest pool / stadium" lookups** – coordinates on every record, ready for distance sorting.
+- **Sports & civic apps** – map stadiums, pools and courts per wilaya, filter by type or status.
+- **Maps** – drop-in GeoJSON point layer for the entire sports infrastructure network.
+- **Research & planning** – facility density by type, capacity analysis, operational status audits.
 
 ## What's inside
 
@@ -74,7 +74,7 @@ const pools = sports.facilitiesByType("P25");       // every 25 m pool
 | Grand stade | `GS` | 1 |
 | **Total** | | **5,141** |
 
-Spanning **58 wilayas**, every facility geocoded — 5,008 to an `exact` point, the
+Spanning **58 wilayas**, every facility geocoded, 5,008 to an `exact` point, the
 remaining 133 `approximate`. `wilaya_code` is linked against the
 [`geoalgeria`](https://www.npmjs.com/package/geoalgeria) wilaya model.
 
@@ -88,7 +88,7 @@ import facilities from "@geoalgeria/sports/data/facilities.json" with { type: "j
 // https://cdn.jsdelivr.net/npm/@geoalgeria/sports/data/facilities.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import sports, { type Facility } from "@geoalgeria/sports";
@@ -146,7 +146,7 @@ URL). For Arabic wilaya and commune names, join `wilaya_code` against the
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 wilaya division dataset that `wilaya_code` here links to. Use `@geoalgeria/sports` when you
 *only* need sports infrastructure data.
 

--- a/packages/telecom/README.md
+++ b/packages/telecom/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/telecom
 
-**Algeria mobile-network coverage — as data you can install.**
+**Algeria mobile-network coverage, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/telecom)](https://www.npmjs.com/package/@geoalgeria/telecom)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/telecom)](https://www.npmjs.com/package/@geoalgeria/telecom)
@@ -13,7 +13,7 @@
 </div>
 
 **2,798 5G coverage points** across Algeria, published by the operators' own
-coverage maps — **Djezzy (1,001)**, **Mobilis (1,621)**, and **Ooredoo (176)** —
+coverage maps, **Djezzy (1,001)**, **Mobilis (1,621)**, and **Ooredoo (176)**,
 each with coordinates and wilaya/commune linkage. Shipped as JSON, CSV, GeoJSON,
 and TypeScript. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
 
@@ -42,9 +42,9 @@ const sites: CoverageSite[] = telecom.coverage("5G");
 
 ## What you can build
 
-- **5G coverage checkers** — "is there 5G near me / in my wilaya?"
-- **Operator comparison** — Djezzy / Mobilis / Ooredoo footprint per wilaya/commune.
-- **Maps** — drop-in GeoJSON point layers for the 5G rollout.
+- **5G coverage checkers** – "is there 5G near me / in my wilaya?"
+- **Operator comparison** – Djezzy / Mobilis / Ooredoo footprint per wilaya/commune.
+- **Maps** – drop-in GeoJSON point layers for the 5G rollout.
 
 ## What's inside
 
@@ -61,18 +61,18 @@ Touggourt).
 > coverage map. Djezzy and Mobilis publish **cell-site** locations; Ooredoo
 > publishes **commune-level** points within covered communes (a few communes
 > carry several). The circles those maps draw are a fixed display radius, **not
-> measured RF coverage** — treat these as 5G *presence* points, not coverage
+> measured RF coverage**, treat these as 5G *presence* points, not coverage
 > polygons.
 
 ## Organization (future-proof)
 
 Coverage is namespaced by **technology**, so adding a new generation later is
-purely additive — nothing renames:
+purely additive, nothing renames:
 
 ```
 data/
   coverage/5g/
-    sites.json          # combined — all operators
+    sites.json          # combined – all operators
     djezzy.json  mobilis.json  ooredoo.json
   csv/coverage/5g/sites.csv          # repo + Release bundle (not in npm tarball)
   geojson/coverage/5g/sites.geojson  # Point features
@@ -110,7 +110,7 @@ FR/AR but no street address; Ooredoo has the commune name only). For Ooredoo,
 ## Need the administrative divisions too?
 
 For wilayas, dairas, and communes, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it's how
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it's how
 you turn a `wilaya_code` into a polygon or name.
 
 ## Source & regeneration
@@ -128,7 +128,7 @@ failed operator never overwrites good committed data with a partial set.
 
 Code is [MIT](LICENSE). The underlying data is © the respective operators
 (**Djezzy**, **Mobilis**, **Ooredoo**), redistributed for reference and to power
-[GeoAlgeria](https://geoalgeria.com). 5G rollout is ongoing — each rebuild
+[GeoAlgeria](https://geoalgeria.com). 5G rollout is ongoing, each rebuild
 reflects whatever the operators' maps currently show; verify against the
 operators for authoritative, real-time information.
 

--- a/packages/tourisme/README.md
+++ b/packages/tourisme/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/tourisme
 
-**Algeria's tourism infrastructure — as data you can install.**
+**Algeria's tourism infrastructure, as data you can install.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/tourisme)](https://www.npmjs.com/package/@geoalgeria/tourisme)
 [![npm downloads](https://img.shields.io/npm/dm/@geoalgeria/tourisme)](https://www.npmjs.com/package/@geoalgeria/tourisme)
@@ -12,8 +12,8 @@
 
 </div>
 
-4,348 geocoded tourism sites across Algeria's 69 wilayas — **hotels**, attractions, historic
-sites, thermal springs and protected areas — each with coordinates, wilaya linkage and source
+4,348 geocoded tourism sites across Algeria's 69 wilayas, **hotels**, attractions, historic
+sites, thermal springs and protected areas, each with coordinates, wilaya linkage and source
 attribution. Sourced from **ASAL Geoportail** (thermal springs), **OpenStreetMap** (hotels,
 attractions, historic sites, parks) and **Wikidata** (heritage sites, museums, parks). Shipped
 as JSON, CSV, and GeoJSON. Part of [GeoAlgeria](https://github.com/yasserstudio/geoalgeria).
@@ -31,16 +31,16 @@ const springs = tourisme.thermalSprings();        // 282
 const inTipaza = tourisme.byWilaya(42);           // all tourism sites in wilaya 42
 const ruins = tourisme.byLayer("historic");       // 1,184 historic sites
 
-// Everything has lat/lng — distance-sort, map, or nearest-site in a few lines.
+// Everything has lat/lng – distance-sort, map, or nearest-site in a few lines.
 ```
 
 ## What you can build
 
-- **Tourism apps** — searchable directory of hotels, attractions and historic sites by wilaya.
-- **Nearest-site lookups** — coordinates on every record, ready for distance sorting.
-- **Maps** — drop-in GeoJSON point layers for the full tourism network.
-- **Thermal-spring guides** — temperature, flow rate, altitude and mineral composition data for 282 springs.
-- **Heritage & culture** — Wikipedia/Wikidata-linked historic sites, monuments and archaeological sites.
+- **Tourism apps** – searchable directory of hotels, attractions and historic sites by wilaya.
+- **Nearest-site lookups** – coordinates on every record, ready for distance sorting.
+- **Maps** – drop-in GeoJSON point layers for the full tourism network.
+- **Thermal-spring guides** – temperature, flow rate, altitude and mineral composition data for 282 springs.
+- **Heritage & culture** – Wikipedia/Wikidata-linked historic sites, monuments and archaeological sites.
 
 ## What's inside
 
@@ -66,7 +66,7 @@ import lodging from "@geoalgeria/tourisme/data/lodging.json" with { type: "json"
 // https://cdn.jsdelivr.net/npm/@geoalgeria/tourisme/data/lodging.json
 ```
 
-The loaders and record shapes are fully **typed** — TypeScript definitions ship in the package:
+The loaders and record shapes are fully **typed**, TypeScript definitions ship in the package:
 
 ```ts
 import tourisme, { type Lodging, type ThermalSpring } from "@geoalgeria/tourisme";
@@ -91,7 +91,7 @@ data/
 
 ## Record shape
 
-**Lodging** — hotels, hostels, guest houses:
+**Lodging** – hotels, hostels, guest houses:
 
 ```json
 {
@@ -119,18 +119,18 @@ data/
 `commune_code` and `commune` are null throughout.
 
 Optional contact and classification fields are present where the source publishes them, and
-absent otherwise — never null. On lodging: `address` (209 records), `phone` (204, several
+absent otherwise, never null. On lodging: `address` (209 records), `phone` (204, several
 numbers `;`-separated as OSM tags them), `website` (84), `stars` (60) and `rooms` (24). On
 attractions: `description` (26). On historic sites: `heritage_status` (17, e.g.
 `"part of UNESCO World Heritage Site"`) and `heritage` (12, the OSM protection level).
 
 Most records on these four layers come from OpenStreetMap, but 115 come from Wikidata instead
 (32 attractions, 75 historic sites, 8 parks). Those carry `source` and `geo_method` of
-`"wikidata"` and a `refs.wikidata` QID with no `refs.osm` — they are CC0, not ODbL, so filter
+`"wikidata"` and a `refs.wikidata` QID with no `refs.osm`, they are CC0, not ODbL, so filter
 on `source` if the distinction matters for your attribution. In all, 236 records carry a
 Wikidata QID and 100 a Wikipedia sitelink.
 
-**Thermal spring** — ASAL Geoportail sourced, with physical properties:
+**Thermal spring** – ASAL Geoportail sourced, with physical properties:
 
 ```json
 {
@@ -154,7 +154,7 @@ Wikidata QID and 100 a Wikipedia sitelink.
 
 `type` is one of `hammam`, `ain`, `source`, `forage`. Physical properties (`temperature_c`,
 `debit_l_s`, `altitude_m`, `minerality`) come directly from the ASAL dataset; `minerality`
-is the only optional one. This is the one layer that names a commune — as `commune`, a name
+is the only optional one. This is the one layer that names a commune, as `commune`, a name
 rather than an ONS `commune_code`, which stays null.
 
 `wilaya_code` is zero-padded to two digits across all layers and joins GeoAlgeria's wilayas.
@@ -162,7 +162,7 @@ rather than an ONS `commune_code`, which stays null.
 ## Need the administrative divisions too?
 
 If you also need wilayas, dairas, and communes to join against, use the main
-**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package — it ships the full
+**[`geoalgeria`](https://www.npmjs.com/package/geoalgeria)** package, it ships the full
 69-wilaya division dataset that `wilaya_code` here links to. Use `@geoalgeria/tourisme`
 when you *only* need tourism data.
 
@@ -170,11 +170,11 @@ when you *only* need tourism data.
 
 Data comes from three sources:
 
-- **ASAL Geoportail** — thermal springs (temperature, flow rate, altitude, mineral composition).
+- **ASAL Geoportail** – thermal springs (temperature, flow rate, altitude, mineral composition).
   Public government data.
-- **OpenStreetMap** — hotels, attractions, historic sites, and parks. Licensed under
+- **OpenStreetMap** – hotels, attractions, historic sites, and parks. Licensed under
   [ODbL](https://opendatacommons.org/licenses/odbl/).
-- **Wikidata** — heritage sites, museums, and park metadata. Licensed under
+- **Wikidata** – heritage sites, museums, and park metadata. Licensed under
   [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## License & attribution

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -4,7 +4,7 @@
 
 # @geoalgeria/transport
 
-**Algeria's transport sector — one install for every mode.**
+**Algeria's transport sector, one install for every mode.**
 
 [![npm](https://img.shields.io/npm/v/@geoalgeria/transport)](https://www.npmjs.com/package/@geoalgeria/transport)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -44,7 +44,7 @@ whole sector.
 
 ## License
 
-Code is [MIT](LICENSE). Each member carries its own data license and attribution — see the
+Code is [MIT](LICENSE). Each member carries its own data license and attribution, see the
 respective package READMEs.
 
 [Browse all packages →](https://geoalgeria.com/data)


### PR DESCRIPTION
Removes every em dash (U+2014) from the repo docs, per the project no-em-dash rule. Two commits:

1. **Package READMEs + README.ar** (28 package READMEs + Arabic root README): 347 em dashes removed. `README.md` / `README.fr.md` were already clean (#127).
2. **Remaining docs** (`CHANGELOG.md`, `AGENTS.md`, `DISCLAIMER.md`, `SECURITY.md`, `docs/agents/`): 82 em dashes removed.

**429 total**, replaced contextually to preserve meaning: colons (introducing lists/explanations), commas/parentheses (appositives), semicolons (trailing clauses), and spaced en dashes (` – `) for term/gloss separators matching the convention already used in feature lists, schema tables, and version headings. Punctuation only: no data, facts, versions, package names, code, or URLs changed.

Notes:
- npm-displayed package READMEs sync at each package next publish (no republish here).
- Out of scope, left as-is: `research/` internal working notes, and a couple of em dashes inside example data records (buses / gares-routieres) that mirror the shipped JSON (a data-content decision).