### PR TITLE
docs(roadmap): urban buses next, and why intercity is a licence question

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,11 +155,32 @@ reads as further along than it is.
   the framing most likely to land: publish once, every transit app can consume
   it, including MAHATATI's competitors and this atlas.
 
-  `live.sogral.com` ("Departs en temps reel", linked from sogral.dz) is the one
-  public web surface found; it refused connections on both HTTPS and HTTP on
-  2026-08-09, so whether it is dead or WAF-blocked is unresolved. Worth one
-  real-browser check before any conversation, since a public web endpoint would
-  change what is reasonable to ask for.
+  **The web surface is `mahatati.sogral.com`** (`live.sogral.com` refused
+  connections on both HTTPS and HTTP; treat it as dead). It is a public page
+  with no login, backed by an undocumented but unauthenticated JSON API:
+
+  - `api/live/summary` and `api/live/summary/{agencyId}`: live counters
+    (planned / open / completed / cancelled departures, reservations).
+  - `api/live/destinations/{agencyId}`: destinations served from a station.
+  - `api/live/departures/infos/route/{agencyId}/{headOfLineId}/{routeId}`: the
+    itinerary, each stop's commune and wilaya plus the **fare in DA**.
+
+  The page's own selects carry 73 departure stations and about 180 destinations,
+  and the results table carries departure time, operator, zone, seats available
+  and status.
+
+  So extraction is technically trivial, and that changes nothing about the
+  answer: the footer reads "Copyright (c) 2021 EPE SOGRAL Spa, tous droits
+  reserves", there is no licence under which this repo could restate the data,
+  and every record here has to carry one. What it does change is the ask. SOGRAL
+  has already built the API; the request is now to document it and licence it,
+  or emit GTFS from it, rather than to build anything. That is a much cheaper
+  yes. Contact is on the page: contact@sogral.dz, 021.77.00.77.
+
+  Legitimate without any permission, and worth doing: cross-check the 74
+  stations in `@geoalgeria/gares-routieres` against the 73 their page lists, to
+  catch renames, closures and new stations. That is reference use of a public
+  page on exactly the basis this repo already redistributes their station list.
   _(logged 2026-08-09)_
 
 ## Releases

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,6 +98,41 @@ reads as further along than it is.
   regeneration was reverted and only the helper fix shipped.
   _(logged 2026-08-03)_
 
+## Transport
+
+- [ ] **`@geoalgeria/buses` re-extracted from OSM route relations (breaking,
+  3.0.0).** The package today is 50 ETUSA lines scraped from Wikipedia with
+  **no coordinates at all**: line-level attributes, `lat`/`lng` null on every
+  record, `geocoded_pct` 0. Its coverage note says OSM `route=bus` coverage
+  tagged ETUSA "is currently thin", and **that is now stale**. Measured against
+  a live Overpass pull on 2026-08-09 (`timestamp_osm_base`
+  2026-08-09T10:51:50Z):
+
+  - **215 bus route relations in Algeria**, of which **100 are ETUSA** (network
+    `إيتوزا` / `ETUSA`), plus Tiaret 28 (ETUS TIARET + the wilaya transport
+    directorate), Setif 5, and smaller sets in Ain Defla, Jijel and elsewhere.
+  - **All 100 ETUSA relations carry drawable geometry**, 1,250 km of route in
+    total; 99 are named, 99 carry `from`/`to`, 48 carry `via`, 53 carry an
+    official line `colour`, and **78 carry stop or platform members**.
+
+  So the deferral reason recorded in the coverage note no longer holds, and the
+  package can go from attribute-only to geometry-bearing with real stops. That
+  is a breaking change (records gain geometry, the id scheme changes from
+  Wikipedia line numbers to OSM relation ids), hence 3.0.0.
+
+  **What the data still cannot support, and must not be claimed:** there are
+  **zero** `interval`, `duration` and `frequency` tags across the 100 ETUSA
+  relations, and only 25 carry `opening_hours`. So the package can answer which
+  lines exist, where they run and where they stop, but never how long a trip
+  takes. Journey planning needs timetables Algeria does not publish openly (no
+  GTFS), and deriving a duration from route length would put a fabricated
+  number beside sourced ones, the same call already made for flight durations
+  in the Aviation section.
+
+  Demand signal: a user on Reddit (2026-08-09) describing exactly this gap,
+  planning a move to an unfamiliar area with no way to see what serves it.
+  _(logged 2026-08-09)_
+
 ## Releases
 
 - [ ] **Umbrella release tag for the current state.** Per-package releases have

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,6 +133,35 @@ reads as further along than it is.
   planning a move to an unfamiliar area with no way to see what serves it.
   _(logged 2026-08-09)_
 
