### PR TITLE
fix(dataset): office-derived commune postal codes + uniqueness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ MEMORY.md
 
 # === Local-markdown issue tracker (mattpocock/skills workflow — specs & tickets) ===
 .scratch/
+
+# Service-account keys live in the workspace-level keys/ folder; never in a repo
+keys/
+*.iam.gserviceaccount.json

--- a/packages/dataset/data/algeria.json
+++ b/packages/dataset/data/algeria.json
@@ -790,7 +790,7 @@
         "name_ar": "العامرية",
         "wilaya_code": 4,
         "daira": "Sigus",
-        "postal_code": "04004",
+        "postal_code": "04038",
         "latitude": 36.111944,
         "longitude": 6.8822,
         "code_commune": 424
@@ -1232,7 +1232,7 @@
         "name_ar": "لارباع",
         "wilaya_code": 5,
         "daira": "Bouzina",
-        "postal_code": "38022",
+        "postal_code": null,
         "latitude": 35.403889,
         "longitude": 6.11124,
         "code_commune": 561
@@ -1252,7 +1252,7 @@
         "name_ar": "لمسان",
         "wilaya_code": 5,
         "daira": "Ouled Si Slimane",
-        "postal_code": "05088",
+        "postal_code": null,
         "latitude": 35.65611,
         "longitude": 5.79667,
         "code_commune": null
@@ -2388,7 +2388,7 @@
         "name_ar": "تبلبالة",
         "wilaya_code": 8,
         "daira": "Tabelbala",
-        "postal_code": "52029",
+        "postal_code": null,
         "latitude": 29.41005,
         "longitude": -3.25261,
         "code_commune": 812
@@ -2420,7 +2420,7 @@
         "name_ar": "عين الرمانة",
         "wilaya_code": 9,
         "daira": "Mouzaïa",
-        "postal_code": "09028",
+        "postal_code": "09023",
         "latitude": 36.3963569,
         "longitude": 2.6487087,
         "code_commune": 924
@@ -2540,7 +2540,7 @@
         "name_ar": "جبابرة",
         "wilaya_code": 9,
         "daira": "Meftah",
-        "postal_code": "09023",
+        "postal_code": "09028",
         "latitude": 36.58416667,
         "longitude": 3.268903,
         "code_commune": 925
@@ -2722,7 +2722,7 @@
         "name_ar": "عين الترك",
         "wilaya_code": 10,
         "daira": "Bouira",
-        "postal_code": "10120",
+        "postal_code": "10033",
         "latitude": 36.393333,
         "longitude": 3.824722,
         "code_commune": 1029
@@ -3144,7 +3144,7 @@
         "name_ar": "ابلسة",
         "wilaya_code": 11,
         "daira": "Abalessa",
-        "postal_code": "11012",
+        "postal_code": null,
         "latitude": 22.89,
         "longitude": 4.84722,
         "code_commune": null
@@ -5014,7 +5014,7 @@
         "name_ar": "عين بنيان",
         "wilaya_code": 16,
         "daira": "Chéraga",
-        "postal_code": "16095",
+        "postal_code": "16018",
         "latitude": 36.791944,
         "longitude": 2.9337917,
         "code_commune": 1657
@@ -5024,7 +5024,7 @@
         "name_ar": "عين طاية",
         "wilaya_code": 16,
         "daira": "Dar El Beïda",
-        "postal_code": "16116",
+        "postal_code": "16019",
         "latitude": 36.7852529,
         "longitude": 3.2869,
         "code_commune": 1641
@@ -5064,7 +5064,7 @@
         "name_ar": "بابا حسن",
         "wilaya_code": 16,
         "daira": "Draria",
-        "postal_code": "16093",
+        "postal_code": "16081",
         "latitude": 36.694697,
         "longitude": 2.972,
         "code_commune": 1647
@@ -5124,7 +5124,7 @@
         "name_ar": "بئر توتة",
         "wilaya_code": 16,
         "daira": "Birtouta",
-        "postal_code": "16118",
+        "postal_code": "16045",
         "latitude": 36.62815,
         "longitude": 2.99889,
         "code_commune": 1636
@@ -5154,7 +5154,7 @@
         "name_ar": "برج البحري",
         "wilaya_code": 16,
         "daira": "Dar El Beïda",
-        "postal_code": "16017",
+        "postal_code": "16046",
         "latitude": 36.779133,
         "longitude": 3.22248,
         "code_commune": 1642
@@ -5204,7 +5204,7 @@
         "name_ar": "الشراقة",
         "wilaya_code": 16,
         "daira": "Chéraga",
-        "postal_code": "16104",
+        "postal_code": "16014",
         "latitude": 36.7677,
         "longitude": 2.95924,
         "code_commune": 1652
@@ -5244,7 +5244,7 @@
         "name_ar": "الدويرة",
         "wilaya_code": 16,
         "daira": "Draria",
-        "postal_code": "16121",
+        "postal_code": null,
         "latitude": 36.67,
         "longitude": 2.9275836,
         "code_commune": 1648
@@ -5254,7 +5254,7 @@
         "name_ar": "الدرارية",
         "wilaya_code": 16,
         "daira": "Draria",
-        "postal_code": "16097",
+        "postal_code": "16050",
         "latitude": 36.7172858,
         "longitude": 3.0025615,
         "code_commune": 1649
@@ -5264,7 +5264,7 @@
         "name_ar": "العاشور",
         "wilaya_code": 16,
         "daira": "Draria",
-        "postal_code": "16049",
+        "postal_code": "16104",
         "latitude": 36.7285583,
         "longitude": 2.9825559,
         "code_commune": 1654
@@ -5314,7 +5314,7 @@
         "name_ar": "المرسى",
         "wilaya_code": 16,
         "daira": "Dar El Beïda",
-        "postal_code": "16036",
+        "postal_code": "16115",
         "latitude": 36.8111249,
         "longitude": 3.254722,
         "code_commune": 1643
@@ -5344,7 +5344,7 @@
         "name_ar": "هراوة",
         "wilaya_code": 16,
         "daira": "Rouïba",
-        "postal_code": "16046",
+        "postal_code": null,
         "latitude": 36.77278,
         "longitude": 3.253056,
         "code_commune": 1639
@@ -5414,7 +5414,7 @@
         "name_ar": "محمد بلوزداد",
         "wilaya_code": 16,
         "daira": "Hussein Dey",
-        "postal_code": "16244",
+        "postal_code": null,
         "latitude": 36.75354,
         "longitude": 3.06228,
         "code_commune": null
@@ -5454,7 +5454,7 @@
         "name_ar": "اولاد شبل",
         "wilaya_code": 16,
         "daira": "Birtouta",
-        "postal_code": "16099",
+        "postal_code": "16118",
         "latitude": 36.6044691,
         "longitude": 2.9875565,
         "code_commune": 1635
@@ -5494,7 +5494,7 @@
         "name_ar": "رغاية",
         "wilaya_code": 16,
         "daira": "Rouïba",
-        "postal_code": "16115",
+        "postal_code": "16036",
         "latitude": 36.7359,
         "longitude": 3.3402,
         "code_commune": 1640
@@ -5504,7 +5504,7 @@
         "name_ar": "الرويبة",
         "wilaya_code": 16,
         "daira": "Rouïba",
-        "postal_code": "16019",
+        "postal_code": "16017",
         "latitude": 36.7259091,
         "longitude": 3.28079,
         "code_commune": 1638
@@ -5514,7 +5514,7 @@
         "name_ar": "السحاولة",
         "wilaya_code": 16,
         "daira": "Bir Mourad Raïs",
-        "postal_code": "16062",
+        "postal_code": null,
         "latitude": 36.7046,
         "longitude": 3.0085182,
         "code_commune": 1645
@@ -5564,7 +5564,7 @@
         "name_ar": "تسالة المرجة",
         "wilaya_code": 16,
         "daira": "Birtouta",
-        "postal_code": "16045",
+        "postal_code": "16099",
         "latitude": 36.6222556,
         "longitude": 2.9225893,
         "code_commune": 1634
@@ -5918,7 +5918,7 @@
         "name_ar": "أراقن سويسي",
         "wilaya_code": 18,
         "daira": "Ziama Mansouriah",
-        "postal_code": "18032",
+        "postal_code": null,
         "latitude": 36.58616,
         "longitude": 5.58065,
         "code_commune": null
@@ -6772,7 +6772,7 @@
         "name_ar": "أولاد إبراهيم",
         "wilaya_code": 20,
         "daira": "Ouled Brahim",
-        "postal_code": "26036",
+        "postal_code": "20002",
         "latitude": 34.99,
         "longitude": 0.4772,
         "code_commune": 2612
@@ -8292,7 +8292,7 @@
         "name_ar": "ابن باديس",
         "wilaya_code": 25,
         "daira": "Aïn Abid",
-        "postal_code": "25102",
+        "postal_code": "25030",
         "latitude": 36.3173,
         "longitude": 6.83195,
         "code_commune": 2503
@@ -8544,7 +8544,7 @@
         "name_ar": "الحوضان",
         "wilaya_code": 26,
         "daira": "Ouzera",
-        "postal_code": "26060",
+        "postal_code": null,
         "latitude": 36.3369617,
         "longitude": 2.8776638,
         "code_commune": 2616
@@ -10014,7 +10014,7 @@
         "name_ar": "عين الكرمة",
         "wilaya_code": 31,
         "daira": "Boutlelis",
-        "postal_code": null,
+        "postal_code": "31059",
         "latitude": 35.648979,
         "longitude": -0.975702,
         "code_commune": 3125
@@ -10610,7 +10610,7 @@
         "name_ar": "العش",
         "wilaya_code": 34,
         "daira": "El Hamadia",
-        "postal_code": "34006",
+        "postal_code": null,
         "latitude": 36.06386,
         "longitude": 4.6167,
         "code_commune": 3407
@@ -12254,7 +12254,7 @@
         "name_ar": "وادي الكبريت",
         "wilaya_code": 41,
         "daira": "Oum El Adhaim",
-        "postal_code": "41026",
+        "postal_code": null,
         "latitude": 35.933333,
         "longitude": 7.9170713,
         "code_commune": 4118
@@ -12334,7 +12334,7 @@
         "name_ar": "سيدي فرج",
         "wilaya_code": 41,
         "daira": "Merahna",
-        "postal_code": "41026",
+        "postal_code": "41030",
         "latitude": 36.1537121,
         "longitude": 8.1952751,
         "code_commune": 4118
@@ -12384,7 +12384,7 @@
         "name_ar": "الزعرورية",
         "wilaya_code": 41,
         "daira": "Taoura",
-        "postal_code": "41010",
+        "postal_code": "41025",
         "latitude": 36.227222,
         "longitude": 7.957778,
         "code_commune": 4104
@@ -12416,7 +12416,7 @@
         "name_ar": "أغبال",
         "wilaya_code": 42,
         "daira": "Gouraya",
-        "postal_code": "42007",
+        "postal_code": "42035",
         "latitude": 36.502778,
         "longitude": 1.845833,
         "code_commune": 4210
@@ -12426,7 +12426,7 @@
         "name_ar": "أحمر العين",
         "wilaya_code": 42,
         "daira": "Ahmar El Ain",
-        "postal_code": "42024",
+        "postal_code": "42005",
         "latitude": 36.47688,
         "longitude": 2.5693337,
         "code_commune": 4227
@@ -12436,7 +12436,7 @@
         "name_ar": "عين تاقورايت",
         "wilaya_code": 42,
         "daira": "Bou Ismail",
-        "postal_code": "42006",
+        "postal_code": "42023",
         "latitude": 36.5868863,
         "longitude": 2.5842062,
         "code_commune": 4217
@@ -12456,7 +12456,7 @@
         "name_ar": "بني ميلك",
         "wilaya_code": 42,
         "daira": "Damous",
-        "postal_code": "42024",
+        "postal_code": null,
         "latitude": 36.444444,
         "longitude": 1.716667,
         "code_commune": 4241
@@ -12466,7 +12466,7 @@
         "name_ar": "بوهارون",
         "wilaya_code": 42,
         "daira": "Bou Ismail",
-        "postal_code": "42020",
+        "postal_code": "42009",
         "latitude": 36.62503,
         "longitude": 2.6548,
         "code_commune": 4209
@@ -12476,7 +12476,7 @@
         "name_ar": "بواسماعيل",
         "wilaya_code": 42,
         "daira": "Bou Ismail",
-        "postal_code": "42041",
+        "postal_code": "42004",
         "latitude": 36.64262,
         "longitude": 2.6899362,
         "code_commune": 4226
@@ -12496,7 +12496,7 @@
         "name_ar": "الشعيبة",
         "wilaya_code": 42,
         "daira": "Kolea",
-        "postal_code": "42019",
+        "postal_code": "42012",
         "latitude": 36.6251,
         "longitude": 2.729167,
         "code_commune": 4216
@@ -12506,7 +12506,7 @@
         "name_ar": "شرشال",
         "wilaya_code": 42,
         "daira": "Cherchell",
-        "postal_code": "42036",
+        "postal_code": "42002",
         "latitude": 36.605,
         "longitude": 2.19083,
         "code_commune": 4222
@@ -12516,7 +12516,7 @@
         "name_ar": "الداموس",
         "wilaya_code": 42,
         "daira": "Damous",
-        "postal_code": "42040",
+        "postal_code": "42014",
         "latitude": 36.5200245,
         "longitude": 1.704167,
         "code_commune": 4223
@@ -12536,7 +12536,7 @@
         "name_ar": "فوكة",
         "wilaya_code": 42,
         "daira": "Fouka",
-        "postal_code": "42008",
+        "postal_code": "42006",
         "latitude": 36.6667,
         "longitude": 2.742117,
         "code_commune": 4225
@@ -12546,7 +12546,7 @@
         "name_ar": "قوراية",
         "wilaya_code": 42,
         "daira": "Gouraya",
-        "postal_code": "42018",
+        "postal_code": "42007",
         "latitude": 36.5675,
         "longitude": 1.905,
         "code_commune": 4202
@@ -12556,7 +12556,7 @@
         "name_ar": "حجوط",
         "wilaya_code": 42,
         "daira": "Hadjout",
-        "postal_code": "42012",
+        "postal_code": "42001",
         "latitude": 36.51257,
         "longitude": 2.4142888,
         "code_commune": 4212
@@ -12616,7 +12616,7 @@
         "name_ar": "مراد",
         "wilaya_code": 42,
         "daira": "Hadjout",
-        "postal_code": "42003",
+        "postal_code": "42019",
         "latitude": 36.47477,
         "longitude": 2.42625,
         "code_commune": 4224
@@ -12636,7 +12636,7 @@
         "name_ar": "الناظور",
         "wilaya_code": 42,
         "daira": "Sidi Amar",
-        "postal_code": "42014",
+        "postal_code": "42038",
         "latitude": 36.569722,
         "longitude": 2.3123031,
         "code_commune": 4215
@@ -12676,7 +12676,7 @@
         "name_ar": "سيدي عامر",
         "wilaya_code": 42,
         "daira": "Sidi Amar",
-        "postal_code": "42023",
+        "postal_code": "42020",
         "latitude": 36.5330597,
         "longitude": 2.306389,
         "code_commune": 4213
@@ -12718,7 +12718,7 @@
         "name_ar": "عين البيضاء أحريش",
         "wilaya_code": 43,
         "daira": "Aïn Beida Harriche",
-        "postal_code": "43033",
+        "postal_code": "43014",
         "latitude": 36.3959678,
         "longitude": 5.893333,
         "code_commune": 4319
@@ -12808,7 +12808,7 @@
         "name_ar": "العياضي برباس",
         "wilaya_code": 43,
         "daira": "Aïn Beida Harriche",
