### PR TITLE
feat(sources): committed raw-capture store (telecom + ecoles reference)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ research/**/*.pdf
 
 # === Research scratch: raw source dumps & landscape notes ===
 # Per-sector scratch, kept local until promoted to a tracked provenance dir.
-# Never commit the raw contents; promote cleaned outputs into a package instead.
+# Since 2026-08-03 canonical raw captures are COMMITTED under sources/ (see
+# sources/README.md); packages migrate there as they are touched. Until a
+# package migrates, its raw pulls stay in these ignored research/ dirs.
 research/_landscape/
 research/_next-dataset/
 research/formation-professionnelle/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's th
 The postal data under `packages/dataset/data/poste/` is a **generated mirror**;
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.
 
+`sources/` holds the **committed raw captures** the fetchers build from — one
+canonical latest capture per (package, source), written only via
+`scripts/lib/source-store.mjs`, so refreshes are reviewable git diffs and every
+converted package rebuilds offline (`--cache`). Rules in
+[`sources/README.md`](sources/README.md). Unconverted packages still cache raw
+pulls in gitignored `research/<pkg>/` until they are next touched.
+
 ## The loop
 
 1. **Branch** off `main`: `fix/commune-name`, `feat/emploi-coords`, `chore/ci`.

--- a/packages/ecoles/README.ar.md
+++ b/packages/ecoles/README.ar.md
@@ -180,8 +180,8 @@ data/
 3. إزالة تكرار المدرسة نفسها المُخرَّطة كنقطةٍ ومبنى معًا؛
 4. إلحاق البلدية/الولاية بأقرب مركز ثقل بلدية.
 
-تُخزَّن الاستخراجات الخام مؤقتًا ضمن
-[`research/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/research/ecoles).
+يُحفَظ الاستخراج الخام ضمن
+[`sources/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/sources/ecoles).
 
 ## الرخصة والإسناد
 

--- a/packages/ecoles/README.fr.md
+++ b/packages/ecoles/README.fr.md
@@ -191,8 +191,8 @@ Lancez `npm run fetch` pour régénérer toutes les sorties. Le script :
 3. déduplique la même école cartographiée à la fois comme nœud et comme bâtiment ;
 4. attache commune/wilaya par centroïde de commune le plus proche.
 
-Les extractions brutes sont mises en cache sous
-[`research/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/research/ecoles).
+L'extraction brute est conservée sous
+[`sources/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/sources/ecoles).
 
 ## Licence & attribution
 

--- a/packages/ecoles/README.md
+++ b/packages/ecoles/README.md
@@ -185,8 +185,8 @@ Run `npm run fetch` to regenerate every output. It:
 3. de-duplicates the same school mapped as both a node and a building;
 4. attaches commune/wilaya by nearest commune centroid.
 