+- [ ] **Intercity coach schedules are a licence problem, not a scraping
+  problem.** ETUSA is Algiers **urban** transport only, so the OSM re-extraction
+  above cannot answer the question a person moving to another wilaya actually
+  asks. The intercity network belongs to **SOGRAL**, the state operator of the
+  gares routieres, whose own app **MAHATATI** (`com.sogral.mobile`) already
+  carries departures, times, fares, operator names and itineraries, and since
+  May 2026 sells tickets through it with CIB / EDAHABIA payment.
+
+  Do **not** extract it. SOGRAL's schedules carry no open licence, so
+  republishing them as a package under MIT or ODbL would be a false licence
+  claim, the same objection that ruled out Google Places for `cliniques`. The
+  app now fronts a payment flow, which makes reverse-engineering its API a
+  different risk class entirely. And a dataset built on a private app API rots
+  silently when the API moves.
+
+  The path is to **ask SOGRAL for a feed, ideally GTFS**. This repo already
+  publishes their 74 gares routieres (`@geoalgeria/gares-routieres`, "Data (c)
+  SOGRAL; redistributed for reference"), so the ask comes from a project
+  already carrying their network with attribution, not from a stranger. GTFS is
+  the framing most likely to land: publish once, every transit app can consume
+  it, including MAHATATI's competitors and this atlas.
+
+  `live.sogral.com` ("Departs en temps reel", linked from sogral.dz) is the one
+  public web surface found; it refused connections on both HTTPS and HTTP on
+  2026-08-09, so whether it is dead or WAF-blocked is unresolved. Worth one
+  real-browser check before any conversation, since a public web endpoint would
+  change what is reasonable to ask for.
+  _(logged 2026-08-09)_
+
 ## Releases
 
 - [ ] **Umbrella release tag for the current state.** Per-package releases have


### PR DESCRIPTION
Logs the transit work as the next version, from a user request on Reddit: someone planning a move to an unfamiliar wilaya, with no way to see what serves it.

## Two entries, and they are different problems

**1. `@geoalgeria/buses` re-extracted from OSM route relations (breaking 3.0.0).**

The package's own coverage note says OSM `route=bus` coverage tagged ETUSA "is currently thin". That is now stale. Measured against a live Overpass pull (`timestamp_osm_base` 2026-08-09T10:51:50Z):

- **215 bus route relations in Algeria**, of which **100 are ETUSA**, plus Tiaret 28, Setif 5, and smaller sets elsewhere
- **all 100 ETUSA relations carry drawable geometry**, 1,250 km of route
- 99 named, 99 with `from`/`to`, 48 with `via`, 53 with an official line `colour`, **78 with stop or platform members**

Today the package ships 50 Wikipedia-derived lines with **no coordinates at all** (`geocoded_pct` 0). Going to real geometry with stops is a breaking change: records gain geometry and the id scheme moves from Wikipedia line numbers to OSM relation ids.

What it still cannot support, recorded so nobody promises it later: **zero** `interval`, `duration` and `frequency` tags across the 100 ETUSA relations, only 25 with `opening_hours`. So the package can say which lines exist, where they run and where they stop, never how long a trip takes. Deriving a duration from route length would put a fabricated number beside sourced ones, the same call already made for flight durations under Aviation.

**2. Intercity coach schedules are a licence question, not a scraping one.**

ETUSA is Algiers **urban** transport, so the re-extraction above cannot answer what a person moving between wilayas actually asks. That network is SOGRAL's, and their own app MAHATATI already carries departures, times, fares and itineraries, with ticket sales since May 2026.

`mahatati.sogral.com` is a public page backed by an undocumented but unauthenticated JSON API (`api/live/summary`, `api/live/destinations/{agencyId}`, `api/live/departures/infos/route/...`, the last returning each stop's commune, wilaya and **fare**). Its selects carry 73 departure stations and about 180 destinations.

So extraction is trivial, and the answer is still no: the footer reads "Copyright (c) 2021 EPE SOGRAL Spa, tous droits reserves", there is no licence under which this repo could restate the data, and every record here has to carry one. The same objection that ruled out Google Places for `cliniques`.

What changes is the ask. SOGRAL has already built the API, so the request is to **document and licence it, or emit GTFS**, not to build anything. This repo already publishes their 74 gares routieres with attribution, so it comes from a project already carrying their network.

Also logged as legitimate without any permission: cross-check our 74 stations against the 73 their page lists, to catch renames, closures and new stations.