-        "postal_code": "43009",
+        "postal_code": "43050",
         "latitude": 36.440278,
         "longitude": 5.9130761,
         "code_commune": 4315
@@ -12968,7 +12968,7 @@
         "name_ar": "تسالة لمطاعي",
         "wilaya_code": 43,
         "daira": "Terrai Bainen",
-        "postal_code": "43007",
+        "postal_code": null,
         "latitude": 36.495833,
         "longitude": 6.32488,
         "code_commune": 4308
@@ -13008,7 +13008,7 @@
         "name_ar": "يحي بني قشة",
         "wilaya_code": 43,
         "daira": "Ferdjioua",
-        "postal_code": "43015",
+        "postal_code": "43019",
         "latitude": 36.235278,
         "longitude": 5.592778,
         "code_commune": 4305
@@ -13140,7 +13140,7 @@
         "name_ar": "بئر ولد خليفة",
         "wilaya_code": 44,
         "daira": "Hammam Righa",
-        "postal_code": "44002",
+        "postal_code": null,
         "latitude": 36.183333,
         "longitude": 2.2333333,
         "code_commune": 4410
@@ -13210,7 +13210,7 @@
         "name_ar": "جندل",
         "wilaya_code": 44,
         "daira": "Djendel",
-        "postal_code": "44023",
+        "postal_code": "44005",
         "latitude": 36.218611,
         "longitude": 2.4137,
         "code_commune": 4405
@@ -13250,7 +13250,7 @@
         "name_ar": "الماين",
         "wilaya_code": 44,
         "daira": "Miliana",
-        "postal_code": "44020",
+        "postal_code": "44051",
         "latitude": 36.145,
         "longitude": 1.758333,
         "code_commune": 4423
@@ -13432,7 +13432,7 @@
         "name_ar": "عسلة",
         "wilaya_code": 45,
         "daira": "Assela",
-        "postal_code": "45030",
+        "postal_code": "45012",
         "latitude": 33.016667,
         "longitude": -0.083333333,
         "code_commune": 4504
@@ -13442,7 +13442,7 @@
         "name_ar": "جنين بورزق",
         "wilaya_code": 45,
         "daira": "Moghrar",
-        "postal_code": "45030",
+        "postal_code": null,
         "latitude": 32.3709321,
         "longitude": -0.804719988,
         "code_commune": 4504
@@ -13512,7 +13512,7 @@
         "name_ar": "سفيسيفة",
         "wilaya_code": 45,
         "daira": "Sfissifa",
-        "postal_code": "45001",
+        "postal_code": "45021",
         "latitude": 32.733333,
         "longitude": -0.868889,
         "code_commune": 4503
@@ -13564,7 +13564,7 @@
         "name_ar": "عين الكيحل",
         "wilaya_code": 46,
         "daira": "Aïn Kihal",
-        "postal_code": "46045",
+        "postal_code": "46008",
         "latitude": 35.204444,
         "longitude": -1.196111,
         "code_commune": 4622
@@ -13624,7 +13624,7 @@
         "name_ar": "شعبة اللحم",
         "wilaya_code": 46,
         "daira": "El Malah",
-        "postal_code": "46033",
+        "postal_code": null,
         "latitude": 35.33619,
         "longitude": -1.1015,
         "code_commune": 4605
@@ -13644,7 +13644,7 @@
         "name_ar": "العامرية",
         "wilaya_code": 46,
         "daira": "El Amria",
-        "postal_code": "46022",
+        "postal_code": "46006",
         "latitude": 35.524726,
         "longitude": -1.016,
         "code_commune": 4606
@@ -13654,7 +13654,7 @@
         "name_ar": "المالح",
         "wilaya_code": 46,
         "daira": "El Malah",
-        "postal_code": "46016",
+        "postal_code": null,
         "latitude": 35.388333,
         "longitude": -1.094444,
         "code_commune": 4607
@@ -13784,7 +13784,7 @@
         "name_ar": "سيدي ورياش",
         "wilaya_code": 46,
         "daira": "Oulhaca El Gheraba",
-        "postal_code": "46033",
+        "postal_code": null,
         "latitude": 35.1862547,
         "longitude": -1.5087605,
         "code_commune": 4605
@@ -13856,7 +13856,7 @@
         "name_ar": "ضاية بن ضحوة",
         "wilaya_code": 47,
         "daira": "Daia Ben Dahoua",
-        "postal_code": "47012",
+        "postal_code": null,
         "latitude": 32.536944,
         "longitude": 3.605556,
         "code_commune": 4707
@@ -13866,7 +13866,7 @@
         "name_ar": "العطف",
         "wilaya_code": 47,
         "daira": "Bounoura",
-        "postal_code": "58006",
+        "postal_code": "47012",
         "latitude": 32.4766504,
         "longitude": 3.74788,
         "code_commune": 4712
@@ -13876,7 +13876,7 @@
         "name_ar": "القرارة",
         "wilaya_code": 47,
         "daira": "El Guerrara",
-        "postal_code": "58001",
+        "postal_code": "47004",
         "latitude": 32.790278,
         "longitude": 4.4882869,
         "code_commune": 4702
@@ -13958,7 +13958,7 @@
         "name_ar": "عين طارق",
         "wilaya_code": 48,
         "daira": "Aïn Tarek",
-        "postal_code": "48016",
+        "postal_code": "48015",
         "latitude": 35.781388,
         "longitude": 1.1302226,
         "code_commune": 4815
@@ -14048,7 +14048,7 @@
         "name_ar": "الحاسي",
         "wilaya_code": 48,
         "daira": "Ammi Moussa",
-        "postal_code": "48067",
+        "postal_code": "48046",
         "latitude": 35.7425,
         "longitude": 1.11143,
         "code_commune": 4804
@@ -14068,7 +14068,7 @@
         "name_ar": "القطار",
         "wilaya_code": 48,
         "daira": "Mazouna",
-        "postal_code": "48051",
+        "postal_code": "48016",
         "latitude": 36.19112,
         "longitude": 0.8160086,
         "code_commune": 4816
@@ -14088,7 +14088,7 @@
         "name_ar": "حد الشكالة",
         "wilaya_code": 48,
         "daira": "Aïn Tarek",
-        "postal_code": "48003",
+        "postal_code": null,
         "latitude": 35.679167,
         "longitude": 1.147222,
         "code_commune": 4808
@@ -14138,7 +14138,7 @@
         "name_ar": "مديونة",
         "wilaya_code": 48,
         "daira": "Sidi M'Hamed Ben Ali",
-        "postal_code": "48015",
+        "postal_code": "48011",
         "latitude": 36.12445404,
         "longitude": 0.747250618,
         "code_commune": 4819
@@ -14208,7 +14208,7 @@
         "name_ar": "أولاد يعيش",
         "wilaya_code": 48,
         "daira": "Ammi Moussa",
-        "postal_code": "48039",
+        "postal_code": "48019",
         "latitude": 35.8266,
         "longitude": 0.961111,
         "code_commune": 4813
@@ -14278,7 +14278,7 @@
         "name_ar": "سيدي امحمد بن عودة",
         "wilaya_code": 48,
         "daira": "El Matmar",
-        "postal_code": "48033",
+        "postal_code": "48030",
         "latitude": 35.60409,
         "longitude": 0.58874,
         "code_commune": 4824
@@ -14524,7 +14524,7 @@
         "name_ar": "رأس الميعاد",
         "wilaya_code": 51,
         "daira": "Sidi Khaled",
-        "postal_code": "05087",
+        "postal_code": "51062",
         "latitude": 34.185603,
         "longitude": 4.4514,
         "code_commune": 515
@@ -14742,7 +14742,7 @@
         "name_ar": "بلدة اعمر",
         "wilaya_code": 55,
         "daira": "Tamacine",
-        "postal_code": "55005",
+        "postal_code": null,
         "latitude": 32.95138889,
         "longitude": 5.980556,
         "code_commune": 5507
@@ -14802,7 +14802,7 @@
         "name_ar": "سيدي سليمان",
         "wilaya_code": 55,
         "daira": "Megarine",
-        "postal_code": "55008",
+        "postal_code": "55037",
         "latitude": 33.28886,
         "longitude": 6.09254,
         "code_commune": 3010
@@ -14874,7 +14874,7 @@
         "name_ar": "برج الحواس",
         "wilaya_code": 56,
         "daira": "Djanet",
-        "postal_code": "56008",
+        "postal_code": null,
         "latitude": 24.882778,
         "longitude": 8.434444,
         "code_commune": 5601
@@ -14998,7 +14998,7 @@
         "name_ar": "المنيعة",
         "wilaya_code": 58,
         "daira": "El Meniaa",
-        "postal_code": "58001",
+        "postal_code": null,
         "latitude": 30.57556,
         "longitude": 2.885833333,
         "code_commune": 5801
@@ -15018,7 +15018,7 @@
         "name_ar": "حاسي القارة",
         "wilaya_code": 58,
         "daira": "El Meniaa",
-        "postal_code": "58006",
+        "postal_code": null,
         "latitude": 30.552222,
         "longitude": 2.915,
         "code_commune": 5803
@@ -15041,7 +15041,7 @@
         "name_ar": "أفلو",
         "wilaya_code": 59,
         "daira": "Aflou",
-        "postal_code": "03001",
+        "postal_code": null,
         "latitude": 34.11279,
         "longitude": 2.1019,
         "code_commune": 319
@@ -15051,7 +15051,7 @@
         "name_ar": "عين سيدي علي",
         "wilaya_code": 59,
         "daira": "Gueltat Sidi Saad",
-        "postal_code": "03028",
+        "postal_code": null,
         "latitude": 34.156872,
         "longitude": 1.542386,
         "code_commune": 311
@@ -15061,7 +15061,7 @@
         "name_ar": "بريدة",
         "wilaya_code": 59,
         "daira": "Brida",
-        "postal_code": "03005",
+        "postal_code": null,
         "latitude": 33.906111,
         "longitude": 1.784444,
         "code_commune": 313
@@ -15071,7 +15071,7 @@
         "name_ar": "البيضاء",
         "wilaya_code": 59,
         "daira": "Aflou",
-        "postal_code": "03013",
+        "postal_code": null,
         "latitude": 34.47475,
         "longitude": 2.17408,
         "code_commune": 312
@@ -15081,7 +15081,7 @@
         "name_ar": "الغيشة",
         "wilaya_code": 59,
         "daira": "El Ghicha",
-        "postal_code": "03023",
+        "postal_code": null,
         "latitude": 33.930145,
         "longitude": 2.140703,
         "code_commune": 314
@@ -15091,7 +15091,7 @@
         "name_ar": "قلتة سيدي سعد",
         "wilaya_code": 59,
         "daira": "Gueltat Sidi Saad",
-        "postal_code": "03025",
+        "postal_code": null,
         "latitude": 34.2961,
         "longitude": 1.94667,
         "code_commune": 310
@@ -15101,7 +15101,7 @@
         "name_ar": "الحاج مشري",
         "wilaya_code": 59,
         "daira": "Hadj Mechri",
-        "postal_code": "03038",
+        "postal_code": null,
         "latitude": 33.9571296,
         "longitude": 1.5992068,
         "code_commune": 315
@@ -15111,7 +15111,7 @@
         "name_ar": "وادي مزي",
         "wilaya_code": 59,
         "daira": "Aflou",
-        "postal_code": "03041",
+        "postal_code": null,
         "latitude": 33.92422,
         "longitude": 2.4369,
         "code_commune": 322
@@ -15121,7 +15121,7 @@
         "name_ar": "وادي مرة",
         "wilaya_code": 59,
         "daira": "Aflou",
-        "postal_code": "03027",
+        "postal_code": null,
         "latitude": 34.1666669,
         "longitude": 2.3166669,
         "code_commune": 321
@@ -15131,7 +15131,7 @@
         "name_ar": "سبقاق",
         "wilaya_code": 59,
         "daira": "El Ghicha",
-        "postal_code": "03003",
+        "postal_code": null,
         "latitude": 34.02958,
         "longitude": 1.92798,
         "code_commune": 302
@@ -15141,7 +15141,7 @@
         "name_ar": "سيدي بوزيد",
         "wilaya_code": 59,
         "daira": "Brida",
-        "postal_code": "03007",
+        "postal_code": null,
         "latitude": 34.342777,
         "longitude": 2.261389,
         "code_commune": 308
@@ -15151,7 +15151,7 @@
         "name_ar": "تاويالة",
         "wilaya_code": 59,
         "daira": "Hadj Mechri",
-        "postal_code": "03026",
+        "postal_code": null,
         "latitude": 33.87186,
         "longitude": 1.8606,
         "code_commune": 317
@@ -15174,7 +15174,7 @@
         "name_ar": "عزيل عبد القادر",
         "wilaya_code": 60,
         "daira": "Azil Abdelkader",
-        "postal_code": "05087",
+        "postal_code": null,
         "latitude": 35.3667,
         "longitude": 5.1833,
         "code_commune": 515
@@ -15184,7 +15184,7 @@
         "name_ar": "بريكة",
         "wilaya_code": 60,
         "daira": "Barika",
-        "postal_code": "05001",
+        "postal_code": null,
         "latitude": 35.3972,
         "longitude": 5.3658,
         "code_commune": 542
@@ -15194,7 +15194,7 @@
         "name_ar": "بيطام",
         "wilaya_code": 60,
         "daira": "Barika",
-        "postal_code": "05045",
+        "postal_code": null,
         "latitude": 35.0333,
         "longitude": 5.3,
         "code_commune": 514
@@ -15204,7 +15204,7 @@
         "name_ar": "الجزار",
         "wilaya_code": 60,
         "daira": "Seggana",
-        "postal_code": "05046",
+        "postal_code": null,
         "latitude": 35.50956,
         "longitude": 5.26679,
         "code_commune": 543
@@ -15214,7 +15214,7 @@
         "name_ar": "إمدوكل",
         "wilaya_code": 60,
         "daira": "Barika",
-        "postal_code": "05037",
+        "postal_code": null,
         "latitude": 35.121,
         "longitude": 5.485278,
         "code_commune": 555
@@ -15224,7 +15224,7 @@
         "name_ar": "أولاد عمار",
         "wilaya_code": 60,
         "daira": "Azil Abdelkader",
-        "postal_code": "05121",
+        "postal_code": null,
         "latitude": 35.15,
         "longitude": 5.34,
         "code_commune": 556
@@ -15234,7 +15234,7 @@
         "name_ar": "سقانة",
         "wilaya_code": 60,
         "daira": "Seggana",
-        "postal_code": "05027",
+        "postal_code": null,
         "latitude": 35.365555,
         "longitude": 5.575,
         "code_commune": 529
@@ -15244,7 +15244,7 @@
         "name_ar": "تيلاطو",
         "wilaya_code": 60,
         "daira": "Tilatou",
-        "postal_code": "05127",
+        "postal_code": null,
         "latitude": 35.329167,
         "longitude": 5.8667,
         "code_commune": 518
@@ -15267,7 +15267,7 @@
         "name_ar": "عين زعطوط",
         "wilaya_code": 61,
         "daira": "El Kantara",
-        "postal_code": "07013",
+        "postal_code": null,
         "latitude": 34.9080556,
         "longitude": 5.83,
         "code_commune": 718
@@ -15277,7 +15277,7 @@
         "name_ar": "برانيس",
         "wilaya_code": 61,
         "daira": "Djemorah",
-        "postal_code": "07023",
+        "postal_code": null,
         "latitude": 34.99338,
         "longitude": 5.775,
         "code_commune": 7003
@@ -15287,7 +15287,7 @@
         "name_ar": "جمورة",
         "wilaya_code": 61,
         "daira": "Djemorah",
-        "postal_code": "07025",
+        "postal_code": null,
         "latitude": 35.1026843,
         "longitude": 5.864722,
         "code_commune": 720
