### PR TITLE
ci(release): GitHub Releases for patches too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,12 +105,12 @@ jobs:
             # never in the title — both are already in the release tag chip + URL.
             RN="node scripts/release-notes.mjs $pkg/CHANGELOG.md $VER $TAG"
 
-            # Patches (docs/corrections) don't get a GitHub Release — the npm version
-            # and the repo's committed data cover them, and the feed stays meaningful.
-            if [ "$($RN is-patch)" = "yes" ]; then
-              echo "skip release: $TAG is a patch — no GitHub Release"
-              continue
-            fi
+            # Patches get a GitHub Release too (decision 2026-08-03): the app's
+            # /changelog ledger is synced from these releases, and a patch that
+            # moves the data date (a correction pass is a live rebuild) left the
+            # ledger provably behind the installed data. The Announce workflow
+            # still only opens Discussions for minor/major, so the feed cost is
+            # one quiet release entry.
 
             NOTES="$RUNNER_TEMP/$(basename "$NAME")-notes.md"  # basename: scoped names contain '/'
             $RN body > "$NOTES" || true


### PR DESCRIPTION
User decision 2026-08-03: drop the patch-skip in the release step. Rationale: the app's /changelog ledger is synced from GH releases, and a patch that legitimately moves the data date (a correction pass is a live rebuild, per resolveDates) leaves the ledger provably behind the installed data — the app's changelog-freshness guard caught exactly this on enseignement-superieur 2.0.1. The two skipped 2.0.1 releases (enseignement-superieur, ooredoo) were backfilled manually with the workflow's own bundle + release-notes recipe; the Announce workflow already handles patches (kit only, no Discussion), verified on both backfills.