-Raw source pulls are cached under
-[`research/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/research/ecoles).
+The raw source pull is captured under
+[`sources/ecoles/`](https://github.com/yasserstudio/geoalgeria/tree/main/sources/ecoles).
 
 ## License & attribution
 

--- a/packages/ecoles/scripts/fetch.mjs
+++ b/packages/ecoles/scripts/fetch.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Build Algeria's schools dataset from OpenStreetMap and emit JSON, CSV, and
- * GeoJSON to ../data. The raw source pull is cached under research/ecoles/.
+ * GeoJSON to ../data. The raw source pull is captured to sources/ecoles/.
  *
  * Source:
  *   - OpenStreetMap (ODbL): amenity=school + amenity=kindergarten in Algeria.
@@ -26,19 +26,19 @@
  * effectively exact; commune best-effort).
  *
  * Usage: node scripts/fetch.mjs            # live pull
- *        node scripts/fetch.mjs --cache    # rebuild from research/ecoles/osm-raw.json
+ *        node scripts/fetch.mjs --cache    # rebuild from sources/ecoles/osm.json
  */
 
-import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import https from "node:https";
-import { MIGRATIONS, writePackageV2, resolveDates, carryOverIds, readCommitted, readCacheFile } from "../../../scripts/lib/v2-transforms.mjs";
+import { MIGRATIONS, writePackageV2, resolveDates, carryOverIds, readCommitted } from "../../../scripts/lib/v2-transforms.mjs";
+import { writeCapture, readCapture } from "../../../scripts/lib/source-store.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = join(__dirname, "..", "data");
 const REPO_ROOT = join(__dirname, "..", "..", "..");
-const RESEARCH_DIR = join(REPO_ROOT, "research", "ecoles");
 // Approximate size of the national school network (primaire + moyen +
 // secondaire) per the Ministry of National Education, for honest coverage
 // framing. Deliberately round — it is a reference order-of-magnitude, not a
@@ -138,8 +138,19 @@ async function fetchOSM() {
         }
         const json = JSON.parse(out);
         if (Array.isArray(json.elements) && json.elements.length >= OSM_MIN) {
-          mkdirSync(RESEARCH_DIR, { recursive: true });
-          writeFileSync(join(RESEARCH_DIR, "osm-raw.json"), JSON.stringify(json) + "\n");
+          // Elements are an unordered set; sort the capture (type then id) so
+          // mirror-to-mirror ordering drift never shows up in the git diff.
+          writeCapture(
+            "ecoles",
+            "osm",
+            {
+              ...json,
+              elements: [...json.elements].sort(
+                (a, b) => a.type.localeCompare(b.type) || a.id - b.id,
+              ),
+            },
+            { url: ep, records: json.elements.length },
+          );
           return json.elements;
         }
         console.warn(`  only ${json.elements?.length ?? 0} elements (< ${OSM_MIN}); treating as partial, trying next…`);
@@ -467,12 +478,10 @@ function assignIds(rows) {
 
 // --- main ------------------------------------------------------------------
 async function main() {
-  // Offline replay: rebuild from the committed OSM pull (research/ecoles/osm-raw.json)
+  // Offline replay: rebuild from the committed capture (sources/ecoles/osm.json)
   // with no network — a dead upstream never blocks re-emission.
   const OFFLINE = process.argv.includes("--cache");
-  const osmRaw = OFFLINE
-    ? JSON.parse(readCacheFile(RESEARCH_DIR, "osm-raw.json", "ecoles")).elements
-    : await fetchOSM();
+  const osmRaw = OFFLINE ? readCapture("ecoles", "osm").elements : await fetchOSM();
   let rows = normOSM(osmRaw);
   console.log(`  OSM: ${rows.length} geocoded schools`);
 

--- a/packages/telecom/scripts/fetch.mjs
+++ b/packages/telecom/scripts/fetch.mjs
@@ -11,8 +11,11 @@
 // Output (via the shared v2 writer): data/5g-<operator>.json + csv/ + geojson/
 // mirrors + canonical metadata.json.
 // Writes are all-or-nothing: if any operator fetch fails, nothing is overwritten
-// (so a partial fetch can't silently clobber good committed data).
-// Run: node scripts/fetch.mjs   (or: npm run fetch)
+// (so a partial fetch can't silently clobber good committed data). Raw payloads
+// are the exception: each operator's response is captured to sources/telecom/
+// the moment it arrives, so the evidence survives even an aborted run.
+// Run: node scripts/fetch.mjs            # live pull (captures to sources/telecom/)
+//      node scripts/fetch.mjs --cache    # offline rebuild from sources/telecom/
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -20,6 +23,11 @@ import { dirname, join } from "node:path";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { MIGRATIONS, writePackageV2 } from "../../../scripts/lib/v2-transforms.mjs";
+import { writeCapture, readCapture } from "../../../scripts/lib/source-store.mjs";
+
+// Offline replay: rebuild from the committed captures with no network — a dead
+// or WAF-blocked operator site never blocks re-emission.
+const OFFLINE = process.argv.includes("--cache");
 
 const PKG = join(dirname(fileURLToPath(import.meta.url)), "..");
 const DATA = join(PKG, "data");
@@ -103,21 +111,30 @@ async function get(url, headers = {}) {
 // Requires the `agent-browser` CLI on PATH.
 async function fetchDjezzy() {
   const base = "https://www.djezzy5g.dz";
-  const ab = (...args) => execFileSync("agent-browser", args, { encoding: "utf8", timeout: AB_TIMEOUT_MS });
   let byWilaya;
-  try {
-    ab("open", `${base}/map.html`);
-    ab("wait", "8000"); // let the .enc fetch + decrypt populate `wilayas`
-    // `wilayas` is a top-level `let` (global lexical binding, not a window prop).
-    byWilaya = abEval(
-      "JSON.stringify((typeof wilayas !== 'undefined' && wilayas) || window.wilayas || {})",
-    );
-  } finally {
+  if (OFFLINE) {
+    byWilaya = readCapture("telecom", "djezzy-5g");
+  } else {
+    const ab = (...args) => execFileSync("agent-browser", args, { encoding: "utf8", timeout: AB_TIMEOUT_MS });
     try {
-      ab("close", "--all");
-    } catch {
-      /* ignore */
+      ab("open", `${base}/map.html`);
+      ab("wait", "8000"); // let the .enc fetch + decrypt populate `wilayas`
+      // `wilayas` is a top-level `let` (global lexical binding, not a window prop).
+      byWilaya = abEval(
+        "JSON.stringify((typeof wilayas !== 'undefined' && wilayas) || window.wilayas || {})",
+      );
+    } finally {
+      try {
+        ab("close", "--all");
+      } catch {
+        /* ignore */
+      }
     }
+    // Raw capture before validation, so the evidence survives an aborted run.
+    writeCapture("telecom", "djezzy-5g", byWilaya, {
+      url: `${base}/map.html`,
+      records: Object.values(byWilaya).reduce((n, w) => n + (w.markers?.length ?? 0), 0),
+    });
   }
 
   const sites = [];
@@ -152,12 +169,18 @@ async function fetchDjezzy() {
 
 // ── Mobilis ───────────────────────────────────────────────────────────────────
 async function fetchMobilis() {
-  const res = await get("https://mobilis.dz/map/5g/data", {
-    "X-Requested-With": "XMLHttpRequest",
-    Referer: "https://mobilis.dz/map/5g",
-    Accept: "application/json, text/plain, */*",
-  });
-  const rows = await res.json();
+  let rows;
+  if (OFFLINE) {
+    rows = readCapture("telecom", "mobilis-5g");
+  } else {
+    const res = await get("https://mobilis.dz/map/5g/data", {
+      "X-Requested-With": "XMLHttpRequest",
+      Referer: "https://mobilis.dz/map/5g",
+      Accept: "application/json, text/plain, */*",
+    });
+    rows = await res.json();
+    writeCapture("telecom", "mobilis-5g", rows, { url: "https://mobilis.dz/map/5g/data" });
+  }
   const sites = [];
   // The 2026-08 re-import ships exact duplicate rows (same coords + commune);
   // keep the first of each — they hash to the same id and the writer rejects dupes.
@@ -224,24 +247,36 @@ function abEval(js) {
 
 async function fetchOoredoo() {
   const url = "https://www.ooredoo.dz/fr/particuliers/internet/5g";
-  const ab = (...args) => execFileSync("agent-browser", args, { encoding: "utf8", timeout: AB_TIMEOUT_MS });
-  let rows;
-  try {
-    ab("open", url);
-    ab("wait", "5000");
-    rows = abEval(
-      "fetch(location.origin+'/o/c/communes?pageSize=3000&filter='+encodeURIComponent('(latitude ne 0 or longitude ne 0)')," +
-        "{headers:{Authorization:sessionStorage.getItem('tokenbearer'),Accept:'application/json'}})" +
-        ".then(r=>r.json()).then(d=>JSON.stringify(d.items.map(it=>({" +
-        "w:it.villayaId&&it.villayaId.key,c:it.communeId&&it.communeId.name,lat:it.latitude,lng:it.longitude}))))",
-    );
-  } finally {
+  let items;
+  if (OFFLINE) {
+    items = readCapture("telecom", "ooredoo-5g");
+  } else {
+    const ab = (...args) => execFileSync("agent-browser", args, { encoding: "utf8", timeout: AB_TIMEOUT_MS });
     try {
-      ab("close", "--all");
-    } catch {
-      /* ignore */
+      ab("open", url);
+      ab("wait", "5000");
+      items = abEval(
+        "fetch(location.origin+'/o/c/communes?pageSize=3000&filter='+encodeURIComponent('(latitude ne 0 or longitude ne 0)')," +
+          "{headers:{Authorization:sessionStorage.getItem('tokenbearer'),Accept:'application/json'}})" +
+          ".then(r=>r.json()).then(d=>JSON.stringify(d.items))",
+      );
+    } finally {
+      try {
+        ab("close", "--all");
+      } catch {
+        /* ignore */
+      }
     }
+    writeCapture("telecom", "ooredoo-5g", items, { url });
   }
+  // Projection happens here, in reviewable Node code, not in the browser eval —
+  // the capture keeps the items as received.
+  const rows = items.map((it) => ({
+    w: it.villayaId && it.villayaId.key,
+    c: it.communeId && it.communeId.name,
+    lat: it.latitude,
+    lng: it.longitude,
+  }));
   const sites = [];
   for (const r of rows) {
     const lat = Number(r.lat),

--- a/research/ecoles/SOURCE.md
+++ b/research/ecoles/SOURCE.md
@@ -27,9 +27,9 @@ out center tags;
 
 Live sizing (2026-07-03): **11,633** `amenity=school` + **242** `amenity=kindergarten`
 → **11,830** after de-dup. Endpoints tried in order: `overpass-api.de`,
-`overpass.kumi.systems`, `maps.mail.ru`. The raw pull is cached to
-`research/ecoles/osm-raw.json` at build time (not committed — ~2 MB, reproducible
-via `npm run fetch`).
+`overpass.kumi.systems`, `maps.mail.ru`. The raw pull is captured to
+`sources/ecoles/osm.json` at build time (committed, per `sources/README.md`;
+offline rebuild via `npm run fetch -- --cache`).
 
 ## Method
 

--- a/scripts/lib/source-store.mjs
+++ b/scripts/lib/source-store.mjs
@@ -1,0 +1,144 @@
+// Source store — committed raw captures under sources/<pkg>/.
+//
+// One canonical LATEST capture per (package, source); git history is the
+// archive. Fetchers write through writeCapture() the moment a raw payload
+// arrives (before any validation that might abort the run, so the evidence
+// survives a failed build). Builds read through readCapture() so a dead or
+// WAF-blocked upstream never blocks re-emission.
+//
+// Payloads are serialized with sorted object keys (array order untouched) so
+// a re-fetch that changes nothing produces a byte-identical file and a real
+// upstream change produces a reviewable git diff.
+//
+// Convention details: sources/README.md.
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
+
+const STORE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "sources");
+
+// pkg and source become path segments; keep them to the documented kebab-case
+// so a variable-built name can never escape sources/ or collide with the manifest.
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+function checkName(kind, value) {
+  if (!NAME_RE.test(String(value))) throw new Error(`source store: invalid ${kind} "${value}" (kebab-case only)`);
+  return value;
+}
+
+// Documented ceiling (sources/README.md): beyond this, capture the trimmed
+// projection the build consumes instead of the full pull.
+const SIZE_WARN_BYTES = 20_000_000;
+
+// JSON.stringify with object keys sorted at every depth. Arrays keep their
+// order: for most sources it is meaningful (and fetchers that receive
+// unordered sets should sort before capturing, so reordering noise never
+// reaches the diff).
+export function stableStringify(value, indent = 2) {
+  const sort = (v) => {
+    if (Array.isArray(v)) return v.map(sort);
+    if (v && typeof v === "object") {
+      // Payloads come from JSON parsing, so only plain objects belong here. A
+      // Map/Set/Date would JSON.stringify to "{}" — a silently empty capture —
+      // so refuse loudly instead.
+      const proto = Object.getPrototypeOf(v);
+      if (proto !== Object.prototype && proto !== null)
+        throw new Error(`source store: non-plain object (${v.constructor?.name ?? "unknown"}) in payload`);
+      return Object.fromEntries(
+        Object.keys(v)
+          .sort()
+          .map((k) => [k, sort(v[k])]),
+      );
+    }
+    return v;
+  };
+  return JSON.stringify(sort(value), null, indent);
+}
+
+function manifestPath(pkg) {
+  return join(STORE_ROOT, pkg, "manifest.json");
+}
+
+function readManifest(pkg) {
+  const p = manifestPath(pkg);
+  return existsSync(p) ? JSON.parse(readFileSync(p, "utf-8")) : {};
+}
+
+/**
+ * Persist a raw source payload to sources/<pkg>/<source>.json and record it in
+ * sources/<pkg>/manifest.json.
+ *
+ * @param {string} pkg     package name (directory under sources/)
+ * @param {string} source  capture name, kebab-case, no extension (e.g. "osm", "mobilis-5g")
+ * @param {*}      payload the raw payload as received (post-parse, pre-transform)
+ * @param {object} meta    { url, retrieved?, records?, note? } — url is required;
+ *                         retrieved defaults to today; records defaults to
+ *                         payload.length when the payload is an array.
+ * @returns {string} the path written
+ */
+export function writeCapture(pkg, source, payload, meta) {
+  checkName("pkg", pkg);
+  checkName("source", source);
+  if (!meta || !meta.url) throw new Error(`writeCapture(${pkg}/${source}): meta.url is required`);
+  const dir = join(STORE_ROOT, pkg);
+  mkdirSync(dir, { recursive: true });
+
+  const body = stableStringify(payload) + "\n";
+  if (Buffer.byteLength(body) > SIZE_WARN_BYTES)
+    console.warn(
+      `  ⚠ sources/${pkg}/${source}.json is ${(Buffer.byteLength(body) / 1e6).toFixed(0)} MB (> 20 MB) — capture the trimmed projection instead (sources/README.md)`,
+    );
+  const file = join(dir, `${source}.json`);
+  writeFileSync(file, body);
+
+  const manifest = readManifest(pkg);
+  manifest[source] = {
+    url: meta.url,
+    retrieved: meta.retrieved ?? new Date().toISOString().slice(0, 10),
+    records: meta.records ?? (Array.isArray(payload) ? payload.length : undefined),
+    sha256: createHash("sha256").update(body).digest("hex"),
+    bytes: Buffer.byteLength(body),
+    ...(meta.note ? { note: meta.note } : {}),
+  };
+  writeFileSync(manifestPath(pkg), stableStringify(manifest) + "\n");
+  return file;
+}
+
+/**
+ * Read a capture back. Throws with a run-the-fetcher hint when absent.
+ * @returns {*} the parsed payload
+ */
+export function readCapture(pkg, source) {
+  checkName("pkg", pkg);
+  checkName("source", source);
+  const file = join(STORE_ROOT, pkg, `${source}.json`);
+  let body;
+  try {
+    body = readFileSync(file, "utf-8");
+  } catch (e) {
+    if (e && e.code === "ENOENT")
+      throw new Error(
+        `sources/${pkg}/${source}.json not found — run the package fetcher once to capture it`,
+      );
+    throw e;
+  }
+  // Captures must only be written through writeCapture; a manifest/file hash
+  // mismatch means a hand edit or corruption — refuse to build from it.
+  const meta = readManifest(pkg)[source];
+  if (meta?.sha256) {
+    const actual = createHash("sha256").update(body).digest("hex");
+    if (actual !== meta.sha256)
+      throw new Error(
+        `sources/${pkg}/${source}.json does not match its manifest sha256 — re-run the fetcher (captures are never edited by hand)`,
+      );
+  }
+  return JSON.parse(body);
+}
+
+/** Manifest entry for a capture, or null if never captured. */
+export function captureMeta(pkg, source) {
+  checkName("pkg", pkg);
+  checkName("source", source);
+  return readManifest(pkg)[source] ?? null;
+}

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,0 +1,52 @@
+# sources/ — committed raw captures
+
+The local reference copy of every upstream payload we build from. One canonical
+**latest** capture per (package, source); **git history is the archive**. This
+directory exists so that:
+
+- every dataset can be rebuilt **offline** — a dead, moved, or WAF-blocked
+  upstream (mobilis.dz, mfp.gov.dz) never blocks re-emission;
+- a refresh is a **reviewable diff**: fetch, compare against the stored capture,
+  review the delta, then promote to the package;
+- the raw evidence behind a published record survives, per the provenance
+  posture.
+
+## Layout
+
+```
+sources/<pkg>/<source>.json   # raw payload as received (post-parse, pre-transform)
+sources/<pkg>/manifest.json   # per-source: url, retrieved, records, sha256, bytes
+```
+
+Written only through `scripts/lib/source-store.mjs` (`writeCapture` /
+`readCapture` / `captureMeta`) — never by hand — so serialization stays
+canonical: sorted object keys at every depth, 2-space indent, trailing newline.
+A re-fetch that changes nothing is **byte-identical**; a real upstream change is
+a clean `git diff`. Fetchers receiving unordered sets sort them before
+capturing, so reordering noise never reaches the diff.
+
+## Workflow
+
+1. `npm run fetch` in the package: raw payloads are captured here the moment
+   they arrive (before validation, so evidence survives an aborted run), then
+   transformed into `packages/<pkg>/data/`.
+2. `git diff sources/<pkg>/` shows exactly what the upstream changed.
+3. Review the delta; commit the capture together with the regenerated package.
+4. Offline rebuild: the package's `--cache` mode reads from here, no network.
+
+## Rules
+
+- Latest capture only — history lives in git. Never `<source>-2026-08.json`
+  date-suffixed siblings.
+- Capture the payload **as received** (post-parse, pre-transform). Cleaning
+  belongs in the fetcher's transform step, visible in code review.
+- Captures are not published: nothing here ships to npm or the CDN.
+- Size: captures of a few MB are fine. For an unusually large pull (>20 MB),
+  capture the trimmed projection the build actually consumes and record the
+  trim in the manifest `note`.
+
+## Status
+
+Converted so far: `telecom`, `ecoles` (reference implementations,
+2026-08-03). Remaining packages convert as they are next touched — their raw
+pulls still land in gitignored `research/<pkg>/` until then.

--- a/test/source-store.test.mjs
+++ b/test/source-store.test.mjs
@@ -1,0 +1,76 @@
+// The source store must produce byte-stable captures (sorted keys, canonical
+// layout) and a manifest that round-trips — that stability is what makes a
+// re-fetch diffable at all.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The store roots itself at the repo's sources/; use a throwaway package name
+// so tests never touch real captures.
+import { stableStringify, writeCapture, readCapture, captureMeta } from "../scripts/lib/source-store.mjs";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PKG = `test-tmp-${process.pid}`;
+const DIR = join(REPO, "sources", PKG);
+
+test("stableStringify sorts keys at every depth and leaves array order alone", () => {
+  const a = stableStringify({ b: 1, a: { z: [3, 1, 2], y: 0 } });
+  const b = stableStringify({ a: { y: 0, z: [3, 1, 2] }, b: 1 });
+  assert.equal(a, b);
+  assert.ok(a.indexOf('"a"') < a.indexOf('"b"'));
+  assert.deepEqual(JSON.parse(a).a.z, [3, 1, 2]);
+});
+
+test("writeCapture/readCapture round-trip, manifest fields, byte stability", (t) => {
+  t.after(() => rmSync(DIR, { recursive: true, force: true }));
+
+  const payload = [{ z: 1, a: "é" }, { a: null, z: 2 }];
+  const file = writeCapture(PKG, "demo", payload, { url: "https://example.dz/x", retrieved: "2026-08-03" });
+  assert.ok(existsSync(file));
+
+  // Round-trip
+  assert.deepEqual(readCapture(PKG, "demo"), payload);
+
+  // Manifest
+  const meta = captureMeta(PKG, "demo");
+  assert.equal(meta.url, "https://example.dz/x");
+  assert.equal(meta.retrieved, "2026-08-03");
+  assert.equal(meta.records, 2);
+  assert.match(meta.sha256, /^[0-9a-f]{64}$/);
+  assert.ok(meta.bytes > 0);
+
+  // Re-capture of an identical payload (keys shuffled) is byte-identical.
+  const before = readFileSync(file, "utf-8");
+  writeCapture(PKG, "demo", [{ a: "é", z: 1 }, { z: 2, a: null }], { url: "https://example.dz/x", retrieved: "2026-08-03" });
+  assert.equal(readFileSync(file, "utf-8"), before);
+
+  // A sibling capture merges into the manifest without clobbering the first.
+  writeCapture(PKG, "demo-2", { ok: true }, { url: "https://example.dz/y", retrieved: "2026-08-03" });
+  assert.equal(captureMeta(PKG, "demo").url, "https://example.dz/x");
+  assert.equal(captureMeta(PKG, "demo-2").url, "https://example.dz/y");
+});
+
+test("readCapture on a missing capture explains how to populate it", () => {
+  assert.throws(() => readCapture(PKG, "never-fetched"), /run the package fetcher/);
+  assert.equal(captureMeta(PKG, "never-fetched"), null);
+});
+
+test("hardening: names are validated, non-plain payloads refused, hand edits detected", (t) => {
+  const pkg = `${PKG}-h`;
+  t.after(() => rmSync(join(REPO, "sources", pkg), { recursive: true, force: true }));
+
+  assert.throws(() => writeCapture("../escape", "x", {}, { url: "u" }), /invalid pkg/);
+  assert.throws(() => writeCapture(pkg, "Bad_Name", {}, { url: "u" }), /invalid source/);
+  assert.throws(() => writeCapture(pkg, "map", new Map([["a", 1]]), { url: "u" }), /non-plain object/);
+
+  const file = writeCapture(pkg, "ok", { a: 1 }, { url: "u" });
+  writeFileSync(file, '{\n  "a": 2\n}\n');
+  assert.throws(() => readCapture(pkg, "ok"), /does not match its manifest sha256/);
+});
+
+test("writeCapture requires a source url", () => {
+  assert.throws(() => writeCapture(PKG, "x", {}, {}), /meta\.url is required/);
+  assert.ok(!existsSync(join(DIR, "x.json")));
+});


### PR DESCRIPTION
## What

A local reference layer for raw upstream payloads: `sources/<pkg>/<source>.json` + a per-package manifest, committed to the repo, written only through the new `scripts/lib/source-store.mjs` helper.

- **Fetch once, rebuild offline**: converted packages replay from the store via `--cache` — a dead, moved, or WAF-blocked upstream (mobilis.dz, mfp.gov.dz) never blocks re-emission.
- **Refreshes are reviewable diffs**: canonical serialization (sorted keys at every depth, stable layout) makes a no-change re-fetch byte-identical and a real upstream change a clean `git diff`.
- **Evidence survives aborted runs**: captures are written the moment a payload arrives, before validation.
- Manifest records url / retrieved / records / sha256 / bytes; sha256 is verified on read (hand edits refuse to build); kebab-case name guard; non-plain-payload guard; 20 MB size warning.

## Converted in this PR

- **telecom**: all three operator payloads captured (ooredoo's `{w,c,lat,lng}` projection moved out of the browser eval into Node so the capture is as received); new `--cache` offline replay.
- **ecoles**: raw Overpass pull rerouted from gitignored `research/ecoles/osm-raw.json` to the store (elements sorted type+id so mirror drift never reaches the diff); `--cache` reads from the store.

Remaining packages convert as they are next touched (their raw pulls stay in gitignored `research/<pkg>/` until then). Docs updated: `sources/README.md` (the convention), AGENTS.md, .gitignore, ecoles READMEs (en/fr/ar) + SOURCE.md.

## Verification

- `pnpm test` 131/131 green (5 new store tests: round-trip, byte stability, manifest merge, name/payload guards, sha256 tamper detection)
- `pnpm validate` clean
- 2-agent review (security + code quality) applied pre-merge: name validation, non-plain guard, sha256-on-read, size warning, telecom `--cache`, ooredoo as-received capture, stale-docs sweep