@@ -15297,7 +15297,7 @@
         "name_ar": "القنطرة",
         "wilaya_code": 61,
         "daira": "El Kantara",
-        "postal_code": "07008",
+        "postal_code": null,
         "latitude": 35.192365,
         "longitude": 5.6668306,
         "code_commune": 717
@@ -15307,7 +15307,7 @@
         "name_ar": "الوطاية",
         "wilaya_code": 61,
         "daira": "El Outaya",
-        "postal_code": "07026",
+        "postal_code": null,
         "latitude": 35.03412,
         "longitude": 5.59517,
         "code_commune": 716
@@ -15330,7 +15330,7 @@
         "name_ar": "بئر العاتر",
         "wilaya_code": 62,
         "daira": "Bir El Ater",
-        "postal_code": "12001",
+        "postal_code": null,
         "latitude": 34.74488,
         "longitude": 8.06,
         "code_commune": 1202
@@ -15340,7 +15340,7 @@
         "name_ar": "العقلة المالحة",
         "wilaya_code": 62,
         "daira": "Negrine",
-        "postal_code": "12043",
+        "postal_code": null,
         "latitude": 35.121944,
         "longitude": 7.9402184,
         "code_commune": 1215
@@ -15350,7 +15350,7 @@
         "name_ar": "فركان",
         "wilaya_code": 62,
         "daira": "Bir El Ater",
-        "postal_code": "12044",
+        "postal_code": null,
         "latitude": 34.56233,
         "longitude": 7.412222,
         "code_commune": 1228
@@ -15360,7 +15360,7 @@
         "name_ar": "نقرين",
         "wilaya_code": 62,
         "daira": "Negrine",
-        "postal_code": "12024",
+        "postal_code": null,
         "latitude": 34.48593,
         "longitude": 7.5193093,
         "code_commune": 1209
@@ -15383,7 +15383,7 @@
         "name_ar": "البويهي",
         "wilaya_code": 63,
         "daira": "Sidi Djillali",
-        "postal_code": "13066",
+        "postal_code": null,
         "latitude": 34.41389,
         "longitude": -1.68583,
         "code_commune": null
@@ -15393,7 +15393,7 @@
         "name_ar": "العريشة",
         "wilaya_code": 63,
         "daira": "El Aricha",
-        "postal_code": "13031",
+        "postal_code": null,
         "latitude": 34.22259,
         "longitude": -1.257,
         "code_commune": 1332
@@ -15403,7 +15403,7 @@
         "name_ar": "القور",
         "wilaya_code": 63,
         "daira": "El Aricha",
-        "postal_code": "13034",
+        "postal_code": null,
         "latitude": 34.63797,
         "longitude": -1.15296,
         "code_commune": 1310
@@ -15413,7 +15413,7 @@
         "name_ar": "سيدي الجيلالي",
         "wilaya_code": 63,
         "daira": "Sidi Djillali",
-        "postal_code": "13043",
+        "postal_code": null,
         "latitude": 34.4609,
         "longitude": -1.5664,
         "code_commune": 1341
@@ -15436,7 +15436,7 @@
         "name_ar": "بوقرة",
         "wilaya_code": 64,
         "daira": "Zmalet El Emir Abdelkader",
-        "postal_code": "14018",
+        "postal_code": null,
         "latitude": 35.553353,
         "longitude": 1.967282,
         "code_commune": 1440
@@ -15446,7 +15446,7 @@
         "name_ar": "حمادية",
         "wilaya_code": 64,
         "daira": "Rechaiga",
-        "postal_code": "14020",
+        "postal_code": null,
         "latitude": 35.45918,
         "longitude": 1.87316,
         "code_commune": 1435
@@ -15456,7 +15456,7 @@
         "name_ar": "قصر الشلالة",
         "wilaya_code": 64,
         "daira": "Ksar Chellala",
-        "postal_code": "14002",
+        "postal_code": null,
         "latitude": 35.21222,
         "longitude": 2.3189,
         "code_commune": 1429
@@ -15466,7 +15466,7 @@
         "name_ar": "الرشايقة",
         "wilaya_code": 64,
         "daira": "Rechaiga",
-        "postal_code": "14026",
+        "postal_code": null,
         "latitude": 35.4081,
         "longitude": 1.9739,
         "code_commune": 1430
@@ -15476,7 +15476,7 @@
         "name_ar": "سرغين",
         "wilaya_code": 64,
         "daira": "Ksar Chellala",
-        "postal_code": "14051",
+        "postal_code": null,
         "latitude": 35.254444,
         "longitude": 2.30861,
         "code_commune": 1439
@@ -15486,7 +15486,7 @@
         "name_ar": "زمالة الأمير عبد القادر",
         "wilaya_code": 64,
         "daira": "Ksar Chellala",
-        "postal_code": "14038",
+        "postal_code": null,
         "latitude": 34.89336,
         "longitude": 2.31,
         "code_commune": 1409
@@ -15509,7 +15509,7 @@
         "name_ar": "عين فقه",
         "wilaya_code": 65,
         "daira": "Sidi Laadjel",
-        "postal_code": "17040",
+        "postal_code": null,
         "latitude": 35.433333,
         "longitude": 3.583333333,
         "code_commune": 1735
@@ -15519,7 +15519,7 @@
         "name_ar": "عين وسارة",
         "wilaya_code": 65,
         "daira": "Aïn Oussera",
-        "postal_code": "17001",
+        "postal_code": null,
         "latitude": 35.4542653,
         "longitude": 2.904444,
         "code_commune": 1731
@@ -15529,7 +15529,7 @@
         "name_ar": "بنهار",
         "wilaya_code": 65,
         "daira": "Aïn Oussera",
-        "postal_code": "17043",
+        "postal_code": null,
         "latitude": 35.4859395,
         "longitude": 3.1081,
         "code_commune": 1732
@@ -15539,7 +15539,7 @@
         "name_ar": "بيرين",
         "wilaya_code": 65,
         "daira": "Birine",
-        "postal_code": "17014",
+        "postal_code": null,
         "latitude": 35.6383108,
         "longitude": 3.2869,
         "code_commune": 1708
@@ -15549,7 +15549,7 @@
         "name_ar": "بويرة الأحداب",
         "wilaya_code": 65,
         "daira": "Bouira Lahdab",
-        "postal_code": "17044",
+        "postal_code": null,
         "latitude": 35.243889,
         "longitude": 3.75,
         "code_commune": 1709
@@ -15559,7 +15559,7 @@
         "name_ar": "الخميس",
         "wilaya_code": 65,
         "daira": "Birine",
-        "postal_code": "17051",
+        "postal_code": null,
         "latitude": 35.5397,
         "longitude": 2.515833,
         "code_commune": 1711
@@ -15569,7 +15569,7 @@
         "name_ar": "قرنيني",
         "wilaya_code": 65,
         "daira": "Aïn Oussera",
-        "postal_code": "17054",
+        "postal_code": null,
         "latitude": 35.19970336,
         "longitude": 2.682895682,
         "code_commune": 1721
@@ -15579,7 +15579,7 @@
         "name_ar": "حد الصحاري",
         "wilaya_code": 65,
         "daira": "Bouira Lahdab",
-        "postal_code": "17022",
+        "postal_code": null,
         "latitude": 35.35056,
         "longitude": 3.3609,
         "code_commune": 1720
@@ -15589,7 +15589,7 @@
         "name_ar": "حاسي فدول",
         "wilaya_code": 65,
         "daira": "Sidi Laadjel",
-        "postal_code": "17056",
+        "postal_code": null,
         "latitude": 35.436666,
         "longitude": 2.2142,
         "code_commune": 1733
@@ -15599,7 +15599,7 @@
         "name_ar": "سيدي لعجال",
         "wilaya_code": 65,
         "daira": "Sidi Laadjel",
-        "postal_code": "17024",
+        "postal_code": null,
         "latitude": 35.438055,
         "longitude": 2.5,
         "code_commune": 1719
@@ -15622,7 +15622,7 @@
         "name_ar": "عمورة",
         "wilaya_code": 66,
         "daira": "Amourah",
-        "postal_code": "17042",
+        "postal_code": null,
         "latitude": 34.354444,
         "longitude": 3.87083333,
         "code_commune": 1734
@@ -15632,7 +15632,7 @@
         "name_ar": "دلدول",
         "wilaya_code": 66,
         "daira": "Messaad",
-        "postal_code": "17415",
+        "postal_code": null,
         "latitude": 34.20519,
         "longitude": 3.25311,
         "code_commune": 1729
@@ -15642,7 +15642,7 @@
         "name_ar": "فيض البطمة",
         "wilaya_code": 66,
         "daira": "Sed Rahal",
-        "postal_code": "17021",
+        "postal_code": null,
         "latitude": 34.527777,
         "longitude": 3.781944,
         "code_commune": 1707
@@ -15652,7 +15652,7 @@
         "name_ar": "قطارة",
         "wilaya_code": 66,
         "daira": "Messaad",
-        "postal_code": "17055",
+        "postal_code": null,
         "latitude": 33.158611,
         "longitude": 4.685277,
         "code_commune": 1718
@@ -15662,7 +15662,7 @@
         "name_ar": "مسعد",
         "wilaya_code": 66,
         "daira": "Messaad",
-        "postal_code": "17003",
+        "postal_code": null,
         "latitude": 34.15429,
         "longitude": 3.50309,
         "code_commune": 1717
@@ -15672,7 +15672,7 @@
         "name_ar": "أم العظام",
         "wilaya_code": 66,
         "daira": "Selmana",
-        "postal_code": "17061",
+        "postal_code": null,
         "latitude": 33.720277,
         "longitude": 4.53056,
         "code_commune": 1724
@@ -15682,7 +15682,7 @@
         "name_ar": "سد الرحال",
         "wilaya_code": 66,
         "daira": "Sed Rahal",
-        "postal_code": "17062",
+        "postal_code": null,
         "latitude": 33.948333,
         "longitude": 3.231111,
         "code_commune": 1706
@@ -15692,7 +15692,7 @@
         "name_ar": "سلمانة",
         "wilaya_code": 66,
         "daira": "Selmana",
-        "postal_code": "17063",
+        "postal_code": null,
         "latitude": 34.16440361,
         "longitude": 3.562011761,
         "code_commune": 1722
@@ -15715,7 +15715,7 @@
         "name_ar": "عين بوسيف",
         "wilaya_code": 67,
         "daira": "Aïn Boucif",
-        "postal_code": "26005",
+        "postal_code": null,
         "latitude": 35.89123,
         "longitude": 3.1585,
         "code_commune": 2604
@@ -15725,7 +15725,7 @@
         "name_ar": "عين اقصير",
         "wilaya_code": 67,
         "daira": "Chellalet El Adhaoura",
-        "postal_code": "26048",
+        "postal_code": null,
         "latitude": 35.818653,
         "longitude": 3.470555,
         "code_commune": 2641
@@ -15735,7 +15735,7 @@
         "name_ar": "عزيز",
         "wilaya_code": 67,
         "daira": "Aziz",
-        "postal_code": "26040",
+        "postal_code": null,
         "latitude": 35.816667,
         "longitude": 2.45,
         "code_commune": 2632
@@ -15745,7 +15745,7 @@
         "name_ar": "بوغار",
         "wilaya_code": 67,
         "daira": "Boghar",
-        "postal_code": "26013",
+        "postal_code": null,
         "latitude": 35.911389,
         "longitude": 2.71667,
         "code_commune": 2625
@@ -15755,7 +15755,7 @@
         "name_ar": "بوعيش",
         "wilaya_code": 67,
         "daira": "Chahbounia",
-        "postal_code": "26054",
+        "postal_code": null,
         "latitude": 35.552778,
         "longitude": 2.1731,
         "code_commune": 2610
@@ -15765,7 +15765,7 @@
         "name_ar": "بوغزول",
         "wilaya_code": 67,
         "daira": "Chahbounia",
-        "postal_code": "26023",
+        "postal_code": null,
         "latitude": 35.7533117,
         "longitude": 2.7381672,
         "code_commune": 2651
@@ -15775,7 +15775,7 @@
         "name_ar": "الشهبونية",
         "wilaya_code": 67,
         "daira": "Chahbounia",
-        "postal_code": "26026",
+        "postal_code": null,
         "latitude": 35.54472221,
         "longitude": 2.603333,
         "code_commune": 2638
@@ -15785,7 +15785,7 @@
         "name_ar": "شلالة العذاورة",
         "wilaya_code": 67,
         "daira": "Chellalet El Adhaoura",
-        "postal_code": "26007",
+        "postal_code": null,
         "latitude": 35.94,
         "longitude": 3.4139,
         "code_commune": 2618
@@ -15795,7 +15795,7 @@
         "name_ar": "شنيقل",
         "wilaya_code": 67,
         "daira": "Chellalet El Adhaoura",
-        "postal_code": "26057",
+        "postal_code": null,
         "latitude": 35.922222,
         "longitude": 3.5667,
         "code_commune": 2640
@@ -15805,7 +15805,7 @@
         "name_ar": "دراق",
         "wilaya_code": 67,
         "daira": "Aziz",
-        "postal_code": "26015",
+        "postal_code": null,
         "latitude": 35.908611,
         "longitude": 2.38778,
         "code_commune": 2608
@@ -15815,7 +15815,7 @@
         "name_ar": "العوينات",
         "wilaya_code": 67,
         "daira": "Aïn Boucif",
-        "postal_code": "26059",
+        "postal_code": null,
         "latitude": 35.3344,
         "longitude": 3.035556,
         "code_commune": 2657
@@ -15825,7 +15825,7 @@
         "name_ar": "الكاف الاخضر",
         "wilaya_code": 67,
         "daira": "Aïn Boucif",
-        "postal_code": "26051",
+        "postal_code": null,
         "latitude": 35.923333,
         "longitude": 3.2875,
         "code_commune": 2617
@@ -15835,7 +15835,7 @@
         "name_ar": "قصر البخاري",
         "wilaya_code": 67,
         "daira": "Ksar El Boukhari",
-        "postal_code": "26003",
+        "postal_code": null,
         "latitude": 35.88889,
         "longitude": 2.74905,
         "code_commune": 2635
@@ -15845,7 +15845,7 @@
         "name_ar": "مفاتحة",
         "wilaya_code": 67,
         "daira": "Ksar El Boukhari",
-        "postal_code": "26049",
+        "postal_code": null,
         "latitude": 35.8831842,
         "longitude": 2.9346884,
         "code_commune": 2649
@@ -15855,7 +15855,7 @@
         "name_ar": "أولاد عنتر",
         "wilaya_code": 67,
         "daira": "Boghar",
-        "postal_code": "26035",
+        "postal_code": null,
         "latitude": 35.9951773,
         "longitude": 2.60231,
         "code_commune": 2658
@@ -15865,7 +15865,7 @@
         "name_ar": "أولاد امعرف",
         "wilaya_code": 67,
         "daira": "Aïn Boucif",
-        "postal_code": "26038",
+        "postal_code": null,
         "latitude": 35.872222,
         "longitude": 3.1585,
         "code_commune": 2603
@@ -15875,7 +15875,7 @@
         "name_ar": "أولاد هلال",
         "wilaya_code": 67,
         "daira": "Boghar",
-        "postal_code": "26037",
+        "postal_code": null,
         "latitude": 35.9370104,
         "longitude": 2.4980197,
         "code_commune": 2622
@@ -15885,7 +15885,7 @@
         "name_ar": "أم الجليل",
         "wilaya_code": 67,
         "daira": "Aziz",
-        "postal_code": "26065",
+        "postal_code": null,
         "latitude": 35.8275,
         "longitude": 2.6239,
         "code_commune": 2642
