### PR TITLE
docs(roadmap): log the generator PIP follow-up, close telecom 2.1.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,6 +75,15 @@ reads as further along than it is.
   against Wikidata/OSM before touching either.
   _(logged 2026-07-29)_
 
+## Generators
+
+- [ ] **Nearest-centroid fallback can cross a boundary.** The ooredoo
+  reconciliation (PR #151) pinned 5 provable upstream coordinate errors to
+  commune points but left 3 records whose nearest-centroid assignment lands in
+  a neighbouring commune; the fix is a point-in-polygon pass in the shared
+  commune-point helper so a fallback point is only accepted inside its own
+  commune. _(logged 2026-08-01)_
+
 ## Releases
 
 - [ ] **Umbrella release tag for the current state.** Per-package releases have
@@ -85,6 +94,17 @@ reads as further along than it is.
 ---
 
 ## Recently closed
+
+- **Telecom 2.1.0, the August Mobilis re-survey** (2026-08-02): Mobilis
+  rebuilt its published 5G map (1,621 -> 1,919 sites; first points in Beni
+  Abbes and In Guezzam), taking the package to 3,096 coverage points. The new
+  feed ships 77 exact duplicate rows and 4 out-of-Algeria points; the fetcher
+  now dedupes with its own logged counter, all three agent-browser call sites
+  share one 180s timeout, per-source `retrieved` dates track each fetch run,
+  and `writePackageV2` fails the build if a source would ship with no
+  retrieval date. Truncation of the exactly-2,000-row response was ruled out
+  (the operator map's own JS does one unpaginated fetch; Alger, at the start
+  of the contiguous id block, grew). PRs #152/#153.
 
 - **The core package now ships all 1,541 communes** (was 1,528). The 13
   name-twin communes of the reform wilayas were added from the sourced records


### PR DESCRIPTION
Docs-only alignment after today's telecom 2.1.0 release:

- New **Generators** section logs the nearest-centroid point-in-polygon follow-up the ooredoo reconciliation (PR #151) left open, so it is tracked in the repo instead of session memory.
- **Recently closed** gains the telecom 2.1.0 entry: the August Mobilis re-survey (1,621 to 1,919 sites, 3,096 total), the fetcher dedupe + timeout hardening, per-run retrieved dates, and the writePackageV2 retrieval-date guard. PRs #152/#153.