### PR TITLE
chore: changeset for the office-derived postal-code correction (#168)

### DIFF
--- a/.changeset/office-derived-postal-codes.md
+++ b/.changeset/office-derived-postal-codes.md
@@ -1,0 +1,5 @@
+---
+"geoalgeria": minor
+---
+
+Commune postal codes are now office-derived: each commune's code comes from its own Algérie Poste offices (baridimap), fixing 187 rows that carried positional or colliding values (Akbou 06001, Bab Ezzouar 16024, Reggane 01004; zero duplicate codes remain). Communes with no resolvable office now carry no code rather than a fabricated one.


### PR DESCRIPTION
PR #168 (187 postal-code rows corrected from the poste package) merged without a changeset, so the `geoalgeria` flagship bump never entered the version PR. Minor per the data-refresh convention.