@@ -15895,7 +15895,7 @@
         "name_ar": "السانق",
         "wilaya_code": 67,
         "daira": "Ksar El Boukhari",
-        "postal_code": "26067",
+        "postal_code": null,
         "latitude": 35.8514,
         "longitude": 3.253056,
         "code_commune": 2664
@@ -15905,7 +15905,7 @@
         "name_ar": "سيدي دامد",
         "wilaya_code": 67,
         "daira": "Aïn Boucif",
-        "postal_code": "26069",
+        "postal_code": null,
         "latitude": 35.8706421,
         "longitude": 3.2531476,
         "code_commune": 2631
@@ -15915,7 +15915,7 @@
         "name_ar": "تفراوت",
         "wilaya_code": 67,
         "daira": "Chellalet El Adhaoura",
-        "postal_code": "26074",
+        "postal_code": null,
         "latitude": 36.0877,
         "longitude": 3.4308,
         "code_commune": 2623
@@ -15938,7 +15938,7 @@
         "name_ar": "عين الملح",
         "wilaya_code": 68,
         "daira": "Aïn El Melh",
-        "postal_code": "28004",
+        "postal_code": null,
         "latitude": 34.8470491,
         "longitude": 4.1634964,
         "code_commune": 2841
@@ -15948,7 +15948,7 @@
         "name_ar": "عين فارس",
         "wilaya_code": 68,
         "daira": "Aïn El Melh",
-        "postal_code": "28023",
+        "postal_code": null,
         "latitude": 35.03583333,
         "longitude": 4.428333333,
         "code_commune": 2837
@@ -15958,7 +15958,7 @@
         "name_ar": "عين الريش",
         "wilaya_code": 68,
         "daira": "Aïn El Melh",
-        "postal_code": "28025",
+        "postal_code": null,
         "latitude": 34.680794,
         "longitude": 4.096956,
         "code_commune": 2844
@@ -15968,7 +15968,7 @@
         "name_ar": "بن سرور",
         "wilaya_code": 68,
         "daira": "Ben Srour",
-        "postal_code": "28009",
+        "postal_code": null,
         "latitude": 35.0404431,
         "longitude": 4.5633795,
         "code_commune": 2824
@@ -15978,7 +15978,7 @@
         "name_ar": "بن زوه",
         "wilaya_code": 68,
         "daira": "Ouled Sidi Brahim",
-        "postal_code": "28028",
+        "postal_code": null,
         "latitude": 35.438055,
         "longitude": 4.383333,
         "code_commune": 2835
@@ -15988,7 +15988,7 @@
         "name_ar": "بئر فضة",
         "wilaya_code": 68,
         "daira": "Aïn El Melh",
-        "postal_code": "28043",
+        "postal_code": null,
         "latitude": 34.82,
         "longitude": 3.899444,
         "code_commune": 2836
@@ -15998,7 +15998,7 @@
         "name_ar": "بوسعادة",
         "wilaya_code": 68,
         "daira": "Bou Saada",
-        "postal_code": "28001",
+        "postal_code": null,
         "latitude": 35.219167,
         "longitude": 4.17402,
         "code_commune": 2820
@@ -16008,7 +16008,7 @@
         "name_ar": "جبل مساعد",
         "wilaya_code": 68,
         "daira": "Djebel Messaad",
-        "postal_code": "28024",
+        "postal_code": null,
         "latitude": 34.991121,
         "longitude": 4.092493,
         "code_commune": 2847
@@ -16018,7 +16018,7 @@
         "name_ar": "الهامل",
         "wilaya_code": 68,
         "daira": "Bou Saada",
-        "postal_code": "28015",
+        "postal_code": null,
         "latitude": 35.1283,
         "longitude": 4.083333,
         "code_commune": 2827
@@ -16028,7 +16028,7 @@
         "name_ar": "الحوامد",
         "wilaya_code": 68,
         "daira": "Khoubana",
-        "postal_code": "28063",
+        "postal_code": null,
         "latitude": 35.2917758,
         "longitude": 4.53358,
         "code_commune": 2826
@@ -16038,7 +16038,7 @@
         "name_ar": "خبانة",
         "wilaya_code": 68,
         "daira": "Khoubana",
-        "postal_code": "28030",
+        "postal_code": null,
         "latitude": 35.31444444,
         "longitude": 4.566944,
         "code_commune": 2807
@@ -16048,7 +16048,7 @@
         "name_ar": "مسيف",
         "wilaya_code": 68,
         "daira": "Khoubana",
-        "postal_code": "28029",
+        "postal_code": null,
         "latitude": 35.3281,
         "longitude": 4.8,
         "code_commune": 2808
@@ -16058,7 +16058,7 @@
         "name_ar": "امجدل",
         "wilaya_code": 68,
         "daira": "Medjedel",
-        "postal_code": "28016",
+        "postal_code": null,
         "latitude": 34.9611111,
         "longitude": 3.6793899,
         "code_commune": 2842
@@ -16068,7 +16068,7 @@
         "name_ar": "مناعة",
         "wilaya_code": 68,
         "daira": "Medjedel",
-        "postal_code": "28016",
+        "postal_code": null,
         "latitude": 35.144444,
         "longitude": 3.694444,
         "code_commune": null
@@ -16078,7 +16078,7 @@
         "name_ar": "محمد بوضياف",
         "wilaya_code": 68,
         "daira": "Ben Srour",
-        "postal_code": "28033",
+        "postal_code": null,
         "latitude": 34.8941667,
         "longitude": 4.428611,
         "code_commune": 2834
@@ -16088,7 +16088,7 @@
         "name_ar": "أولاد سيدي ابراهيم",
         "wilaya_code": 68,
         "daira": "Ouled Sidi Brahim",
-        "postal_code": "28032",
+        "postal_code": null,
         "latitude": 35.2992435,
         "longitude": 4.1696166,
         "code_commune": 2821
@@ -16098,7 +16098,7 @@
         "name_ar": "أولاد سليمان",
         "wilaya_code": 68,
         "daira": "Ben Srour",
-        "postal_code": "28031",
+        "postal_code": null,
         "latitude": 34.91609,
         "longitude": 4.73694444,
         "code_commune": 2825
@@ -16108,7 +16108,7 @@
         "name_ar": "ولتام",
         "wilaya_code": 68,
         "daira": "Bou Saada",
-        "postal_code": "28054",
+        "postal_code": null,
         "latitude": 35.0350816,
         "longitude": 5.3360215,
         "code_commune": 2846
@@ -16118,7 +16118,7 @@
         "name_ar": "سيدي عامر",
         "wilaya_code": 68,
         "daira": "Sidi Ameur",
-        "postal_code": "28035",
+        "postal_code": null,
         "latitude": 35.367,
         "longitude": 3.9,
         "code_commune": null
@@ -16138,7 +16138,7 @@
         "name_ar": "سليم",
         "wilaya_code": 68,
         "daira": "Djebel Messaad",
-        "postal_code": "28037",
+        "postal_code": null,
         "latitude": 34.938889,
         "longitude": 3.734722222,
         "code_commune": 2843
@@ -16148,7 +16148,7 @@
         "name_ar": "تامسة",
         "wilaya_code": 68,
         "daira": "Sidi Ameur",
-        "postal_code": "28065",
+        "postal_code": null,
         "latitude": 35.173611,
         "longitude": 3.925556,
         "code_commune": 2823
@@ -16158,7 +16158,7 @@
         "name_ar": "زرزور",
         "wilaya_code": 68,
         "daira": "Ben Srour",
-        "postal_code": "28067",
+        "postal_code": null,
         "latitude": 35.0358333,
         "longitude": 4.433333,
         "code_commune": 2833
@@ -16181,7 +16181,7 @@
         "name_ar": "عين العراك",
         "wilaya_code": 69,
         "daira": "El Abiodh Sidi Cheikh",
-        "postal_code": "32019",
+        "postal_code": null,
         "latitude": 33.4100573,
         "longitude": 0.7385302,
         "code_commune": 3208
@@ -16191,7 +16191,7 @@
         "name_ar": "اربوات",
         "wilaya_code": 69,
         "daira": "El Abiodh Sidi Cheikh",
-        "postal_code": "32005",
+        "postal_code": null,
         "latitude": 33.08833333,
         "longitude": 0.5823,
         "code_commune": 3209
@@ -16201,7 +16201,7 @@
         "name_ar": "بوسمغون",
         "wilaya_code": 69,
         "daira": "Boussemghoun",
-        "postal_code": "32014",
+        "postal_code": null,
         "latitude": 32.8643,
         "longitude": 0.0201,
         "code_commune": 3213
@@ -16211,7 +16211,7 @@
         "name_ar": "شلالة",
         "wilaya_code": 69,
         "daira": "Chellala",
-        "postal_code": "32015",
+        "postal_code": null,
         "latitude": 33.0327072,
         "longitude": 0.0586818,
         "code_commune": 3214
@@ -16221,7 +16221,7 @@
         "name_ar": "البنود",
         "wilaya_code": 69,
         "daira": "El Abiodh Sidi Cheikh",
-        "postal_code": "32025",
+        "postal_code": null,
         "latitude": 32.31222222,
         "longitude": 0.244444,
         "code_commune": 3216
@@ -16231,7 +16231,7 @@
         "name_ar": "المحرة",
         "wilaya_code": 69,
         "daira": "Chellala",
-        "postal_code": "32024",
+        "postal_code": null,
         "latitude": 33.311667,
         "longitude": 0.364444,
         "code_commune": 3219
@@ -16241,7 +16241,7 @@
         "name_ar": "الأبيض سيدي الشيخ",
         "wilaya_code": 69,
         "daira": "El Abiodh Sidi Cheikh",
-        "postal_code": "32003",
+        "postal_code": null,
         "latitude": 32.898611,
         "longitude": 0.544444,
         "code_commune": 3207

--- a/packages/dataset/data/communes_w1_w23.json
+++ b/packages/dataset/data/communes_w1_w23.json
@@ -744,7 +744,7 @@
     "name_ar": "العامرية",
     "wilaya_code": 4,
     "daira": "Sigus",
-    "postal_code": "04004",
+    "postal_code": "04038",
     "latitude": 36.111944,
     "longitude": 6.8822,
     "code_commune": 424
@@ -1174,7 +1174,7 @@
     "name_ar": "لارباع",
     "wilaya_code": 5,
     "daira": "Bouzina",
-    "postal_code": "38022",
+    "postal_code": null,
     "latitude": 35.403889,
     "longitude": 6.11124,
     "code_commune": 561
@@ -1194,7 +1194,7 @@
     "name_ar": "لمسان",
     "wilaya_code": 5,
     "daira": "Ouled Si Slimane",
-    "postal_code": "05088",
+    "postal_code": null,
     "latitude": 35.65611,
     "longitude": 5.79667,
     "code_commune": null
@@ -2294,7 +2294,7 @@
     "name_ar": "تبلبالة",
     "wilaya_code": 8,
     "daira": "Tabelbala",
-    "postal_code": "52029",
+    "postal_code": null,
     "latitude": 29.41005,
     "longitude": -3.25261,
     "code_commune": 812
@@ -2314,7 +2314,7 @@
     "name_ar": "عين الرمانة",
     "wilaya_code": 9,
     "daira": "Mouzaïa",
-    "postal_code": "09028",
+    "postal_code": "09023",
     "latitude": 36.3963569,
     "longitude": 2.6487087,
     "code_commune": 924
@@ -2434,7 +2434,7 @@
     "name_ar": "جبابرة",
     "wilaya_code": 9,
     "daira": "Meftah",
-    "postal_code": "09023",
+    "postal_code": "09028",
     "latitude": 36.58416667,
     "longitude": 3.268903,
     "code_commune": 925
@@ -2604,7 +2604,7 @@
     "name_ar": "عين الترك",
     "wilaya_code": 10,
     "daira": "Bouira",
-    "postal_code": "10120",
+    "postal_code": "10033",
     "latitude": 36.393333,
     "longitude": 3.824722,
     "code_commune": 1029
@@ -3014,7 +3014,7 @@
     "name_ar": "ابلسة",
     "wilaya_code": 11,
     "daira": "Abalessa",
-    "postal_code": "11012",
+    "postal_code": null,
     "latitude": 22.89,
     "longitude": 4.84722,
     "code_commune": null
@@ -4824,7 +4824,7 @@
     "name_ar": "عين بنيان",
     "wilaya_code": 16,
     "daira": "Chéraga",
-    "postal_code": "16095",
+    "postal_code": "16018",
     "latitude": 36.791944,
     "longitude": 2.9337917,
     "code_commune": 1657
@@ -4834,7 +4834,7 @@
     "name_ar": "عين طاية",
     "wilaya_code": 16,
     "daira": "Dar El Beïda",
-    "postal_code": "16116",
+    "postal_code": "16019",
     "latitude": 36.7852529,
     "longitude": 3.2869,
     "code_commune": 1641
@@ -4874,7 +4874,7 @@
     "name_ar": "بابا حسن",
     "wilaya_code": 16,
     "daira": "Draria",
-    "postal_code": "16093",
+    "postal_code": "16081",
     "latitude": 36.694697,
     "longitude": 2.972,
     "code_commune": 1647
@@ -4934,7 +4934,7 @@
     "name_ar": "بئر توتة",
     "wilaya_code": 16,
     "daira": "Birtouta",
-    "postal_code": "16118",
+    "postal_code": "16045",
     "latitude": 36.62815,
     "longitude": 2.99889,
     "code_commune": 1636
@@ -4964,7 +4964,7 @@
     "name_ar": "برج البحري",
     "wilaya_code": 16,
     "daira": "Dar El Beïda",
-    "postal_code": "16017",
+    "postal_code": "16046",
     "latitude": 36.779133,
     "longitude": 3.22248,
     "code_commune": 1642
@@ -5014,7 +5014,7 @@
     "name_ar": "الشراقة",
     "wilaya_code": 16,
     "daira": "Chéraga",
-    "postal_code": "16104",
+    "postal_code": "16014",
     "latitude": 36.7677,
     "longitude": 2.95924,
     "code_commune": 1652
@@ -5054,7 +5054,7 @@
     "name_ar": "الدويرة",
     "wilaya_code": 16,
     "daira": "Draria",
-    "postal_code": "16121",
+    "postal_code": null,
     "latitude": 36.67,
     "longitude": 2.9275836,
     "code_commune": 1648
@@ -5064,7 +5064,7 @@
     "name_ar": "الدرارية",
     "wilaya_code": 16,
     "daira": "Draria",
-    "postal_code": "16097",
+    "postal_code": "16050",
     "latitude": 36.7172858,
     "longitude": 3.0025615,
     "code_commune": 1649
@@ -5074,7 +5074,7 @@
     "name_ar": "العاشور",
     "wilaya_code": 16,
     "daira": "Draria",
-    "postal_code": "16049",
+    "postal_code": "16104",
     "latitude": 36.7285583,
     "longitude": 2.9825559,
     "code_commune": 1654
@@ -5124,7 +5124,7 @@
     "name_ar": "المرسى",
     "wilaya_code": 16,
     "daira": "Dar El Beïda",
-    "postal_code": "16036",
+    "postal_code": "16115",
     "latitude": 36.8111249,
     "longitude": 3.254722,
     "code_commune": 1643
@@ -5154,7 +5154,7 @@
     "name_ar": "هراوة",
     "wilaya_code": 16,
     "daira": "Rouïba",
-    "postal_code": "16046",
+    "postal_code": null,
     "latitude": 36.77278,
     "longitude": 3.253056,
     "code_commune": 1639
@@ -5224,7 +5224,7 @@
     "name_ar": "محمد بلوزداد",
     "wilaya_code": 16,
     "daira": "Hussein Dey",
-    "postal_code": "16244",
+    "postal_code": null,
     "latitude": 36.75354,
     "longitude": 3.06228,
     "code_commune": null
