### PR TITLE
fix(generators): point-in-polygon commune join + ferroviaire drift finding

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,12 +77,26 @@ reads as further along than it is.
 
 ## Generators
 
-- [ ] **Nearest-centroid fallback can cross a boundary.** The ooredoo
-  reconciliation (PR #151) pinned 5 provable upstream coordinate errors to
-  commune points but left 3 records whose nearest-centroid assignment lands in
-  a neighbouring commune; the fix is a point-in-polygon pass in the shared
-  commune-point helper so a fallback point is only accepted inside its own
-  commune. _(logged 2026-08-01)_
+- [x] **Nearest-centroid fallback can cross a boundary** — fixed in the shared
+  helper: `attachCommune` now resolves the containing wilaya by point-in-polygon
+  against the 69 boundaries first and restricts the centroid search to it, so
+  the join can never cross a wilaya boundary (commune-level containment stays
+  best-effort; commune polygons don't exist). Data effects land at each
+  package's next refresh — the 3 known ooredoo records (documented in their
+  coverageNote) repair themselves on the next ooredoo fetch. Per-package local
+  copies of `nearestCommune` (djezzy, ooredoo, culture, ecoles,
+  enseignement-superieur) converge on the shared helper as those packages are
+  touched. _(logged 2026-08-01, fixed 2026-08-03)_
+
+- [ ] **Ferroviaire regeneration drifts from the committed dataset.** Discovered
+  while testing the fix above: re-running `packages/ferroviaire/scripts/fetch.mjs`
+  on today's committed research/ferroviaire raws produces 233 coordinate
+  changes, 232 name changes and 18 id add/removes against the committed data —
+  the OSM↔Wikidata merge no longer reproduces what shipped, and the per-wilaya
+  sequential ids reshuffle (the id-churn class the v2 generator rework
+  eliminated elsewhere). Until diagnosed, do NOT regenerate ferroviaire; the
+  regeneration was reverted and only the helper fix shipped.
+  _(logged 2026-08-03)_
 
 ## Releases
 

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -5,9 +5,28 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { loadBoundaries, pointInGeometry } from "../../packages/schema/index.js";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEG = Math.PI / 180;
+
+let WILAYA_BOUNDARIES = null;
+function wilayaBoundaries() {
+  if (!WILAYA_BOUNDARIES) {
+    const fc = JSON.parse(
+      readFileSync(join(REPO_ROOT, "packages", "dataset", "data", "geojson", "wilaya-boundaries.geojson"), "utf-8"),
+    );
+    WILAYA_BOUNDARIES = loadBoundaries(fc);
+  }
+  return WILAYA_BOUNDARIES;
+}
+
+/** Wilaya code whose polygon contains (lat,lng), or null when no polygon does
+ *  (offshore, or just outside the simplified national outline). */
+export function containingWilayaCode(lat, lng) {
+  for (const [code, geom] of wilayaBoundaries()) if (pointInGeometry(lng, lat, geom)) return code;
+  return null;
+}
 
 /** Round to 6 decimals (≈0.1 m), or null. */
 export const round6 = (n) =>
@@ -57,24 +76,35 @@ export function loadCommunes() {
   return out;
 }
 
-/** Nearest commune centroid to (lat,lng) — squared planar distance, cosLat-scaled. */
-export function nearestCommune(lat, lng, communes) {
+/** Nearest commune centroid to (lat,lng) — squared planar distance, cosLat-scaled.
+ *  With `wilayaCode`, only that wilaya's communes are candidates: a point near a
+ *  boundary must not be claimed by the neighbouring wilaya's nearer centroid
+ *  (the ooredoo mislinks, ROADMAP "Generators"). Falls back to the unrestricted
+ *  search if the code matches no commune row. */
+export function nearestCommune(lat, lng, communes, wilayaCode = null) {
+  const w = wilayaCode == null ? null : wcode(wilayaCode);
   let best = null, bestD = Infinity;
   const cosLat = Math.cos(lat * DEG);
   for (const c of communes) {
+    if (w != null && wcode(c.wilaya_code) !== w) continue;
     const dx = (c.longitude - lng) * cosLat;
     const dy = c.latitude - lat;
     const d = dx * dx + dy * dy;
     if (d < bestD) { bestD = d; best = c; }
   }
+  if (!best && w != null) return nearestCommune(lat, lng, communes);
   return best;
 }
 
-/** Attach wilaya_code/commune/commune_code by nearest centroid (mutates rows with lat/lng). */
+/** Attach wilaya_code/commune/commune_code by nearest centroid (mutates rows with
+ *  lat/lng). Point-in-polygon first: when a wilaya polygon contains the point,
+ *  the commune is the nearest centroid WITHIN that wilaya, so the join can never
+ *  cross a wilaya boundary. Commune polygons don't exist in the dataset, so
+ *  commune-level containment stays best-effort (documented in LINKAGE). */
 export function attachCommune(rows, communes = loadCommunes()) {
   for (const r of rows) {
     if (!Number.isFinite(r.lat) || !Number.isFinite(r.lng)) continue;
-    const c = nearestCommune(r.lat, r.lng, communes);
+    const c = nearestCommune(r.lat, r.lng, communes, containingWilayaCode(r.lat, r.lng));
     if (!c) continue;
     r.wilaya_code = wcode(c.wilaya_code);
     r.commune = c.name_fr;

--- a/test/build-utils-pip.test.mjs
+++ b/test/build-utils-pip.test.mjs
@@ -1,0 +1,47 @@
+// The commune join must not cross a wilaya boundary: a near-boundary point used
+// to be claimed by whichever commune centroid was planar-nearest, wilaya
+// notwithstanding (the 3 ooredoo mislinks, ROADMAP "Generators"). attachCommune
+// now resolves the containing wilaya by point-in-polygon first and restricts the
+// centroid search to it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  containingWilayaCode,
+  nearestCommune,
+  attachCommune,
+  loadCommunes,
+} from "../scripts/lib/build-utils.mjs";
+
+test("containingWilayaCode resolves interior points and returns null offshore", () => {
+  assert.equal(containingWilayaCode(36.7538, 3.0588), "16"); // central Algiers
+  assert.equal(containingWilayaCode(35.6971, -0.6308), "31"); // central Oran
+  assert.equal(containingWilayaCode(37.5, 3.0), null); // Mediterranean
+});
+
+test("nearestCommune with a wilaya restriction ignores a nearer foreign centroid", () => {
+  const point = { lat: 36.0, lng: 3.0 };
+  const communes = [
+    { name_fr: "Foreign-Near", wilaya_code: "35", latitude: 36.001, longitude: 3.001, code_commune: "3501" },
+    { name_fr: "Own-Far", wilaya_code: "16", latitude: 36.05, longitude: 3.05, code_commune: "1601" },
+  ];
+  assert.equal(nearestCommune(point.lat, point.lng, communes).name_fr, "Foreign-Near");
+  assert.equal(nearestCommune(point.lat, point.lng, communes, "16").name_fr, "Own-Far");
+  // Unmatchable restriction falls back to the unrestricted search, never null.
+  assert.equal(nearestCommune(point.lat, point.lng, communes, "99").name_fr, "Foreign-Near");
+});
+
+test("attachCommune stamps the containing wilaya on real data", () => {
+  const communes = loadCommunes();
+  const rows = [
+    { lat: 36.7538, lng: 3.0588 }, // Algiers
+    { lat: 36.9, lng: 7.7666 }, // Annaba
+  ];
+  attachCommune(rows, communes);
+  assert.equal(rows[0].wilaya_code, "16");
+  assert.equal(rows[1].wilaya_code, "23");
+  for (const r of rows) {
+    assert.ok(r.commune, "commune attached");
+    // The attached commune's wilaya agrees with the polygon that contains the point.
+    assert.equal(r.wilaya_code, containingWilayaCode(r.lat, r.lng));
+  }
+});


### PR DESCRIPTION
## What

Closes the ROADMAP **Generators** item (logged 2026-08-01 after the ooredoo reconciliation):

- `attachCommune` in `scripts/lib/build-utils.mjs` now resolves the **containing wilaya by point-in-polygon** (schema's `loadBoundaries`/`pointInGeometry` over the 69 boundary polygons) and restricts the nearest-centroid commune search to that wilaya. A near-boundary point can no longer be claimed by a neighbouring wilaya's nearer centroid.
- `nearestCommune` gains an optional wilaya restriction with fallback; offshore/outside-outline points keep today's unrestricted behaviour.
- New tests: containment resolution (Algiers/Oran/offshore), foreign-centroid rejection, real-data join agreement.
- Commune-level containment stays best-effort (no commune polygons exist) — documented in the helper.

Data effects land at each package's **next refresh**; the 3 known ooredoo records (flagged in their coverageNote since PR #151) repair on the next ooredoo fetch. Per-package local `nearestCommune` copies converge on the shared helper as packages are touched.

## Finding: ferroviaire regeneration drift (new ROADMAP item, not shipped)

Regenerating the two shared-helper consumers to measure blast radius showed **gares-routieres byte-stable** but **ferroviaire NOT reproducible**: 233 coordinate changes, 232 name changes, 18 id add/removes against committed data — the OSM↔WD merge no longer reproduces what shipped and the per-wilaya sequential ids reshuffle. That regeneration was **reverted**, and the drift is logged in ROADMAP for its own investigation. Nothing in this PR touches package data.

## Verification

- `pnpm test` 134/134 (3 new), `pnpm validate` clean