### PR TITLE
research: screen the long-haul listed routes, five should not be drawn

### DIFF
--- a/research/_flight-routes/build_route_dataset.py
+++ b/research/_flight-routes/build_route_dataset.py
@@ -67,6 +67,12 @@ VERIFIED = [
      "source": "https://www.observalgerie.com/"},
     {"from": "ORN", "to": "IST", "flight": "AH 3024", "status": "active",
      "source": "https://www.aeroroutes.com/"},
+    # The African long-haul block, AH 53xx, on Air Algérie's own metal: neither
+    # returned a codeshare object.
+    {"from": "ALG", "to": "JNB", "flight": "AH 5360", "status": "active",
+     "source": "https://www.airalgerie.dz/decouvrir/nos-destinations/"},
+    {"from": "ALG", "to": "DLA", "flight": "AH 5350", "status": "active",
+     "source": "https://www.airalgerie.dz/decouvrir/nos-destinations/"},
 ]
 
 # Pairs where a booking probe returned an AH flight number that is a CODESHARE on
@@ -78,7 +84,17 @@ VERIFIED = [
 # CZL-IST returns TK 8666 on Turkish metal with AH as the marketing carrier;
 # ORN-IST returns AH 3024 with NO codeshare object at all, so that one is Air
 # Algérie's own and is promoted to verified above (ratio 1.02).
-CODESHARE_ONLY = {("ALG", "IST"), ("CZL", "IST")}
+CODESHARE_ONLY = {("ALG", "IST"), ("CZL", "IST"), ("ALG", "DOH")}
+
+# Screened and found to be flown by ANOTHER airline entirely, with no Air Algérie
+# leg at all, not even a codeshare. A published table listing Air Algérie on these
+# is not enough to draw them: the probe returns Saudia and Royal Jordanian metal
+# and nothing of Air Algérie's. They may be seasonal, Hajj-period or simply a
+# table error, and either way an arc here would assert something unsupported.
+OPERATED_BY_OTHERS = {
+    ("ALG", "JED"),   # SV 0340 / SV 0342, Saudia
+    ("ALG", "AMM"),   # RJ 0518, Royal Jordanian
+}
 
 
 def haversine(a, b, c, d):
@@ -130,7 +146,7 @@ def main():
         key = (frm, to)
         if key in seen:
             continue
-        if key in CODESHARE_ONLY:
+        if key in CODESHARE_ONLY or key in OPERATED_BY_OTHERS:
             skipped["codeshare"].append(key); continue
         if frm not in ep or to not in ep:
             skipped["no_endpoint"].append(key); continue

--- a/research/_flight-routes/collection-rules.md
+++ b/research/_flight-routes/collection-rules.md
@@ -393,3 +393,40 @@ calendar week is ~840 MCP calls, and MCP tool calls cannot be scripted. Use the
 adaptive shape instead: two dates per direction first, escalating to a full week
 only where both come back empty. That concentrates effort on the pairs where the
 answer is actually in doubt.
+
+## 18. Codeshare screening results, first pass (2026-07-28)
+
+Twelve of the highest-risk `listed` routes screened, chosen by great-circle
+distance on the reasoning that Air Algérie's own metal realistically covers
+Europe, the Maghreb, the Sahel and the near Middle East, so the far ones are where
+another airline is likely to be flying.
+
+**Five of twelve should not be drawn as Air Algérie routes.** That is a high
+enough error rate that no long-haul `listed` route should reach the map unscreened.
+
+| Pair | Probe | Verdict |
+| --- | --- | --- |
+| `ALG-JNB` | `AH 5360`, 9h20, no codeshare object | **verified**, ratio 0.95 |
+| `ALG-DLA` | `AH 5350`, 5h05, no codeshare object | **verified**, ratio 0.99 |
+| `ALG-DOH` | `QR 1380` on Qatar metal, AH as marketing carrier | **codeshare, excluded** |
+| `ALG-JED` | `SV 0340` / `SV 0342`, Saudia, no AH leg at all | **flown by another airline, excluded** |
+| `ALG-AMM` | `RJ 0518`, Royal Jordanian, no AH leg at all | **flown by another airline, excluded** |
+| `ALG-ABJ`, `ALG-BEY`, `ALG-DXB`, `ALG-NBJ`, `ALG-ABV`, `ALG-BKO`, `ALG-NIM` | empty | unresolved, stay `listed` |
+
+Note the third category, which the codeshare rule did not anticipate. `ALG-JED`
+and `ALG-AMM` return **no Air Algérie leg whatsoever**, only Saudia and Royal
+Jordanian. A published table listing Air Algérie on those pairs is not enough to
+draw them. They may be seasonal, Hajj-period, or simply a table error; whichever
+it is, an arc would assert something the evidence does not support. So there are
+now two exclusion sets, not one: `CODESHARE_ONLY` and `OPERATED_BY_OTHERS`.
+
+Air Algérie's own long-haul African flights appear in an `AH 53xx` block
+(`5350` Douala, `5360` Johannesburg), which is a useful smell test but not a rule:
+confirm each leg rather than inferring from the number.
+
+**41 `listed` routes remain unscreened**, mostly short-haul France, Spain and the
+Maghreb where Air Algérie's own operation is far more likely. They are not
+risk-free, though: `ALG-CDG` returned an Air France leg codeshared with AH
+alongside Air Algérie's own metal, so European pairs carry codeshares too. The
+difference is that there the codeshare sits beside a genuine AH flight rather
+than replacing it.

--- a/research/_flight-routes/route-dataset.json
+++ b/research/_flight-routes/route-dataset.json
@@ -71,20 +71,6 @@
       "great_circle_km": 3106
     },
     {
-      "id": "alg-amm",
-      "from": "ALG",
-      "to": "AMM",
-      "carrier": "AH",
-      "flight": null,
-      "status": "unclear",
-      "days": null,
-      "evidence": "listed",
-      "source": "https://www.air-journal.fr/2025-08-17-air-algerie-relance-ses-vols-vers-beyrouth-et-amman-devoile-la-livree-de-sa-filiale-domestic-airlines-5264784.html",
-      "source_is_the_table": false,
-      "listed_at": "Houari Boumediene Airport",
-      "great_circle_km": 3050
-    },
-    {
       "id": "alg-ayt",
       "from": "ALG",
       "to": "AYT",
@@ -157,28 +143,12 @@
       "from": "ALG",
       "to": "DLA",
       "carrier": "AH",
-      "flight": null,
-      "status": "unclear",
+      "flight": "AH 5350",
+      "status": "active",
       "days": null,
-      "evidence": "listed",
-      "source": "https://www.algerie360.com/air-algerie-lance-2-nouvelles-liaisons-interieures-des-la-semaine-prochain/",
-      "source_is_the_table": false,
-      "listed_at": "Houari Boumediene Airport",
+      "evidence": "verified",
+      "source": "https://www.airalgerie.dz/decouvrir/nos-destinations/",
       "great_circle_km": 3696
-    },
-    {
-      "id": "alg-doh",
-      "from": "ALG",
-      "to": "DOH",
-      "carrier": "AH",
-      "flight": null,
-      "status": "unclear",
-      "days": null,
-      "evidence": "listed",
-      "source": "https://www.algerie360.com/air-algerie-se-transforme-deux-nouvelles-filiales-pour-les-services-au-sol-et-la-formation-des-2026/",
-      "source_is_the_table": false,
-      "listed_at": "Houari Boumediene Airport",
-      "great_circle_km": 4733
     },
     {
       "id": "alg-dxb",
@@ -221,31 +191,15 @@
       "great_circle_km": 3058
     },
     {
-      "id": "alg-jed",
-      "from": "ALG",
-      "to": "JED",
-      "carrier": "AH",
-      "flight": null,
-      "status": "unclear",
-      "days": null,
-      "evidence": "listed",
-      "source": "https://www.dzair-tube.dz/fr/saison-du-hadj-2026-air-algerie-mobilise-ses-grands-moyens-pour-le-transport-des-pelerins/",
-      "source_is_the_table": false,
-      "listed_at": "Houari Boumediene Airport",
-      "great_circle_km": 3838
-    },
-    {
       "id": "alg-jnb",
       "from": "ALG",
       "to": "JNB",
       "carrier": "AH",
-      "flight": null,
-      "status": "unclear",
+      "flight": "AH 5360",
+      "status": "active",
       "days": null,
-      "evidence": "listed",
-      "source": "https://www.algerie360.com/air-algerie-reprend-ses-vols-vers-cette-destination-internationale/",
-      "source_is_the_table": false,
-      "listed_at": "Houari Boumediene Airport",
+      "evidence": "verified",
+      "source": "https://www.airalgerie.dz/decouvrir/nos-destinations/",
       "great_circle_km": 7463
     },
     {
@@ -986,13 +940,6 @@
       "country": "DZ"
     },
     {
-      "iata": "AMM",
-      "name": "Queen Alia International Airport",
-      "lat": 31.7226009369,
-      "lng": 35.9931983948,
-      "country": "JO"
-    },
-    {
       "iata": "AYT",
       "name": "Antalya International Airport",
       "lat": 36.898701,
@@ -1082,13 +1029,6 @@
       "lat": 4.00608,
       "lng": 9.71948,
       "country": "CM"
-    },
-    {
-      "iata": "DOH",
-      "name": "Hamad International Airport",
-      "lat": 25.273056,
-      "lng": 51.608056,
-      "country": "QA"
     },
     {
       "iata": "DXB",


### PR DESCRIPTION
First codeshare screening pass over the `listed` tier, ranked by great-circle distance on the reasoning that Air Algérie's own metal covers Europe, the Maghreb, the Sahel and the near Middle East, so the far pairs are where another airline is likely flying.

**Five of twelve fail.** That rate is too high to let any long-haul `listed` route reach the map unscreened.

| Pair | Probe | Verdict |
|---|---|---|
| `ALG-JNB` | `AH 5360`, 9h20, no codeshare | **verified**, ratio 0.95 |
| `ALG-DLA` | `AH 5350`, 5h05, no codeshare | **verified**, ratio 0.99 |
| `ALG-DOH` | `QR 1380`, Qatar metal, AH marketing | **codeshare, excluded** |
| `ALG-JED` | `SV 0340/0342`, Saudia, **no AH leg at all** | **excluded** |
| `ALG-AMM` | `RJ 0518`, Royal Jordanian, **no AH leg at all** | **excluded** |
| 7 others | empty | unresolved, stay `listed` |

## A category the codeshare rule missed

`ALG-JED` and `ALG-AMM` are worse than codeshares. The probe returns **no Air Algérie leg whatsoever** — only Saudia and Royal Jordanian metal. A published table listing Air Algérie on those pairs was not enough to draw them.

They may be seasonal, Hajj-period, or a table error. Whichever it is, the arc asserted something the evidence does not support. So there are now **two exclusion sets**: `CODESHARE_ONLY` and `OPERATED_BY_OTHERS`.

## What remains

**41 `listed` routes are unscreened**, mostly short-haul France, Spain and Maghreb where Air Algérie's own operation is far likelier. Not risk-free though: `ALG-CDG` returns an Air France leg codeshared with AH *beside* Air Algérie's own metal — European pairs carry codeshares too, they just sit next to a real AH flight rather than replacing it.

Air Algérie's African long-haul appears in an `AH 53xx` block (5350 Douala, 5360 Johannesburg). Useful smell test, not a rule — confirm each leg.