@@ -5264,7 +5264,7 @@
     "name_ar": "اولاد شبل",
     "wilaya_code": 16,
     "daira": "Birtouta",
-    "postal_code": "16099",
+    "postal_code": "16118",
     "latitude": 36.6044691,
     "longitude": 2.9875565,
     "code_commune": 1635
@@ -5304,7 +5304,7 @@
     "name_ar": "رغاية",
     "wilaya_code": 16,
     "daira": "Rouïba",
-    "postal_code": "16115",
+    "postal_code": "16036",
     "latitude": 36.7359,
     "longitude": 3.3402,
     "code_commune": 1640
@@ -5314,7 +5314,7 @@
     "name_ar": "الرويبة",
     "wilaya_code": 16,
     "daira": "Rouïba",
-    "postal_code": "16019",
+    "postal_code": "16017",
     "latitude": 36.7259091,
     "longitude": 3.28079,
     "code_commune": 1638
@@ -5324,7 +5324,7 @@
     "name_ar": "السحاولة",
     "wilaya_code": 16,
     "daira": "Bir Mourad Raïs",
-    "postal_code": "16062",
+    "postal_code": null,
     "latitude": 36.7046,
     "longitude": 3.0085182,
     "code_commune": 1645
@@ -5374,7 +5374,7 @@
     "name_ar": "تسالة المرجة",
     "wilaya_code": 16,
     "daira": "Birtouta",
-    "postal_code": "16045",
+    "postal_code": "16099",
     "latitude": 36.6222556,
     "longitude": 2.9225893,
     "code_commune": 1634
@@ -5704,7 +5704,7 @@
     "name_ar": "أراقن سويسي",
     "wilaya_code": 18,
     "daira": "Ziama Mansouriah",
-    "postal_code": "18032",
+    "postal_code": null,
     "latitude": 36.58616,
     "longitude": 5.58065,
     "code_commune": null
@@ -6534,7 +6534,7 @@
     "name_ar": "أولاد إبراهيم",
     "wilaya_code": 20,
     "daira": "Ouled Brahim",
-    "postal_code": "26036",
+    "postal_code": "20002",
     "latitude": 34.99,
     "longitude": 0.4772,
     "code_commune": 2612

--- a/packages/dataset/data/communes_w24_w48.json
+++ b/packages/dataset/data/communes_w24_w48.json
@@ -364,7 +364,7 @@
     "name_ar": "ابن باديس",
     "wilaya_code": 25,
     "daira": "Aïn Abid",
-    "postal_code": "25102",
+    "postal_code": "25030",
     "latitude": 36.3173,
     "longitude": 6.83195,
     "code_commune": 2503
@@ -604,7 +604,7 @@
     "name_ar": "الحوضان",
     "wilaya_code": 26,
     "daira": "Ouzera",
-    "postal_code": "26060",
+    "postal_code": null,
     "latitude": 36.3369617,
     "longitude": 2.8776638,
     "code_commune": 2616
@@ -2014,7 +2014,7 @@
     "name_ar": "عين الكرمة",
     "wilaya_code": 31,
     "daira": "Boutlelis",
-    "postal_code": null,
+    "postal_code": "31059",
     "latitude": 35.648979,
     "longitude": -0.975702,
     "code_commune": 3125
@@ -2574,7 +2574,7 @@
     "name_ar": "العش",
     "wilaya_code": 34,
     "daira": "El Hamadia",
-    "postal_code": "34006",
+    "postal_code": null,
     "latitude": 36.06386,
     "longitude": 4.6167,
     "code_commune": 3407
@@ -4134,7 +4134,7 @@
     "name_ar": "وادي الكبريت",
     "wilaya_code": 41,
     "daira": "Oum El Adhaim",
-    "postal_code": "41026",
+    "postal_code": null,
     "latitude": 35.933333,
     "longitude": 7.9170713,
     "code_commune": 4118
@@ -4214,7 +4214,7 @@
     "name_ar": "سيدي فرج",
     "wilaya_code": 41,
     "daira": "Merahna",
-    "postal_code": "41026",
+    "postal_code": "41030",
     "latitude": 36.1537121,
     "longitude": 8.1952751,
     "code_commune": 4118
@@ -4264,7 +4264,7 @@
     "name_ar": "الزعرورية",
     "wilaya_code": 41,
     "daira": "Taoura",
-    "postal_code": "41010",
+    "postal_code": "41025",
     "latitude": 36.227222,
     "longitude": 7.957778,
     "code_commune": 4104
@@ -4284,7 +4284,7 @@
     "name_ar": "أغبال",
     "wilaya_code": 42,
     "daira": "Gouraya",
-    "postal_code": "42007",
+    "postal_code": "42035",
     "latitude": 36.502778,
     "longitude": 1.845833,
     "code_commune": 4210
@@ -4294,7 +4294,7 @@
     "name_ar": "أحمر العين",
     "wilaya_code": 42,
     "daira": "Ahmar El Ain",
-    "postal_code": "42024",
+    "postal_code": "42005",
     "latitude": 36.47688,
     "longitude": 2.5693337,
     "code_commune": 4227
@@ -4304,7 +4304,7 @@
     "name_ar": "عين تاقورايت",
     "wilaya_code": 42,
     "daira": "Bou Ismail",
-    "postal_code": "42006",
+    "postal_code": "42023",
     "latitude": 36.5868863,
     "longitude": 2.5842062,
     "code_commune": 4217
@@ -4324,7 +4324,7 @@
     "name_ar": "بني ميلك",
     "wilaya_code": 42,
     "daira": "Damous",
-    "postal_code": "42024",
+    "postal_code": null,
     "latitude": 36.444444,
     "longitude": 1.716667,
     "code_commune": 4241
@@ -4334,7 +4334,7 @@
     "name_ar": "بوهارون",
     "wilaya_code": 42,
     "daira": "Bou Ismail",
-    "postal_code": "42020",
+    "postal_code": "42009",
     "latitude": 36.62503,
     "longitude": 2.6548,
     "code_commune": 4209
@@ -4344,7 +4344,7 @@
     "name_ar": "بواسماعيل",
     "wilaya_code": 42,
     "daira": "Bou Ismail",
-    "postal_code": "42041",
+    "postal_code": "42004",
     "latitude": 36.64262,
     "longitude": 2.6899362,
     "code_commune": 4226
@@ -4364,7 +4364,7 @@
     "name_ar": "الشعيبة",
     "wilaya_code": 42,
     "daira": "Kolea",
-    "postal_code": "42019",
+    "postal_code": "42012",
     "latitude": 36.6251,
     "longitude": 2.729167,
     "code_commune": 4216
@@ -4374,7 +4374,7 @@
     "name_ar": "شرشال",
     "wilaya_code": 42,
     "daira": "Cherchell",
-    "postal_code": "42036",
+    "postal_code": "42002",
     "latitude": 36.605,
     "longitude": 2.19083,
     "code_commune": 4222
@@ -4384,7 +4384,7 @@
     "name_ar": "الداموس",
     "wilaya_code": 42,
     "daira": "Damous",
-    "postal_code": "42040",
+    "postal_code": "42014",
     "latitude": 36.5200245,
     "longitude": 1.704167,
     "code_commune": 4223
@@ -4404,7 +4404,7 @@
     "name_ar": "فوكة",
     "wilaya_code": 42,
     "daira": "Fouka",
-    "postal_code": "42008",
+    "postal_code": "42006",
     "latitude": 36.6667,
     "longitude": 2.742117,
     "code_commune": 4225
@@ -4414,7 +4414,7 @@
     "name_ar": "قوراية",
     "wilaya_code": 42,
     "daira": "Gouraya",
-    "postal_code": "42018",
+    "postal_code": "42007",
     "latitude": 36.5675,
     "longitude": 1.905,
     "code_commune": 4202
@@ -4424,7 +4424,7 @@
     "name_ar": "حجوط",
     "wilaya_code": 42,
     "daira": "Hadjout",
-    "postal_code": "42012",
+    "postal_code": "42001",
     "latitude": 36.51257,
     "longitude": 2.4142888,
     "code_commune": 4212
@@ -4484,7 +4484,7 @@
     "name_ar": "مراد",
     "wilaya_code": 42,
     "daira": "Hadjout",
-    "postal_code": "42003",
+    "postal_code": "42019",
     "latitude": 36.47477,
     "longitude": 2.42625,
     "code_commune": 4224
@@ -4504,7 +4504,7 @@
     "name_ar": "الناظور",
     "wilaya_code": 42,
     "daira": "Sidi Amar",
-    "postal_code": "42014",
+    "postal_code": "42038",
     "latitude": 36.569722,
     "longitude": 2.3123031,
     "code_commune": 4215
@@ -4544,7 +4544,7 @@
     "name_ar": "سيدي عامر",
     "wilaya_code": 42,
     "daira": "Sidi Amar",
-    "postal_code": "42023",
+    "postal_code": "42020",
     "latitude": 36.5330597,
     "longitude": 2.306389,
     "code_commune": 4213
@@ -4574,7 +4574,7 @@
     "name_ar": "عين البيضاء أحريش",
     "wilaya_code": 43,
     "daira": "Aïn Beida Harriche",
-    "postal_code": "43033",
+    "postal_code": "43014",
     "latitude": 36.3959678,
     "longitude": 5.893333,
     "code_commune": 4319
@@ -4664,7 +4664,7 @@
     "name_ar": "العياضي برباس",
     "wilaya_code": 43,
     "daira": "Aïn Beida Harriche",
-    "postal_code": "43009",
+    "postal_code": "43050",
     "latitude": 36.440278,
     "longitude": 5.9130761,
     "code_commune": 4315
@@ -4824,7 +4824,7 @@
     "name_ar": "تسالة لمطاعي",
     "wilaya_code": 43,
     "daira": "Terrai Bainen",
-    "postal_code": "43007",
+    "postal_code": null,
     "latitude": 36.495833,
     "longitude": 6.32488,
     "code_commune": 4308
@@ -4864,7 +4864,7 @@
     "name_ar": "يحي بني قشة",
     "wilaya_code": 43,
     "daira": "Ferdjioua",
-    "postal_code": "43015",
+    "postal_code": "43019",
     "latitude": 36.235278,
     "longitude": 5.592778,
     "code_commune": 4305
@@ -4984,7 +4984,7 @@
     "name_ar": "بئر ولد خليفة",
     "wilaya_code": 44,
     "daira": "Hammam Righa",
-    "postal_code": "44002",
+    "postal_code": null,
     "latitude": 36.183333,
     "longitude": 2.2333333,
     "code_commune": 4410
@@ -5054,7 +5054,7 @@
     "name_ar": "جندل",
     "wilaya_code": 44,
     "daira": "Djendel",
-    "postal_code": "44023",
+    "postal_code": "44005",
     "latitude": 36.218611,
     "longitude": 2.4137,
     "code_commune": 4405
@@ -5094,7 +5094,7 @@
     "name_ar": "الماين",
     "wilaya_code": 44,
     "daira": "Miliana",
-    "postal_code": "44020",
+    "postal_code": "44051",
     "latitude": 36.145,
     "longitude": 1.758333,
     "code_commune": 4423
@@ -5264,7 +5264,7 @@
     "name_ar": "عسلة",
     "wilaya_code": 45,
     "daira": "Assela",
-    "postal_code": "45030",
+    "postal_code": "45012",
     "latitude": 33.016667,
     "longitude": -0.083333333,
     "code_commune": 4504
@@ -5274,7 +5274,7 @@
     "name_ar": "جنين بورزق",
     "wilaya_code": 45,
     "daira": "Moghrar",
-    "postal_code": "45030",
+    "postal_code": null,
     "latitude": 32.3709321,
     "longitude": -0.804719988,
     "code_commune": 4504
@@ -5344,7 +5344,7 @@
     "name_ar": "سفيسيفة",
     "wilaya_code": 45,
     "daira": "Sfissifa",
-    "postal_code": "45001",
+    "postal_code": "45021",
     "latitude": 32.733333,
     "longitude": -0.868889,
     "code_commune": 4503
@@ -5384,7 +5384,7 @@
     "name_ar": "عين الكيحل",
     "wilaya_code": 46,
     "daira": "Aïn Kihal",
-    "postal_code": "46045",
+    "postal_code": "46008",
     "latitude": 35.204444,
     "longitude": -1.196111,
     "code_commune": 4622
@@ -5444,7 +5444,7 @@
     "name_ar": "شعبة اللحم",
     "wilaya_code": 46,
     "daira": "El Malah",
-    "postal_code": "46033",
+    "postal_code": null,
     "latitude": 35.33619,
     "longitude": -1.1015,
     "code_commune": 4605
@@ -5464,7 +5464,7 @@
     "name_ar": "العامرية",
     "wilaya_code": 46,
     "daira": "El Amria",
-    "postal_code": "46022",
+    "postal_code": "46006",
     "latitude": 35.524726,
     "longitude": -1.016,
     "code_commune": 4606
@@ -5474,7 +5474,7 @@
     "name_ar": "المالح",
     "wilaya_code": 46,
     "daira": "El Malah",
-    "postal_code": "46016",
+    "postal_code": null,
     "latitude": 35.388333,
     "longitude": -1.094444,
     "code_commune": 4607
@@ -5604,7 +5604,7 @@
     "name_ar": "سيدي ورياش",
     "wilaya_code": 46,
     "daira": "Oulhaca El Gheraba",
-    "postal_code": "46033",
+    "postal_code": null,
     "latitude": 35.1862547,
     "longitude": -1.5087605,
     "code_commune": 4605
@@ -5664,7 +5664,7 @@
     "name_ar": "ضاية بن ضحوة",
     "wilaya_code": 47,
     "daira": "Daia Ben Dahoua",
-    "postal_code": "47012",
+    "postal_code": null,
     "latitude": 32.536944,
     "longitude": 3.605556,
     "code_commune": 4707
@@ -5674,7 +5674,7 @@
     "name_ar": "العطف",
     "wilaya_code": 47,
     "daira": "Bounoura",
-    "postal_code": "58006",
+    "postal_code": "47012",
     "latitude": 32.4766504,
     "longitude": 3.74788,
     "code_commune": 4712
@@ -5684,7 +5684,7 @@
     "name_ar": "القرارة",
     "wilaya_code": 47,
     "daira": "El Guerrara",
-    "postal_code": "58001",
+    "postal_code": "47004",
     "latitude": 32.790278,
     "longitude": 4.4882869,
     "code_commune": 4702
@@ -5754,7 +5754,7 @@
     "name_ar": "عين طارق",
     "wilaya_code": 48,
     "daira": "Aïn Tarek",
-    "postal_code": "48016",
+    "postal_code": "48015",
     "latitude": 35.781388,
     "longitude": 1.1302226,
     "code_commune": 4815
@@ -5844,7 +5844,7 @@
     "name_ar": "الحاسي",
     "wilaya_code": 48,
     "daira": "Ammi Moussa",
-    "postal_code": "48067",
+    "postal_code": "48046",
     "latitude": 35.7425,
     "longitude": 1.11143,
     "code_commune": 4804
@@ -5864,7 +5864,7 @@
     "name_ar": "القطار",
     "wilaya_code": 48,
     "daira": "Mazouna",
-    "postal_code": "48051",
+    "postal_code": "48016",
     "latitude": 36.19112,
     "longitude": 0.8160086,
     "code_commune": 4816
@@ -5884,7 +5884,7 @@
     "name_ar": "حد الشكالة",
     "wilaya_code": 48,
     "daira": "Aïn Tarek",
-    "postal_code": "48003",
+    "postal_code": null,
     "latitude": 35.679167,
     "longitude": 1.147222,
     "code_commune": 4808
