### PR TITLE
docs: add a roadmap, since the data side had nowhere to track open work

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Watch or ⭐ the repo to follow along, and [open a discussion](https://github.co
 
 ## Contributing
 
-Corrections and additions are welcome, see [CONTRIBUTING.md](CONTRIBUTING.md). Good first issues usually just need a source link or a missing commune coordinate. Found wrong data? [Open an issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose).
+Corrections and additions are welcome, see [CONTRIBUTING.md](CONTRIBUTING.md). What is planned and what is still open is in [`ROADMAP.md`](ROADMAP.md). Good first issues usually just need a source link or a missing commune coordinate. Found wrong data? [Open an issue](https://github.com/yasserstudio/geoalgeria/issues/new/choose).
 
 ## Versioning & releases
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,82 @@
+# Roadmap
+
+Open work on the data side. The app has its own roadmap at
+[`geoalgeria.com/docs/ROADMAP.md`](https://github.com/yasserstudio/geoalgeria.com/blob/main/docs/ROADMAP.md);
+items here are the ones whose work lives in **this** repo, even when the symptom
+shows up in the app.
+
+Every item states what it costs and what is genuinely unknown, so nothing here
+reads as further along than it is.
+
+---
+
+## Contract
+
+- [ ] **`@geoalgeria/telecom` still predates the v2 contract.** Its
+  `data/metadata.json` carries no `schema_version` at all and it is absent from
+  the `MIGRATIONS` config in `scripts/lib/v2-transforms.mjs`, so it never went
+  through the v2 pass every other package did. Coverage polygons are not a
+  `GeoRecord` collection, which is why it was skipped and why the migration is a
+  design question rather than a mechanical one: decide whether coverage is a
+  relation file (like `routes.json`) or its own shape, then migrate.
+  _(logged 2026-07-28)_
+
+## Aviation
+
+- [ ] **Foreign airport names, in every language.** `route-endpoints.json` carries
+  one `name` per airport and it is French, so the app renders "Aéroport d'Alger"
+  inside an Arabic card. The 13 Algerian origins are worked around with app-side
+  strings; the **50 foreign endpoints** are not, and should not be, since names
+  belong in the data. Wants `name_en` / `name_ar` on the endpoint records, then a
+  minor bump. Bounded, and the highest-value item on this list.
+  _(logged 2026-07-28)_
+
+- [ ] **Scheduled flight duration per route.** Asked for on the route card and
+  refused, correctly: there is no duration field, and **0 of 122** routes in
+  `research/_flight-routes/route-dataset.json` carry one. The great-circle
+  duration check used during verification was computed and discarded. Deriving a
+  duration from distance would put a fabricated number beside sourced ones. Wants
+  scheduled block times collected per route from a citable source.
+  _(logged 2026-07-28)_
+
+- [ ] **64 routes are `listed` rather than `verified`,** and some pairs are
+  one-directional (an outbound leg with no recorded return). `listed` means a
+  published table names the carrier serving the pair without confirming Air
+  Algérie operates it. Open-ended collection work with no natural finish line;
+  better run as background than as a track.
+  _(logged 2026-07-28)_
+
+- [ ] **Carriers beyond Air Algérie.** v1 is deliberately one operator, which the
+  app's title and copy now have to caveat, since other carriers do fly nonstop
+  from Algeria. Widening it is mostly a collection question: the app's route card
+  already falls back to a bare code for any carrier with no mark on file.
+  _(logged 2026-07-28)_
+
+- [ ] **Dated-snapshot framing.** Routes churn seasonally, unlike every other
+  dataset here, so the package should carry a validity window rather than reading
+  as evergreen. Affects the descriptor, not the records.
+  _(logged 2026-07-27)_
+
+## Releases
+
+- [ ] **Umbrella release tag for the current state.** Per-package releases have
+  kept up; the project-level tag has not. Manual, and worth doing at the next
+  meaningful group of bumps rather than on its own.
+  _(logged 2026-07-22)_
+
+## Verification
+
+- [ ] **`gares-routieres` geo precision.** 71 records are `exact` and 3 are
+  `approximate`. An earlier note recorded a precision mismatch on 2 records;
+  whether those are among the 3 approximate ones, or a separate disagreement
+  between the declared precision and the source, has not been re-checked since.
+  **Confirm the finding before acting on it** rather than trusting the note.
+  _(logged 2026-07-22, unverified)_
+
+---
+
+## Recently closed
+
+- **Em-dash sweep of the package READMEs**: done. Grepping every
+  `packages/*/README*.md` for the character returns nothing, so the sweep tracked
+  since 2026-07-23 has already landed. Verified 2026-07-28.


### PR DESCRIPTION
The app has had a roadmap all along. This repo had none, so its follow-ups lived only in scattered notes.

Seven items, each with what it costs and what is genuinely unknown, plus a link from the README so it can be found.

## Two remembered follow-ups did not survive checking

Which is the argument for writing them down rather than carrying them:

- **Em-dash sweep of the package READMEs** was tracked since 2026-07-23. Grepping every `packages/*/README*.md` for the character returns nothing. It is already done, so it is filed under *recently closed*, not open.
- **gares-routieres precision** was noted as a mismatch on 2 records. The data currently shows 71 `exact` and 3 `approximate`, and whether those are the same finding has not been re-checked. The item says **confirm before acting** rather than asserting a bug that may not exist.

## One did survive

`@geoalgeria/telecom` carries **no `schema_version` at all** in its `data/metadata.json` and is **absent from the `MIGRATIONS` config** in `scripts/lib/v2-transforms.mjs`, so it never went through the v2 pass every other package did. Recorded as a design question rather than a mechanical migration: coverage polygons are not a `GeoRecord` collection, which is why it was skipped in the first place.

## The rest

Aviation follow-ups (foreign airport names as `name_en`/`name_ar`, scheduled block times, the 64 `listed` routes, carriers beyond Air Algérie, dated-snapshot framing) and the outstanding umbrella release tag.

Docs only. `validate-packages` passes; no data changed.
