### PR TITLE
fix(release): clamp GitHub release titles to a readable length

### DIFF
--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -63,15 +63,44 @@ const isBullet = (l) => /^\s*[-*]\s+/.test(l);
 const cleanBullet = (l) =>
   l.replace(/^\s*[-*]\s+/, "").replace(/^[0-9a-f]{7,}:\s*/i, "").replace(/\*\*/g, "").trim();
 
+// GitHub rejects a release name over 256 characters with a bare HTTP 422, which
+// fails the whole release step AFTER packages have already been staged, leaving
+// the release half done. A changeset written as one long paragraph (the
+// cliniques 1.0.0 one ran past 1,200 characters) hits this, so the title is
+// always clamped here rather than trusted to be short.
+//
+// Clamped well under the hard limit, because a 256-character release name is
+// unreadable in the releases list anyway. Order of preference: the first
+// sentence, then a word-boundary cut, then the tag. The full text is never
+// lost, it is the first thing in the release body.
+const MAX_TITLE = 120;
+const GITHUB_MAX_TITLE = 256;
+
+export function clampTitle(text, tagFallback) {
+  const s = text.trim();
+  if (s.length <= MAX_TITLE) return s;
+
+  // A first sentence that fits is the natural title.
+  const firstSentence = s.match(/^(.+?[.!?])(?:\s|$)/)?.[1];
+  if (firstSentence && firstSentence.length <= MAX_TITLE) return firstSentence;
+
+  // Otherwise cut on a word boundary and mark the truncation.
+  const cut = s.slice(0, MAX_TITLE - 1);
+  const atSpace = cut.lastIndexOf(" ");
+  const trimmed = (atSpace > MAX_TITLE / 2 ? cut.slice(0, atSpace) : cut).replace(/[\s,;:.-]+$/, "");
+  const out = trimmed ? `${trimmed}...` : tagFallback;
+  return out.length <= GITHUB_MAX_TITLE ? out : tagFallback;
+}
+
 function title() {
   for (const l of section) {
     if (!l.trim()) continue;
     if (isHeading(l)) continue;
     if (isBullet(l)) break; // hit the bullets before any prose → use the bullet path
-    return l.trim().replace(/\*\*/g, ""); // prose title line (jeunesse style)
+    return clampTitle(l.trim().replace(/\*\*/g, ""), tag); // prose title line (jeunesse style)
   }
   const bullet = section.find(isBullet);
-  return bullet ? cleanBullet(bullet) : tag;
+  return bullet ? clampTitle(cleanBullet(bullet), tag) : tag;
 }
 
 // --- body ----------------------------------------------------------------------


### PR DESCRIPTION
The release workflow derives a GitHub Release name from the changelog's first prose line. GitHub rejects a name over 256 characters with a bare HTTP 422, and it does so **after** packages are staged, so the run fails with the release half done.

That is exactly what happened on the cliniques 1.0.0 release today: the changeset is a single paragraph running past 1,200 characters, so `gh release create` returned `name is too long (maximum is 256 characters)` and the whole step exited 1, even though staging had already succeeded.

## The fix

Titles are clamped to **120** characters, well under the hard limit, because a 256-character name is unreadable in the releases list anyway. Order of preference:

1. the first sentence, if it fits
2. a word-boundary cut with an ellipsis
3. the tag

Nothing is lost. The full text is already the first thing in the release body.

Verified against the two real changelogs:

- `@geoalgeria/cliniques@1.0.0` -> `New package \`@geoalgeria/cliniques\`, Algeria's clinics and proximity-care facilities from OpenStreetMap.` (105 chars, was 1,200+)
- `@geoalgeria/pharmacies@2.1.0` -> unchanged in shape, clamped at the sentence

Short titles pass through untouched, and a long title with no sentence boundary cuts on a word.