@@ -5934,7 +5934,7 @@
     "name_ar": "مديونة",
     "wilaya_code": 48,
     "daira": "Sidi M'Hamed Ben Ali",
-    "postal_code": "48015",
+    "postal_code": "48011",
     "latitude": 36.12445404,
     "longitude": 0.747250618,
     "code_commune": 4819
@@ -6004,7 +6004,7 @@
     "name_ar": "أولاد يعيش",
     "wilaya_code": 48,
     "daira": "Ammi Moussa",
-    "postal_code": "48039",
+    "postal_code": "48019",
     "latitude": 35.8266,
     "longitude": 0.961111,
     "code_commune": 4813
@@ -6074,7 +6074,7 @@
     "name_ar": "سيدي امحمد بن عودة",
     "wilaya_code": 48,
     "daira": "El Matmar",
-    "postal_code": "48033",
+    "postal_code": "48030",
     "latitude": 35.60409,
     "longitude": 0.58874,
     "code_commune": 4824

--- a/packages/dataset/data/communes_w49_w69.json
+++ b/packages/dataset/data/communes_w49_w69.json
@@ -164,7 +164,7 @@
     "name_ar": "رأس الميعاد",
     "wilaya_code": 51,
     "daira": "Sidi Khaled",
-    "postal_code": "05087",
+    "postal_code": "51062",
     "latitude": 34.185603,
     "longitude": 4.4514,
     "code_commune": 515
@@ -334,7 +334,7 @@
     "name_ar": "بلدة اعمر",
     "wilaya_code": 55,
     "daira": "Tamacine",
-    "postal_code": "55005",
+    "postal_code": null,
     "latitude": 32.95138889,
     "longitude": 5.980556,
     "code_commune": 5507
@@ -394,7 +394,7 @@
     "name_ar": "سيدي سليمان",
     "wilaya_code": 55,
     "daira": "Megarine",
-    "postal_code": "55008",
+    "postal_code": "55037",
     "latitude": 33.28886,
     "longitude": 6.09254,
     "code_commune": 3010
@@ -454,7 +454,7 @@
     "name_ar": "برج الحواس",
     "wilaya_code": 56,
     "daira": "Djanet",
-    "postal_code": "56008",
+    "postal_code": null,
     "latitude": 24.882778,
     "longitude": 8.434444,
     "code_commune": 5601
@@ -554,7 +554,7 @@
     "name_ar": "المنيعة",
     "wilaya_code": 58,
     "daira": "El Meniaa",
-    "postal_code": "58001",
+    "postal_code": null,
     "latitude": 30.57556,
     "longitude": 2.885833333,
     "code_commune": 5801
@@ -574,7 +574,7 @@
     "name_ar": "حاسي القارة",
     "wilaya_code": 58,
     "daira": "El Meniaa",
-    "postal_code": "58006",
+    "postal_code": null,
     "latitude": 30.552222,
     "longitude": 2.915,
     "code_commune": 5803
@@ -584,7 +584,7 @@
     "name_ar": "أفلو",
     "wilaya_code": 59,
     "daira": "Aflou",
-    "postal_code": "03001",
+    "postal_code": null,
     "latitude": 34.11279,
     "longitude": 2.1019,
     "code_commune": 319
@@ -594,7 +594,7 @@
     "name_ar": "عين سيدي علي",
     "wilaya_code": 59,
     "daira": "Gueltat Sidi Saad",
-    "postal_code": "03028",
+    "postal_code": null,
     "latitude": 34.156872,
     "longitude": 1.542386,
     "code_commune": 311
@@ -604,7 +604,7 @@
     "name_ar": "بريدة",
     "wilaya_code": 59,
     "daira": "Brida",
-    "postal_code": "03005",
+    "postal_code": null,
     "latitude": 33.906111,
     "longitude": 1.784444,
     "code_commune": 313
@@ -614,7 +614,7 @@
     "name_ar": "البيضاء",
     "wilaya_code": 59,
     "daira": "Aflou",
-    "postal_code": "03013",
+    "postal_code": null,
     "latitude": 34.47475,
     "longitude": 2.17408,
     "code_commune": 312
@@ -624,7 +624,7 @@
     "name_ar": "الغيشة",
     "wilaya_code": 59,
     "daira": "El Ghicha",
-    "postal_code": "03023",
+    "postal_code": null,
     "latitude": 33.930145,
     "longitude": 2.140703,
     "code_commune": 314
@@ -634,7 +634,7 @@
     "name_ar": "قلتة سيدي سعد",
     "wilaya_code": 59,
     "daira": "Gueltat Sidi Saad",
-    "postal_code": "03025",
+    "postal_code": null,
     "latitude": 34.2961,
     "longitude": 1.94667,
     "code_commune": 310
@@ -644,7 +644,7 @@
     "name_ar": "الحاج مشري",
     "wilaya_code": 59,
     "daira": "Hadj Mechri",
-    "postal_code": "03038",
+    "postal_code": null,
     "latitude": 33.9571296,
     "longitude": 1.5992068,
     "code_commune": 315
@@ -654,7 +654,7 @@
     "name_ar": "وادي مزي",
     "wilaya_code": 59,
     "daira": "Aflou",
-    "postal_code": "03041",
+    "postal_code": null,
     "latitude": 33.92422,
     "longitude": 2.4369,
     "code_commune": 322
@@ -664,7 +664,7 @@
     "name_ar": "وادي مرة",
     "wilaya_code": 59,
     "daira": "Aflou",
-    "postal_code": "03027",
+    "postal_code": null,
     "latitude": 34.1666669,
     "longitude": 2.3166669,
     "code_commune": 321
@@ -674,7 +674,7 @@
     "name_ar": "سبقاق",
     "wilaya_code": 59,
     "daira": "El Ghicha",
-    "postal_code": "03003",
+    "postal_code": null,
     "latitude": 34.02958,
     "longitude": 1.92798,
     "code_commune": 302
@@ -684,7 +684,7 @@
     "name_ar": "سيدي بوزيد",
     "wilaya_code": 59,
     "daira": "Brida",
-    "postal_code": "03007",
+    "postal_code": null,
     "latitude": 34.342777,
     "longitude": 2.261389,
     "code_commune": 308
@@ -694,7 +694,7 @@
     "name_ar": "تاويالة",
     "wilaya_code": 59,
     "daira": "Hadj Mechri",
-    "postal_code": "03026",
+    "postal_code": null,
     "latitude": 33.87186,
     "longitude": 1.8606,
     "code_commune": 317
@@ -704,7 +704,7 @@
     "name_ar": "عزيل عبد القادر",
     "wilaya_code": 60,
     "daira": "Azil Abdelkader",
-    "postal_code": "05087",
+    "postal_code": null,
     "latitude": 35.3667,
     "longitude": 5.1833,
     "code_commune": 515
@@ -714,7 +714,7 @@
     "name_ar": "بريكة",
     "wilaya_code": 60,
     "daira": "Barika",
-    "postal_code": "05001",
+    "postal_code": null,
     "latitude": 35.3972,
     "longitude": 5.3658,
     "code_commune": 542
@@ -724,7 +724,7 @@
     "name_ar": "بيطام",
     "wilaya_code": 60,
     "daira": "Barika",
-    "postal_code": "05045",
+    "postal_code": null,
     "latitude": 35.0333,
     "longitude": 5.3,
     "code_commune": 514
@@ -734,7 +734,7 @@
     "name_ar": "الجزار",
     "wilaya_code": 60,
     "daira": "Seggana",
-    "postal_code": "05046",
+    "postal_code": null,
     "latitude": 35.50956,
     "longitude": 5.26679,
     "code_commune": 543
@@ -744,7 +744,7 @@
     "name_ar": "إمدوكل",
     "wilaya_code": 60,
     "daira": "Barika",
-    "postal_code": "05037",
+    "postal_code": null,
     "latitude": 35.121,
     "longitude": 5.485278,
     "code_commune": 555
@@ -754,7 +754,7 @@
     "name_ar": "أولاد عمار",
     "wilaya_code": 60,
     "daira": "Azil Abdelkader",
-    "postal_code": "05121",
+    "postal_code": null,
     "latitude": 35.15,
     "longitude": 5.34,
     "code_commune": 556
@@ -764,7 +764,7 @@
     "name_ar": "سقانة",
     "wilaya_code": 60,
     "daira": "Seggana",
-    "postal_code": "05027",
+    "postal_code": null,
     "latitude": 35.365555,
     "longitude": 5.575,
     "code_commune": 529
@@ -774,7 +774,7 @@
     "name_ar": "تيلاطو",
     "wilaya_code": 60,
     "daira": "Tilatou",
-    "postal_code": "05127",
+    "postal_code": null,
     "latitude": 35.329167,
     "longitude": 5.8667,
     "code_commune": 518
@@ -784,7 +784,7 @@
     "name_ar": "عين زعطوط",
     "wilaya_code": 61,
     "daira": "El Kantara",
-    "postal_code": "07013",
+    "postal_code": null,
     "latitude": 34.9080556,
     "longitude": 5.83,
     "code_commune": 718
@@ -794,7 +794,7 @@
     "name_ar": "برانيس",
     "wilaya_code": 61,
     "daira": "Djemorah",
-    "postal_code": "07023",
+    "postal_code": null,
     "latitude": 34.99338,
     "longitude": 5.775,
     "code_commune": 7003
@@ -804,7 +804,7 @@
     "name_ar": "جمورة",
     "wilaya_code": 61,
     "daira": "Djemorah",
-    "postal_code": "07025",
+    "postal_code": null,
     "latitude": 35.1026843,
     "longitude": 5.864722,
     "code_commune": 720
@@ -814,7 +814,7 @@
     "name_ar": "القنطرة",
     "wilaya_code": 61,
     "daira": "El Kantara",
-    "postal_code": "07008",
+    "postal_code": null,
     "latitude": 35.192365,
     "longitude": 5.6668306,
     "code_commune": 717
@@ -824,7 +824,7 @@
     "name_ar": "الوطاية",
     "wilaya_code": 61,
     "daira": "El Outaya",
-    "postal_code": "07026",
+    "postal_code": null,
     "latitude": 35.03412,
     "longitude": 5.59517,
     "code_commune": 716
@@ -834,7 +834,7 @@
     "name_ar": "بئر العاتر",
     "wilaya_code": 62,
     "daira": "Bir El Ater",
-    "postal_code": "12001",
+    "postal_code": null,
     "latitude": 34.74488,
     "longitude": 8.06,
     "code_commune": 1202
@@ -844,7 +844,7 @@
     "name_ar": "العقلة المالحة",
     "wilaya_code": 62,
     "daira": "Negrine",
-    "postal_code": "12043",
+    "postal_code": null,
     "latitude": 35.121944,
     "longitude": 7.9402184,
     "code_commune": 1215
@@ -854,7 +854,7 @@
     "name_ar": "فركان",
     "wilaya_code": 62,
     "daira": "Bir El Ater",
-    "postal_code": "12044",
+    "postal_code": null,
     "latitude": 34.56233,
     "longitude": 7.412222,
     "code_commune": 1228
@@ -864,7 +864,7 @@
     "name_ar": "نقرين",
     "wilaya_code": 62,
     "daira": "Negrine",
-    "postal_code": "12024",
+    "postal_code": null,
     "latitude": 34.48593,
     "longitude": 7.5193093,
     "code_commune": 1209
@@ -874,7 +874,7 @@
     "name_ar": "البويهي",
     "wilaya_code": 63,
     "daira": "Sidi Djillali",
-    "postal_code": "13066",
+    "postal_code": null,
     "latitude": 34.41389,
     "longitude": -1.68583,
     "code_commune": null
@@ -884,7 +884,7 @@
     "name_ar": "العريشة",
     "wilaya_code": 63,
     "daira": "El Aricha",
-    "postal_code": "13031",
+    "postal_code": null,
     "latitude": 34.22259,
     "longitude": -1.257,
     "code_commune": 1332
@@ -894,7 +894,7 @@
     "name_ar": "القور",
     "wilaya_code": 63,
     "daira": "El Aricha",
-    "postal_code": "13034",
+    "postal_code": null,
     "latitude": 34.63797,
     "longitude": -1.15296,
     "code_commune": 1310
@@ -904,7 +904,7 @@
     "name_ar": "سيدي الجيلالي",
     "wilaya_code": 63,
     "daira": "Sidi Djillali",
-    "postal_code": "13043",
+    "postal_code": null,
     "latitude": 34.4609,
     "longitude": -1.5664,
     "code_commune": 1341
@@ -914,7 +914,7 @@
     "name_ar": "بوقرة",
     "wilaya_code": 64,
     "daira": "Zmalet El Emir Abdelkader",
-    "postal_code": "14018",
+    "postal_code": null,
     "latitude": 35.553353,
     "longitude": 1.967282,
     "code_commune": 1440
@@ -924,7 +924,7 @@
     "name_ar": "حمادية",
     "wilaya_code": 64,
     "daira": "Rechaiga",
-    "postal_code": "14020",
+    "postal_code": null,
     "latitude": 35.45918,
     "longitude": 1.87316,
     "code_commune": 1435
@@ -934,7 +934,7 @@
     "name_ar": "قصر الشلالة",
     "wilaya_code": 64,
     "daira": "Ksar Chellala",
-    "postal_code": "14002",
+    "postal_code": null,
     "latitude": 35.21222,
     "longitude": 2.3189,
     "code_commune": 1429
@@ -944,7 +944,7 @@
     "name_ar": "الرشايقة",
     "wilaya_code": 64,
     "daira": "Rechaiga",
-    "postal_code": "14026",
+    "postal_code": null,
     "latitude": 35.4081,
     "longitude": 1.9739,
     "code_commune": 1430
@@ -954,7 +954,7 @@
     "name_ar": "سرغين",
     "wilaya_code": 64,
     "daira": "Ksar Chellala",
-    "postal_code": "14051",
+    "postal_code": null,
     "latitude": 35.254444,
     "longitude": 2.30861,
     "code_commune": 1439
@@ -964,7 +964,7 @@
     "name_ar": "زمالة الأمير عبد القادر",
     "wilaya_code": 64,
     "daira": "Ksar Chellala",
-    "postal_code": "14038",
+    "postal_code": null,
     "latitude": 34.89336,
     "longitude": 2.31,
     "code_commune": 1409
@@ -974,7 +974,7 @@
     "name_ar": "عين فقه",
     "wilaya_code": 65,
     "daira": "Sidi Laadjel",
-    "postal_code": "17040",
+    "postal_code": null,
     "latitude": 35.433333,
     "longitude": 3.583333333,
     "code_commune": 1735
@@ -984,7 +984,7 @@
     "name_ar": "عين وسارة",
     "wilaya_code": 65,
     "daira": "Aïn Oussera",
-    "postal_code": "17001",
+    "postal_code": null,
     "latitude": 35.4542653,
     "longitude": 2.904444,
     "code_commune": 1731
@@ -994,7 +994,7 @@
     "name_ar": "بنهار",
     "wilaya_code": 65,
     "daira": "Aïn Oussera",
-    "postal_code": "17043",
+    "postal_code": null,
     "latitude": 35.4859395,
     "longitude": 3.1081,
     "code_commune": 1732
@@ -1004,7 +1004,7 @@
     "name_ar": "بيرين",
     "wilaya_code": 65,
     "daira": "Birine",
-    "postal_code": "17014",
+    "postal_code": null,
     "latitude": 35.6383108,
     "longitude": 3.2869,
     "code_commune": 1708
@@ -1014,7 +1014,7 @@
     "name_ar": "بويرة الأحداب",
     "wilaya_code": 65,
     "daira": "Bouira Lahdab",
-    "postal_code": "17044",
+    "postal_code": null,
     "latitude": 35.243889,
     "longitude": 3.75,
     "code_commune": 1709
