### PR TITLE
research(aviation): return-leg screening, first pass

### DIFF
--- a/research/_flight-routes/screen_returns_soar.py
+++ b/research/_flight-routes/screen_returns_soar.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Screen the un-recorded return legs against Soar live flight status.
+
+The dataset holds 96 city-pairs of which 70 are one-directional: the outbound
+leg is recorded (mostly from Wikipedia's airport tables, which are written
+outbound-only) and the return is silent. This asks Soar, for each silent
+direction, whether an AH flight actually operates it in the next week, and what
+its scheduled times are.
+
+STANDING RULE (research/_flight-routes/collection-rules.md): Soar is a
+HYPOTHESIS GENERATOR, never a source_url. Nothing this script writes may enter
+route-dataset.json directly. Each hit is a lead to confirm against a citable
+source (the airport's own schedule page, aeroroutes, the airline), and each
+miss is NOT a negative: live status only shows flights on days they operate,
+so a low-frequency route can miss all seven probes and still exist.
+
+Usage: python3 screen_returns_soar.py [days=7]
+Writes soar-return-screen-<today>.json next to this file.
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+
+from soar import call, session
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def one_directional_pairs():
+    d = json.load(open(os.path.join(HERE, "route-dataset.json"), encoding="utf-8"))
+    dz = {e["iata"] for e in d["endpoints"] if e["country"] == "DZ"}
+    dirs = {}
+    for r in d["routes"]:
+        key = tuple(sorted((r["from"], r["to"])))
+        dirs.setdefault(key, {"legs": []})["legs"].append(r)
+    out = []
+    for key, v in sorted(dirs.items()):
+        have = {(r["from"], r["to"]) for r in v["legs"]}
+        for a, b in [key, key[::-1]]:
+            if (a, b) not in have and (b, a) in have:
+                recorded = next(r for r in v["legs"] if (r["from"], r["to"]) == (b, a))
+                out.append({"dep": a, "arr": b, "recorded_leg": recorded["id"],
+                            "recorded_evidence": recorded["evidence"]})
+    return out, dz
+
+
+def main():
+    days = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+    pairs, _ = one_directional_pairs()
+    print(f"{len(pairs)} silent directions to screen, up to {days} days each")
+    sid = session()
+    today = datetime.date.today()
+    results = []
+    for i, p in enumerate(pairs):
+        hit = None
+        tried = 0
+        for offset in range(days):
+            date = (today + datetime.timedelta(days=offset)).isoformat()
+            tried += 1
+            try:
+                d = call("soar_get_live_flight_status",
+                         {"airline_iata": "AH", "dep_iata": p["dep"], "arr_iata": p["arr"],
+                          "date": date}, sid)
+                text = d["result"]["content"][0]["text"] if isinstance(d, dict) else str(d)
+                payload = json.loads(text)
+            except Exception as e:  # transient or shape surprise: record, move on
+                results.append({**p, "error": str(e)[:120], "date": date})
+                hit = "error"
+                break
+            fl = payload.get("flight")
+            if fl and fl.get("route", {}).get("dep_iata") == p["dep"]:
+                hit = {
+                    "flight_iata": fl.get("flight_iata"),
+                    "status": fl.get("status"),
+                    "date": date,
+                    "scheduled_dep": (fl.get("departure") or {}).get("scheduled"),
+                    "scheduled_arr": (fl.get("arrival") or {}).get("scheduled"),
+                }
+                break
+            time.sleep(0.4)
+        if hit == "error":
+            pass
+        elif hit:
+            results.append({**p, "found": hit, "days_probed": tried})
+            print(f"  [{i+1}/{len(pairs)}] {p['dep']}->{p['arr']}: {hit['flight_iata']} "
+                  f"{hit['scheduled_dep']} -> {hit['scheduled_arr']} ({hit['date']})")
+        else:
+            results.append({**p, "found": None, "days_probed": tried})
+            print(f"  [{i+1}/{len(pairs)}] {p['dep']}->{p['arr']}: no operation seen in {tried} day(s)")
+    out = {
+        "screened_at": today.isoformat(),
+        "days_window": days,
+        "note": ("HYPOTHESES ONLY. Soar/airlabs is never a source_url. A found flight is a "
+                 "lead to confirm against a citable source; a miss is not a negative "
+                 "(low-frequency routes can escape a 7-day live window)."),
+        "results": results,
+    }
+    path = os.path.join(HERE, f"soar-return-screen-{today.isoformat()}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    found = sum(1 for r in results if r.get("found"))
+    print(f"\n{found}/{len(pairs)} silent directions have a live AH operation -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/_flight-routes/soar-return-screen-2026-07-29.json
+++ b/research/_flight-routes/soar-return-screen-2026-07-29.json
@@ -1,0 +1,48 @@
+{
+  "screened_at": "2026-07-29",
+  "method": "soar_get_live_flight_status (in-session MCP), flight-number candidates derived from the recorded leg's number +/-1. The raw mcp.flysoar.ai endpoint exposes only search/book, and the service 502'd mid-screen, so only the 5 numbered verified legs were probed, not the full 70.",
+  "note": "HYPOTHESES ONLY. Soar/airlabs is never a source_url. A found flight is a lead to confirm against a citable source; a miss is not a negative (a numbered candidate can be wrong without the route being absent).",
+  "results": [
+    {
+      "dep": "ORY",
+      "arr": "BLJ",
+      "candidate_for": "return of blj-cdg (AH1120)",
+      "flight_iata": "AH1121",
+      "status": "en-route at screen time",
+      "scheduled": "14:55 -> 16:10 local",
+      "finding": "STRONG: the Paris->Batna return operates from ORY, not CDG. The silent cdg-blj direction may genuinely not exist; ory-blj is a candidate NEW route (airport-level split, the exact reason endpoints are airport-level)."
+    },
+    {
+      "dep": "IST",
+      "arr": "ORN",
+      "candidate_for": "return of orn-ist (AH3024)",
+      "flight_iata": "AH3025",
+      "status": "en-route at screen time",
+      "scheduled": "17:20 -> 19:55 local",
+      "finding": "STRONG: the silent IST->ORN return operates."
+    },
+    {
+      "dep": "DLA",
+      "arr": "ALG",
+      "candidate_for": "return of alg-dla (AH5350)",
+      "flight_iata": "AH5351",
+      "status": "no live match",
+      "finding": "miss, not a negative"
+    },
+    {
+      "dep": "LYS",
+      "arr": "TLM",
+      "candidate_for": "return of tlm-lys (AH1098)",
+      "flight_iata": "AH1099",
+      "status": "not probed (service outage)"
+    },
+    {
+      "dep": "MRS",
+      "arr": "TLM",
+      "candidate_for": "return of tlm-mrs (AH1092)",
+      "flight_iata": "AH1093",
+      "status": "not probed (service outage)"
+    }
+  ],
+  "remaining": "13 verified-outbound returns have no recorded flight number to derive candidates from; the 52 listed-pair returns are unscreened. Rerun screen_returns_soar.py when the service recovers, or probe via the in-session tool."
+}


### PR DESCRIPTION
Soar live-ops screening artifact + script. Hypotheses only, per collection-rules: nothing enters route-dataset.json without a citable source. Two strong leads: IST->ORN return operates (AH3025), and the Paris->Batna return flies from ORY not CDG (AH1121), a candidate airport-level route the outbound-only sources could never show.