@@ -1024,7 +1024,7 @@
     "name_ar": "الخميس",
     "wilaya_code": 65,
     "daira": "Birine",
-    "postal_code": "17051",
+    "postal_code": null,
     "latitude": 35.5397,
     "longitude": 2.515833,
     "code_commune": 1711
@@ -1034,7 +1034,7 @@
     "name_ar": "قرنيني",
     "wilaya_code": 65,
     "daira": "Aïn Oussera",
-    "postal_code": "17054",
+    "postal_code": null,
     "latitude": 35.19970336,
     "longitude": 2.682895682,
     "code_commune": 1721
@@ -1044,7 +1044,7 @@
     "name_ar": "حد الصحاري",
     "wilaya_code": 65,
     "daira": "Bouira Lahdab",
-    "postal_code": "17022",
+    "postal_code": null,
     "latitude": 35.35056,
     "longitude": 3.3609,
     "code_commune": 1720
@@ -1054,7 +1054,7 @@
     "name_ar": "حاسي فدول",
     "wilaya_code": 65,
     "daira": "Sidi Laadjel",
-    "postal_code": "17056",
+    "postal_code": null,
     "latitude": 35.436666,
     "longitude": 2.2142,
     "code_commune": 1733
@@ -1064,7 +1064,7 @@
     "name_ar": "سيدي لعجال",
     "wilaya_code": 65,
     "daira": "Sidi Laadjel",
-    "postal_code": "17024",
+    "postal_code": null,
     "latitude": 35.438055,
     "longitude": 2.5,
     "code_commune": 1719
@@ -1074,7 +1074,7 @@
     "name_ar": "عمورة",
     "wilaya_code": 66,
     "daira": "Amourah",
-    "postal_code": "17042",
+    "postal_code": null,
     "latitude": 34.354444,
     "longitude": 3.87083333,
     "code_commune": 1734
@@ -1084,7 +1084,7 @@
     "name_ar": "دلدول",
     "wilaya_code": 66,
     "daira": "Messaad",
-    "postal_code": "17415",
+    "postal_code": null,
     "latitude": 34.20519,
     "longitude": 3.25311,
     "code_commune": 1729
@@ -1094,7 +1094,7 @@
     "name_ar": "فيض البطمة",
     "wilaya_code": 66,
     "daira": "Sed Rahal",
-    "postal_code": "17021",
+    "postal_code": null,
     "latitude": 34.527777,
     "longitude": 3.781944,
     "code_commune": 1707
@@ -1104,7 +1104,7 @@
     "name_ar": "قطارة",
     "wilaya_code": 66,
     "daira": "Messaad",
-    "postal_code": "17055",
+    "postal_code": null,
     "latitude": 33.158611,
     "longitude": 4.685277,
     "code_commune": 1718
@@ -1114,7 +1114,7 @@
     "name_ar": "مسعد",
     "wilaya_code": 66,
     "daira": "Messaad",
-    "postal_code": "17003",
+    "postal_code": null,
     "latitude": 34.15429,
     "longitude": 3.50309,
     "code_commune": 1717
@@ -1124,7 +1124,7 @@
     "name_ar": "أم العظام",
     "wilaya_code": 66,
     "daira": "Selmana",
-    "postal_code": "17061",
+    "postal_code": null,
     "latitude": 33.720277,
     "longitude": 4.53056,
     "code_commune": 1724
@@ -1134,7 +1134,7 @@
     "name_ar": "سد الرحال",
     "wilaya_code": 66,
     "daira": "Sed Rahal",
-    "postal_code": "17062",
+    "postal_code": null,
     "latitude": 33.948333,
     "longitude": 3.231111,
     "code_commune": 1706
@@ -1144,7 +1144,7 @@
     "name_ar": "سلمانة",
     "wilaya_code": 66,
     "daira": "Selmana",
-    "postal_code": "17063",
+    "postal_code": null,
     "latitude": 34.16440361,
     "longitude": 3.562011761,
     "code_commune": 1722
@@ -1154,7 +1154,7 @@
     "name_ar": "عين بوسيف",
     "wilaya_code": 67,
     "daira": "Aïn Boucif",
-    "postal_code": "26005",
+    "postal_code": null,
     "latitude": 35.89123,
     "longitude": 3.1585,
     "code_commune": 2604
@@ -1164,7 +1164,7 @@
     "name_ar": "عين اقصير",
     "wilaya_code": 67,
     "daira": "Chellalet El Adhaoura",
-    "postal_code": "26048",
+    "postal_code": null,
     "latitude": 35.818653,
     "longitude": 3.470555,
     "code_commune": 2641
@@ -1174,7 +1174,7 @@
     "name_ar": "عزيز",
     "wilaya_code": 67,
     "daira": "Aziz",
-    "postal_code": "26040",
+    "postal_code": null,
     "latitude": 35.816667,
     "longitude": 2.45,
     "code_commune": 2632
@@ -1184,7 +1184,7 @@
     "name_ar": "بوغار",
     "wilaya_code": 67,
     "daira": "Boghar",
-    "postal_code": "26013",
+    "postal_code": null,
     "latitude": 35.911389,
     "longitude": 2.71667,
     "code_commune": 2625
@@ -1194,7 +1194,7 @@
     "name_ar": "بوعيش",
     "wilaya_code": 67,
     "daira": "Chahbounia",
-    "postal_code": "26054",
+    "postal_code": null,
     "latitude": 35.552778,
     "longitude": 2.1731,
     "code_commune": 2610
@@ -1204,7 +1204,7 @@
     "name_ar": "بوغزول",
     "wilaya_code": 67,
     "daira": "Chahbounia",
-    "postal_code": "26023",
+    "postal_code": null,
     "latitude": 35.7533117,
     "longitude": 2.7381672,
     "code_commune": 2651
@@ -1214,7 +1214,7 @@
     "name_ar": "الشهبونية",
     "wilaya_code": 67,
     "daira": "Chahbounia",
-    "postal_code": "26026",
+    "postal_code": null,
     "latitude": 35.54472221,
     "longitude": 2.603333,
     "code_commune": 2638
@@ -1224,7 +1224,7 @@
     "name_ar": "شلالة العذاورة",
     "wilaya_code": 67,
     "daira": "Chellalet El Adhaoura",
-    "postal_code": "26007",
+    "postal_code": null,
     "latitude": 35.94,
     "longitude": 3.4139,
     "code_commune": 2618
@@ -1234,7 +1234,7 @@
     "name_ar": "شنيقل",
     "wilaya_code": 67,
     "daira": "Chellalet El Adhaoura",
-    "postal_code": "26057",
+    "postal_code": null,
     "latitude": 35.922222,
     "longitude": 3.5667,
     "code_commune": 2640
@@ -1244,7 +1244,7 @@
     "name_ar": "دراق",
     "wilaya_code": 67,
     "daira": "Aziz",
-    "postal_code": "26015",
+    "postal_code": null,
     "latitude": 35.908611,
     "longitude": 2.38778,
     "code_commune": 2608
@@ -1254,7 +1254,7 @@
     "name_ar": "العوينات",
     "wilaya_code": 67,
     "daira": "Aïn Boucif",
-    "postal_code": "26059",
+    "postal_code": null,
     "latitude": 35.3344,
     "longitude": 3.035556,
     "code_commune": 2657
@@ -1264,7 +1264,7 @@
     "name_ar": "الكاف الاخضر",
     "wilaya_code": 67,
     "daira": "Aïn Boucif",
-    "postal_code": "26051",
+    "postal_code": null,
     "latitude": 35.923333,
     "longitude": 3.2875,
     "code_commune": 2617
@@ -1274,7 +1274,7 @@
     "name_ar": "قصر البخاري",
     "wilaya_code": 67,
     "daira": "Ksar El Boukhari",
-    "postal_code": "26003",
+    "postal_code": null,
     "latitude": 35.88889,
     "longitude": 2.74905,
     "code_commune": 2635
@@ -1284,7 +1284,7 @@
     "name_ar": "مفاتحة",
     "wilaya_code": 67,
     "daira": "Ksar El Boukhari",
-    "postal_code": "26049",
+    "postal_code": null,
     "latitude": 35.8831842,
     "longitude": 2.9346884,
     "code_commune": 2649
@@ -1294,7 +1294,7 @@
     "name_ar": "أولاد عنتر",
     "wilaya_code": 67,
     "daira": "Boghar",
-    "postal_code": "26035",
+    "postal_code": null,
     "latitude": 35.9951773,
     "longitude": 2.60231,
     "code_commune": 2658
@@ -1304,7 +1304,7 @@
     "name_ar": "أولاد امعرف",
     "wilaya_code": 67,
     "daira": "Aïn Boucif",
-    "postal_code": "26038",
+    "postal_code": null,
     "latitude": 35.872222,
     "longitude": 3.1585,
     "code_commune": 2603
@@ -1314,7 +1314,7 @@
     "name_ar": "أولاد هلال",
     "wilaya_code": 67,
     "daira": "Boghar",
-    "postal_code": "26037",
+    "postal_code": null,
     "latitude": 35.9370104,
     "longitude": 2.4980197,
     "code_commune": 2622
@@ -1324,7 +1324,7 @@
     "name_ar": "أم الجليل",
     "wilaya_code": 67,
     "daira": "Aziz",
-    "postal_code": "26065",
+    "postal_code": null,
     "latitude": 35.8275,
     "longitude": 2.6239,
     "code_commune": 2642
@@ -1334,7 +1334,7 @@
     "name_ar": "السانق",
     "wilaya_code": 67,
     "daira": "Ksar El Boukhari",
-    "postal_code": "26067",
+    "postal_code": null,
     "latitude": 35.8514,
     "longitude": 3.253056,
     "code_commune": 2664
@@ -1344,7 +1344,7 @@
     "name_ar": "سيدي دامد",
     "wilaya_code": 67,
     "daira": "Aïn Boucif",
-    "postal_code": "26069",
+    "postal_code": null,
     "latitude": 35.8706421,
     "longitude": 3.2531476,
     "code_commune": 2631
@@ -1354,7 +1354,7 @@
     "name_ar": "تفراوت",
     "wilaya_code": 67,
     "daira": "Chellalet El Adhaoura",
-    "postal_code": "26074",
+    "postal_code": null,
     "latitude": 36.0877,
     "longitude": 3.4308,
     "code_commune": 2623
@@ -1364,7 +1364,7 @@
     "name_ar": "عين الملح",
     "wilaya_code": 68,
     "daira": "Aïn El Melh",
-    "postal_code": "28004",
+    "postal_code": null,
     "latitude": 34.8470491,
     "longitude": 4.1634964,
     "code_commune": 2841
@@ -1374,7 +1374,7 @@
     "name_ar": "عين فارس",
     "wilaya_code": 68,
     "daira": "Aïn El Melh",
-    "postal_code": "28023",
+    "postal_code": null,
     "latitude": 35.03583333,
     "longitude": 4.428333333,
     "code_commune": 2837
@@ -1384,7 +1384,7 @@
     "name_ar": "عين الريش",
     "wilaya_code": 68,
     "daira": "Aïn El Melh",
-    "postal_code": "28025",
+    "postal_code": null,
     "latitude": 34.680794,
     "longitude": 4.096956,
     "code_commune": 2844
@@ -1394,7 +1394,7 @@
     "name_ar": "بن سرور",
     "wilaya_code": 68,
     "daira": "Ben Srour",
-    "postal_code": "28009",
+    "postal_code": null,
     "latitude": 35.0404431,
     "longitude": 4.5633795,
     "code_commune": 2824
@@ -1404,7 +1404,7 @@
     "name_ar": "بن زوه",
     "wilaya_code": 68,
     "daira": "Ouled Sidi Brahim",
-    "postal_code": "28028",
+    "postal_code": null,
     "latitude": 35.438055,
     "longitude": 4.383333,
     "code_commune": 2835
@@ -1414,7 +1414,7 @@
     "name_ar": "بئر فضة",
     "wilaya_code": 68,
     "daira": "Aïn El Melh",
-    "postal_code": "28043",
+    "postal_code": null,
     "latitude": 34.82,
     "longitude": 3.899444,
     "code_commune": 2836
@@ -1424,7 +1424,7 @@
     "name_ar": "بوسعادة",
     "wilaya_code": 68,
     "daira": "Bou Saada",
-    "postal_code": "28001",
+    "postal_code": null,
     "latitude": 35.219167,
     "longitude": 4.17402,
     "code_commune": 2820
@@ -1434,7 +1434,7 @@
     "name_ar": "جبل مساعد",
     "wilaya_code": 68,
     "daira": "Djebel Messaad",
-    "postal_code": "28024",
+    "postal_code": null,
     "latitude": 34.991121,
     "longitude": 4.092493,
     "code_commune": 2847
@@ -1444,7 +1444,7 @@
     "name_ar": "الهامل",
     "wilaya_code": 68,
     "daira": "Bou Saada",
-    "postal_code": "28015",
+    "postal_code": null,
     "latitude": 35.1283,
     "longitude": 4.083333,
     "code_commune": 2827
@@ -1454,7 +1454,7 @@
     "name_ar": "الحوامد",
     "wilaya_code": 68,
     "daira": "Khoubana",
-    "postal_code": "28063",
+    "postal_code": null,
     "latitude": 35.2917758,
     "longitude": 4.53358,
     "code_commune": 2826
@@ -1464,7 +1464,7 @@
     "name_ar": "خبانة",
     "wilaya_code": 68,
     "daira": "Khoubana",
-    "postal_code": "28030",
+    "postal_code": null,
     "latitude": 35.31444444,
     "longitude": 4.566944,
     "code_commune": 2807
@@ -1474,7 +1474,7 @@
     "name_ar": "مسيف",
     "wilaya_code": 68,
     "daira": "Khoubana",
-    "postal_code": "28029",
+    "postal_code": null,
     "latitude": 35.3281,
     "longitude": 4.8,
     "code_commune": 2808
@@ -1484,7 +1484,7 @@
     "name_ar": "امجدل",
     "wilaya_code": 68,
     "daira": "Medjedel",
-    "postal_code": "28016",
+    "postal_code": null,
     "latitude": 34.9611111,
     "longitude": 3.6793899,
     "code_commune": 2842
@@ -1494,7 +1494,7 @@
     "name_ar": "مناعة",
     "wilaya_code": 68,
     "daira": "Medjedel",
-    "postal_code": "28016",
+    "postal_code": null,
     "latitude": 35.144444,
     "longitude": 3.694444,
     "code_commune": null
@@ -1504,7 +1504,7 @@
     "name_ar": "محمد بوضياف",
     "wilaya_code": 68,
     "daira": "Ben Srour",
-    "postal_code": "28033",
+    "postal_code": null,
     "latitude": 34.8941667,
     "longitude": 4.428611,
     "code_commune": 2834
@@ -1514,7 +1514,7 @@
     "name_ar": "أولاد سيدي ابراهيم",
     "wilaya_code": 68,
     "daira": "Ouled Sidi Brahim",
-    "postal_code": "28032",
+    "postal_code": null,
     "latitude": 35.2992435,
     "longitude": 4.1696166,
     "code_commune": 2821
@@ -1524,7 +1524,7 @@
     "name_ar": "أولاد سليمان",
     "wilaya_code": 68,
     "daira": "Ben Srour",
-    "postal_code": "28031",
+    "postal_code": null,
     "latitude": 34.91609,
     "longitude": 4.73694444,
     "code_commune": 2825
@@ -1534,7 +1534,7 @@
     "name_ar": "ولتام",
     "wilaya_code": 68,
     "daira": "Bou Saada",
-    "postal_code": "28054",
+    "postal_code": null,
     "latitude": 35.0350816,
     "longitude": 5.3360215,
     "code_commune": 2846
@@ -1544,7 +1544,7 @@
     "name_ar": "سيدي عامر",
     "wilaya_code": 68,
     "daira": "Sidi Ameur",
-    "postal_code": "28035",
+    "postal_code": null,
     "latitude": 35.367,
     "longitude": 3.9,
     "code_commune": null
@@ -1564,7 +1564,7 @@
     "name_ar": "سليم",
     "wilaya_code": 68,
     "daira": "Djebel Messaad",
-    "postal_code": "28037",
+    "postal_code": null,
     "latitude": 34.938889,
     "longitude": 3.734722222,
     "code_commune": 2843
@@ -1574,7 +1574,7 @@
     "name_ar": "تامسة",
     "wilaya_code": 68,
     "daira": "Sidi Ameur",
-    "postal_code": "28065",
+    "postal_code": null,
     "latitude": 35.173611,
     "longitude": 3.925556,
     "code_commune": 2823
@@ -1584,7 +1584,7 @@
     "name_ar": "زرزور",
     "wilaya_code": 68,
     "daira": "Ben Srour",
-    "postal_code": "28067",
+    "postal_code": null,
     "latitude": 35.0358333,
     "longitude": 4.433333,
     "code_commune": 2833
@@ -1594,7 +1594,7 @@
     "name_ar": "عين العراك",
     "wilaya_code": 69,
     "daira": "El Abiodh Sidi Cheikh",
-    "postal_code": "32019",
+    "postal_code": null,
     "latitude": 33.4100573,
     "longitude": 0.7385302,
     "code_commune": 3208
@@ -1604,7 +1604,7 @@
     "name_ar": "اربوات",
     "wilaya_code": 69,
     "daira": "El Abiodh Sidi Cheikh",
-    "postal_code": "32005",
+    "postal_code": null,
     "latitude": 33.08833333,
     "longitude": 0.5823,
     "code_commune": 3209
@@ -1614,7 +1614,7 @@
     "name_ar": "بوسمغون",
     "wilaya_code": 69,
     "daira": "Boussemghoun",
-    "postal_code": "32014",
+    "postal_code": null,
     "latitude": 32.8643,
     "longitude": 0.0201,
     "code_commune": 3213
@@ -1624,7 +1624,7 @@
     "name_ar": "شلالة",
     "wilaya_code": 69,
     "daira": "Chellala",
-    "postal_code": "32015",
+    "postal_code": null,
     "latitude": 33.0327072,
     "longitude": 0.0586818,
     "code_commune": 3214
@@ -1634,7 +1634,7 @@
     "name_ar": "البنود",
     "wilaya_code": 69,
     "daira": "El Abiodh Sidi Cheikh",
-    "postal_code": "32025",
+    "postal_code": null,
     "latitude": 32.31222222,
     "longitude": 0.244444,
     "code_commune": 3216
@@ -1644,7 +1644,7 @@
     "name_ar": "المحرة",
     "wilaya_code": 69,
     "daira": "Chellala",
-    "postal_code": "32024",
+    "postal_code": null,
     "latitude": 33.311667,
     "longitude": 0.364444,
     "code_commune": 3219
@@ -1654,7 +1654,7 @@
     "name_ar": "الأبيض سيدي الشيخ",
     "wilaya_code": 69,
     "daira": "El Abiodh Sidi Cheikh",
-    "postal_code": "32003",
+    "postal_code": null,
     "latitude": 32.898611,
     "longitude": 0.544444,
     "code_commune": 3207

--- a/scripts/fix-commune-postal-codes.mjs
+++ b/scripts/fix-commune-postal-codes.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+// Correct the flagship dataset's commune postal codes from the poste package.
+//
+// WHY. The dataset's `postal_code` values outside the wilaya chef-lieux turned
+// out to be largely wrong: Akbou shipped as 06009 where Algérie Poste's own
+// locator (and every public directory) says 06001; Bab Ezzouar shipped as
+// 16030, which is actually Bologhine's code. The chef-lieux (Adrar 01000,
+// Alger Centre 16000, Setif 19000...) were right, which is how the sequence
+// survived review: the visible anchors held while the long tail drifted.
+//
+// SOURCE OF TRUTH. packages/poste/data/postoffices.json - 3,908 offices from
+// baridimap.poste.dz (Algérie Poste's official locator), each carrying the
+// office's postal code. In Algeria the postal code IS the office code: the
+// code directories cite for a commune is the code of its principal office
+// (verified externally for Akbou 06001, Bab Ezzouar 16024, Reggane 01004;
+// the live API re-checked 2026-08-07, byte-identical to our capture).
+//
+// RULE, per commune:
+//   1. Collect the commune's offices: join by (wilaya, folded name), and only
+//      when that misses, by baridimap's commune code - accepted solely when
+//      the code's wilaya matches and neither side name-claims elsewhere
+//      (baridimap's commune codes drift from ours on a few rows; a code join
+//      that contradicts a name join is drift, not signal).
+//   2. If the CURRENT code is among the commune's real office codes, keep it:
+//      it is verified-current, and stability beats churn.
+//   3. Else the canonical code is the principal office's: the office NAMED
+//      like the commune (with or without a trailing RP), else the best class
+//      (HC > CE > R1 > R2 > R3 > R4), ties to the lowest code.
+//   4. A commune with no resolvable office loses its code (null): the page
+//      copy has an honest no-postal-code variant, and keeping a fabricated
+//      value is worse than admitting the gap.
+//
+// USAGE
+//   node scripts/fix-commune-postal-codes.mjs               # dry-run report
+//   node scripts/fix-commune-postal-codes.mjs --write       # patch dataset pkg
+//   node scripts/fix-commune-postal-codes.mjs --write \
+//        --target /path/algeria.json --target /path/communes.geojson
+//      # patch arbitrary carriers (the app repo's committed copies) with the
+//      # SAME mapping, so every surface agrees.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, basename } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..");
+const POSTE = join(ROOT, "packages/poste/data/postoffices.json");
+const DATASET = join(ROOT, "packages/dataset/data");
+
+const WRITE = process.argv.includes("--write");
+const targets = [];
+for (let i = 2; i < process.argv.length; i++) {
+  if (process.argv[i] === "--target") targets.push(process.argv[++i]);
+}
+
+/** Accent-fold + uppercase + collapse separators, for name joins. */
+function fold(s) {
+  return (s ?? "")
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toUpperCase()
+    .replace(/['’-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Spacing-blind variant, the tier between the exact name join and the code
+ * join: "Sidi M'hamed Benali" vs baridimap's "SIDI M'HAMED BEN ALI" differ
+ * only in where the spaces fall, and falling through to the code join there
+ * is dangerous precisely when the commune code is one of the dataset's known
+ * duplicated rows (two communes sharing a code would both inherit the same
+ * office group, colliding their postal codes).
+ */
+const tight = (s) => fold(s).replace(/ /g, "");
+
+/** Office class rank; the principal office of a commune has the best class. */
+const CLASS_RANK = { HC: 0, CE: 1, R1: 2, R2: 3, R3: 4, R4: 5 };
+const rank = (c) => CLASS_RANK[c] ?? 9;
+
+// ---------------------------------------------------------------------------
+// Group the offices per baridimap commune.
+// ---------------------------------------------------------------------------
+const offices = JSON.parse(readFileSync(POSTE, "utf-8"));
+/** key "w|FOLDEDNAME" -> group; also byCode "0101" -> group */
+const byName = new Map();
+const byTight = new Map();
+const byCode = new Map();
+for (const o of offices) {
+  if (!o.postal_code) continue;
+  const w = Number(o.wilaya_code);
+  const nameKey = `${w}|${fold(o.commune)}`;
+  const codeKey = String(o.commune_code).padStart(4, "0");
+  let g = byName.get(nameKey);
+  if (!g) {
+    g = { wilaya: w, folded: fold(o.commune), offices: [] };
+    byName.set(nameKey, g);
+    byTight.set(`${w}|${tight(o.commune)}`, g);
+  }
+  g.offices.push({ code: o.postal_code, cls: o.class, name: fold(o.name) });
+  if (!byCode.has(codeKey)) byCode.set(codeKey, g);
+}
+
+// ---------------------------------------------------------------------------
+// Build the (wilaya, folded name) -> postal_code mapping from the dataset's
+// own commune list, so every carrier is patched with one consistent answer.
+// ---------------------------------------------------------------------------
+const algeria = JSON.parse(readFileSync(join(DATASET, "algeria.json"), "utf-8"));
+const wilayasArr = Array.isArray(algeria) ? algeria : algeria.wilayas;
+
+/** folded commune names per wilaya, to veto cross-commune code joins */
+const namesPerWilaya = new Map();
+for (const w of wilayasArr) {
+  const set = new Set();
+  // Spacing-blind, matching the join tiers: the veto must recognise a name
+  // however the spaces fall, or a spacing variant slips past it.
+  for (const c of w.communes) set.add(tight(c.name_fr));
+  namesPerWilaya.set(Number(w.code), set);
+}
+
+function groupFor(wilayaCode, commune) {
+  const foldedName = fold(commune.name_fr);
+  const named =
+    byName.get(`${wilayaCode}|${foldedName}`) ??
+    byTight.get(`${wilayaCode}|${tight(commune.name_fr)}`);
+  if (named) return named;
+  const codeKey = String(commune.code_commune ?? "").padStart(4, "0");
+  const coded = byCode.get(codeKey);
+  if (!coded) return null;
+  // Guards: same wilaya, and the coded group's own name must not belong to a
+  // DIFFERENT commune of this wilaya (that group is theirs, reachable by the
+  // name join; lending it here would be the code drift we're defending against).
+  if (coded.wilaya !== wilayaCode) return null;
+  const codedTight = tight(coded.folded);
+  if (codedTight !== tight(commune.name_fr) && namesPerWilaya.get(wilayaCode)?.has(codedTight)) {
+    return null;
+  }
+  return coded;
+}
+
+function canonical(group, foldedName, current) {
+  const codes = group.offices.map((o) => o.code);
+  if (current && codes.includes(current)) return current;
+  const principal =
+    group.offices.find((o) => o.name === foldedName) ??
+    group.offices.find((o) => o.name === `${foldedName} RP`);
+  if (principal) return principal.code;
+  return [...group.offices].sort(
+    (a, b) => rank(a.cls) - rank(b.cls) || a.code.localeCompare(b.code),
+  )[0].code;
+}
+
+const mapping = new Map(); // "w|FOLDED" -> code | null
+const report = { kept: 0, replaced: 0, filled: 0, nulled: 0, samples: [] };
+for (const w of wilayasArr) {
+  const wc = Number(w.code);
+  for (const c of w.communes) {
+    const foldedName = fold(c.name_fr);
+    const key = `${wc}|${foldedName}`;
+    const g = groupFor(wc, c);
+    const current = c.postal_code || null;
+    let next;
+    if (!g) {
+      next = null;
+      if (current) report.nulled++;
+    } else {
+      next = canonical(g, foldedName, current);
+      if (!current) report.filled++;
+      else if (next === current) report.kept++;
+      else {
+        report.replaced++;
+        if (report.samples.length < 12)
+          report.samples.push(`${wc} ${c.name_fr}: ${current} -> ${next}`);
+      }
+    }
+    mapping.set(key, next);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Apply the mapping to a carrier file (dataset json, flat list, or geojson).
+// ---------------------------------------------------------------------------
+function patchCommune(rec, wilayaCode) {
+  const key = `${Number(wilayaCode)}|${fold(rec.name_fr)}`;
+  if (!mapping.has(key)) return { miss: rec.name_fr };
+  const next = mapping.get(key);
+  const prev = rec.postal_code ?? null;
+  if (next === prev) return { same: true };
+  rec.postal_code = next;
+  return { changed: true };
+}
+
+function applyTo(path) {
+  const doc = JSON.parse(readFileSync(path, "utf-8"));
+  let changed = 0;
+  const misses = [];
+  const visit = (rec, w) => {
+    const r = patchCommune(rec, w);
+    if (r.changed) changed++;
+    if (r.miss) misses.push(`${w}|${r.miss}`);
+  };
+  if (doc?.type === "FeatureCollection") {
+    for (const f of doc.features) visit(f.properties, f.properties.wilaya_code);
+  } else {
+    const arr = Array.isArray(doc) ? doc : doc.wilayas;
+    if (arr[0]?.communes) {
+      for (const w of arr) for (const c of w.communes) visit(c, w.code);
+    } else {
+      for (const c of arr) visit(c, c.wilaya_code);
+    }
+  }
+  if (WRITE) writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+  console.log(
+    `${WRITE ? "patched" : "would patch"} ${basename(path)}: ${changed} commune(s)` +
+      (misses.length ? `; UNMATCHED in target: ${misses.join(", ")}` : ""),
+  );
+  return misses.length;
+}
+
+console.log(
+  `mapping: ${report.kept} kept, ${report.replaced} replaced, ` +
+    `${report.filled} filled, ${report.nulled} nulled (no resolvable office)`,
+);
+for (const s of report.samples) console.log(`  ${s}`);
+
+// Pins: externally-verified answers this run must reproduce, or it aborts.
+const PINS = [
+  [6, "Akbou", "06001"],
+  [16, "Bab Ezzouar", "16024"],
+  [16, "Alger Centre", "16000"],
+  [1, "Reggane", "01004"],
+  [1, "Adrar", "01000"],
+  [19, "Setif", "19000"],
+];
+for (const [w, name, want] of PINS) {
+  const got = mapping.get(`${w}|${fold(name)}`);
+  if (got !== want) {
+    console.error(`PIN FAILED: ${name} expected ${want}, got ${got}`);
+    process.exit(1);
+  }
+}
+console.log("pins ok (Akbou 06001, Bab Ezzouar 16024, Reggane 01004, chef-lieux kept)");
+
+const files = targets.length
+  ? targets
+  : [
+      join(DATASET, "algeria.json"),
+      join(DATASET, "communes_w1_w23.json"),
+      join(DATASET, "communes_w24_w48.json"),
+      join(DATASET, "communes_w49_w69.json"),
+    ];
+let totalMisses = 0;
+for (const f of files) totalMisses += applyTo(f);
+if (totalMisses) {
+  console.error("Some target rows had no mapping entry; investigate before shipping.");
+  process.exitCode = 2;
+}


### PR DESCRIPTION
## What

The commune `postal_code` column had three defect classes, surfaced by the app's postal-code uniqueness guard:

- **43 cross-commune collisions**: 2026 reform daughters kept codes that mother-wilaya communes also carry (Sebgag/59 vs Ksar El Hirane/03 on 03003).
- **54 codes that are not any of the commune's own office codes** (stale or neighbour-swapped).
- **132 communes carrying a code with no resolvable office at all.**

## How

`scripts/fix-commune-postal-codes.mjs` (committed, rerunnable) derives each commune's code from its own offices in `packages/poste` (the baridimap capture, re-verified byte-identical against the live API on 2026-08-07):

1. Keep the current code when it is among the commune's real office codes (1,350 rows).
2. Else take the principal office's code: office named like the commune (spacing-blind name tier included), else best class (HC > CE > R1 > R2 > R3 > R4), ties to lowest code.
3. Joins are wilaya-scoped and guarded so the dataset's duplicated commune codes (#164 family) cannot cross-assign office groups.
4. No resolvable offices means no code (null), honestly; downstream copy has a no-postal-code variant.

**187 rows changed across the four carriers; zero duplicate codes remain.** Pins the script enforces (externally verified): Akbou 06001, Bab Ezzouar 16024, Reggane 01004, chef-lieux unchanged.

## Context

GSC (Jul 23 - Aug 6): 297 distinct "code postal X" queries, 1,256 impressions, 2 clicks. The app-side copies are synced by the same script in the app repo (commit 3e8a393, deploys with the rentrée batch).

Also folds in the gitignore guard for service-account key locations.

Tests: 134/134.