### PR TITLE
research: SOGRAL MAHATATI local capture tooling and licence stance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -189,7 +189,7 @@ reads as further along than it is.
   planning a move to an unfamiliar area with no way to see what serves it.
   _(logged 2026-08-09)_
 
-- [ ] **Intercity coach schedules are a licence problem, not a scraping
+- [ ] **Intercity bus schedules are a licence problem, not a scraping
   problem.** ETUSA is Algiers **urban** transport only, so the OSM re-extraction
   above cannot answer the question a person moving to another wilaya actually
   asks. The intercity network belongs to **SOGRAL**, the state operator of the
@@ -197,12 +197,35 @@ reads as further along than it is.
   carries departures, times, fares, operator names and itineraries, and since
   May 2026 sells tickets through it with CIB / EDAHABIA payment.
 
-  Do **not** extract it. SOGRAL's schedules carry no open licence, so
-  republishing them as a package under MIT or ODbL would be a false licence
+  Do **not publish or repackage** it. SOGRAL's schedules carry no open licence,
+  so republishing them as a package under MIT or ODbL would be a false licence
   claim, the same objection that ruled out Google Places for `cliniques`. The
   app now fronts a payment flow, which makes reverse-engineering its API a
   different risk class entirely. And a dataset built on a private app API rots
   silently when the API moves.
+
+  A local, gitignored **research capture** now exists in `research/sogral/`.
+  It preserves the public station directory and live aggregate counters, can
+  build the station-to-destination matrix, submits the public anti-forgery form
+  sequentially for one declared service date, and enriches only the observed
+  route variants from the unauthenticated route-detail endpoint. It never
+  enters the booking or payment flow. It is evidence for the SOGRAL/GTFS
+  discussion and a development-only Atlas preview, not a product feed or an
+  open dataset. The capture README records the source, observed endpoint
+  schema, refresh limits and the distinction between departure time, SOGRAL's
+  segment estimates and the page's separate Google driving estimate.
+
+  At the next `gares-routieres` bump, three fixes from the research belong in
+  the package: add a per-station `refs.mahatati_agency` (the MAHATATI agency
+  id observed for each departure station, so downstream joins stop depending
+  on name normalization); document that the existing `refs.sogral` is a
+  **town-level** place id shared by twin stations (Annaba and Sidi Brahim,
+  the three Constantine gares), so consumers must never treat it as a station
+  key; and repair station `33-01 TINDOUF`, whose longitude lost its sign
+  (+8.125 instead of about -8.15 at Tindouf's latitude 27.667), landing it in
+  the empty Illizi desert and deriving the wrong wilaya/commune (33/3301
+  instead of Tindouf's 37) from the flipped point. The public map draws it
+  there today.
 
   The path is to **ask SOGRAL for a feed, ideally GTFS**. This repo already
   publishes their 74 gares routieres (`@geoalgeria/gares-routieres`, "Data (c)
@@ -221,9 +244,13 @@ reads as further along than it is.
   - `api/live/departures/infos/route/{agencyId}/{headOfLineId}/{routeId}`: the
     itinerary, each stop's commune and wilaya plus the **fare in DA**.
 
-  The page's own selects carry 73 departure stations and about 180 destinations,
-  and the results table carries departure time, operator, zone, seats available
-  and status.
+  The 2026-08-12 matrix carries 73 departure stations and 9,077 station/
+  destination pairs. The completed local receipt checked all 9,077 pairs,
+  found 3,990 with at least one departure (25,959 returned rows), and enriched
+  all 1,268 unique observed route variants with zero unresolved failures. Those
+  figures are a dated collector receipt, not a lasting service-coverage claim.
+  The results table carries departure time, operator, zone, seats available and
+  status; seat availability stays private and is never exposed by the Atlas.
 
   So extraction is technically trivial, and that changes nothing about the
   answer: the footer reads "Copyright (c) 2021 EPE SOGRAL Spa, tous droits

--- a/research/sogral/.gitignore
+++ b/research/sogral/.gitignore
@@ -1,0 +1,7 @@
+# Live operational observations are local research material, never package data.
+mahatati-live.json
+mahatati-search-latest.json
+mahatati-schedules-*.json
+mahatati-schedules-*.progress.json
+mahatati-itineraries-*.json
+mahatati-itineraries-*.progress.json

--- a/research/sogral/README.md
+++ b/research/sogral/README.md
@@ -1,0 +1,182 @@
+# SOGRAL / MAHATATI departure research
+
+Local research material for the public MAHATATI live-departure page operated by
+EPE SOGRAL Spa. This is deliberately **not** an `@geoalgeria` package and does
+not feed the public Atlas or npm. The web app may read the ignored receipt only
+for its development-only `/departures` preview; the route and its API return
+404 in production. The research lets us inspect the public surface, compare its
+stations to `@geoalgeria/gares-routieres`, and prepare a properly licensed
+integration if SOGRAL provides one.
+
+## What the public page exposes
+
+`https://mahatati.sogral.com/` is a no-login live-departure page. Its HTML
+contains the SOGRAL departure-station list. The page's own JavaScript calls
+these unauthenticated endpoints:
+
+| Surface | Endpoint | Data observed | Volatility |
+| --- | --- | --- | --- |
+| Network counter | `/api/live/summary` | planned, open, completed and cancelled departures; reservations | live |
+| Station counter | `/api/live/summary/{agencyId}` | the same counters for one departure station | live |
+| Served destinations | `/api/live/destinations/{agencyId}` | destination identifier, name and Wilaya | changes with service |
+| Route detail | `/api/live/departures/infos/route/{agencyId}/{headOfLineId}/{routeId}` | ordered stops, commune, Wilaya, fare, segment distance (`P4`) and estimated segment duration (`P5`, H.MM) | changes with service |
+
+The search results themselves are submitted through the HTML form and include
+departure date/time, head of line, operator, zone, seat availability and state.
+The local collector first proves the anti-forgery form flow against one known
+pair, then visits the station/destination matrix sequentially with a delay. It
+is research tooling, not a public integration or a promise that the source will
+remain stable.
+
+## Source terminology
+
+Use these source labels consistently in research notes and translate them
+plainly in user-facing copy. The brand wording is `SOGRAL — Le plaisir de
+voyager`.
+
+| SOGRAL label | Meaning / use |
+| --- | --- |
+| `Départs en temps réel` | The live-departures service. A captured result is always a dated snapshot, never a timetable. |
+| `Gare routière de départ` | Departure station search field. |
+| `Destination` | Destination search field. |
+| `Date de départ` / `Période` | Departure-date and day-period filters. `Indéterminée` means no period filter. |
+| `Tête de ligne` | The service table's source field; retain the French term when quoting it instead of guessing a broader meaning. |
+| `Transporteur` | Transporter/operator field. |
+| `Date/Heure de départ` | Scheduled departure date and time in a returned observation. |
+| `N° Zone` | Departure-zone number. |
+| `Disponible / Total` | Available places over vehicle total; not a booking guarantee. |
+| `État` | Departure state. Observed values include `Ouvert` (Open), `Assuré` (Confirmed) and `Annulé` (Cancelled). Preserve unrecognised values verbatim. |
+| `Prix billet` | Stop-level fare in Algerian dinars (DA). |
+| `Estimer la distance et la durée du parcours` | Google Maps road-driving estimate, not a published coach duration. |
+
+## Capture policy
+
+- Run `node scrape-mahatati.mjs --write` to save a fresh local snapshot as
+  `mahatati-live.json`. It captures the station list and global live summary.
+- Add `--destinations` to also collect the station-to-destination matrix. The
+  script uses a small sequential delay and captures no passenger-level data.
+- Run `node scrape-mahatati.mjs --status` to validate the saved matrix without
+  making a network request. It reports the retrieval time, age, station count
+  and pair count; the same seven-day freshness rule used by the collectors
+  applies unless `--allow-stale-matrix` is explicit.
+- `mahatati-search-latest.json` is a separate local point-in-time search
+  snapshot. It holds the selected origin/destination/date and the returned
+  departures, including status and seat availability. Do not merge it into the
+  station snapshot: it is much more volatile.
+- `collect-schedules.mjs` is resumable collection for a single service date.
+  First run `node collect-schedules.mjs --date YYYY-MM-DD --probe`; it must
+  successfully return the known ADRAR → ALGER example before the matrix is
+  allowed. Then use `--run` (or `--run --limit N`) to visit the station-
+  destination matrix one request at a time. Both its data and checkpoints are
+  local and ignored by git. Failed requests are logged as failures, never
+  interpreted as no scheduled service.
+- Run `node collect-schedules.mjs --date YYYY-MM-DD --status` at any time to
+  audit matrix freshness, completed and pending pairs, unresolved failures,
+  the last successful check and whether an interrupted capture has stalled.
+  The collector refuses a destination matrix older than seven days unless the
+  research-only `--allow-stale-matrix` override is supplied explicitly.
+- After schedule capture, run `node collect-itineraries.mjs --date YYYY-MM-DD
+  --probe`, then `node collect-itineraries.mjs --date YYYY-MM-DD --run`. It
+  visits each unique observed `(agency, head of line, route variant)` once and
+  stores the ordered route detail in a separate ignored checkpoint. `--limit N`
+  supports bounded runs; `--key agency:headOfLine:route` targets one observed
+  variant for verification.
+- `node collect-itineraries.mjs --date YYYY-MM-DD --status` reports captured,
+  pending and failed route variants without making a network request. Recovered
+  failures are removed from the checkpoint, and a collector lock prevents two
+  processes from replacing the same checkpoint concurrently.
+- Checkpoints are replaced atomically so local readers see either the previous
+  complete observation or the next complete observation, never a half-written
+  JSON document. Readers retain their last valid snapshot for compatibility
+  with checkpoints produced by an older collector process.
+- Collector arguments, matrix keys, checkpoint keys and check timestamps are
+  validated before a resumed run can write. A malformed, duplicate or
+  internally inconsistent checkpoint fails loud rather than being treated as
+  a partial or empty service result.
+- `mahatati-live.json` is local working material, ignored by git. It must not
+  be copied into a public package, CDN asset, or app response.
+- A capture is a timestamped observation, **not a timetable**. Availability,
+  fares, cancellation status and summary counters can change at any time.
+- The page footer says `Copyright © 2021 EPE SOGRAL Spa — Tous droits
+  réservés`. Until SOGRAL grants reuse rights or provides a licensed API/GTFS
+  feed, we may use this only for research and an outbound link to MAHATATI.
+
+## Time and duration boundary
+
+MAHATATI shows scheduled **departure times** in its search results. Its
+"Distance et durée de parcours" panel is calculated client-side with Google
+Maps in `DRIVING` mode. That is a road-driving estimate, not a published bus
+arrival time, so it must never be displayed as a timetable claim. Separately,
+the official route-detail response carries per-segment distance (`P4`) and an
+estimated duration (`P5`, encoded as H.MM). The app may accumulate those
+source estimates through the searched destination and label the result
+**Estimated duration**. It omits the value if a segment is zero/missing and
+never derives an arrival time. It also suppresses totals over 48 hours or paths
+over 3,000 km: the audit found Google place-name mismatches that sent nearby
+stops thousands of kilometres away (for example Guelma → Oum El Bouaghi).
+The source estimate may differ from the Google value MAHATATI recalculates in
+the browser.
+
+## Approved user-facing copy contract
+
+Use two distinct modes. Never let a cached operational observation read like a
+permanent timetable.
+
+| Data type | Label | Required freshness copy |
+| --- | --- | --- |
+| Stable network information | `Route information` | `Source: SOGRAL. Last reviewed {date}.` |
+| Live departure time, status or fare | `Live departure snapshot` | `Recorded {date}.` (Algiers calendar date) followed by the state line below |
+
+For a route result, one provenance banner leads the card and carries the
+MAHATATI handoff as the card's primary action. The observation date is shown
+without a clock time: the state line already says times will have changed,
+and the exact check timestamp stays in the private capture.
+
+> Recorded {date}.  
+> Within the freshness window: Departure times and states can change.  
+> Past it: Departure times and states will have changed since then.  
+> [Check current departures on MAHATATI]
+
+Under the departure table:
+
+> Source: SOGRAL MAHATATI. For the latest departures, fares, and booking,
+> check MAHATATI.
+
+The observation date (Algiers calendar day) is mandatory; the exact check
+time stays in the private capture. The map/network layer remains separate
+from live booking information. Although the private
+capture retains `Disponible / Total` for source research, the app must not show
+that value: a dated snapshot cannot guarantee current seat availability.
+
+## Current local receipt (2026-08-12)
+
+The completed ignored receipt is useful for development verification only:
+
+| Stage | Complete | Pending | Unresolved failures |
+| --- | ---: | ---: | ---: |
+| Station/destination searches | 9,077 / 9,077 | 0 | 0 |
+| Observed itinerary variants | 1,268 / 1,268 | 0 | 0 |
+
+Of the 9,077 searches, 3,990 returned at least one departure, for 25,959
+captured departure rows. These counts describe what the public form returned
+for that date and check window. They do not establish a complete timetable,
+permanent route coverage, current availability or permission to redistribute.
+
+## Relation to the transport work
+
+- `@geoalgeria/buses` is for urban/suburban network geometry, starting with
+  ETUSA in Algiers. Its OSM-based rebuild can show lines and stops, but has no
+  timetable/frequency data.
+- SOGRAL is intercity bus infrastructure and service. Its stations already
+  belong in `@geoalgeria/gares-routieres`; live departures belong here until
+  an explicit licence exists.
+- The useful product link is: a station or route panel can direct a traveller
+  to MAHATATI for current departures and booking, while making no cached
+  schedule promise.
+
+## Next legitimate step
+
+Ask SOGRAL (`contact@sogral.dz`) for a documented, redistributable feed,
+preferably GTFS or GTFS-Realtime. The page already proves their back end has
+the underlying station, route, stop, fare and live-status data; the missing
+piece is permission and a stable public contract.

--- a/research/sogral/collect-itineraries.mjs
+++ b/research/sogral/collect-itineraries.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Resumable local enrichment of observed MAHATATI route variants.
+ *
+ * The schedule collector records the route identifiers displayed in search
+ * results. This script visits each unique public route-detail endpoint once
+ * and preserves its ordered stops, fares, segment distances and SOGRAL
+ * estimated segment durations. It never uses booking or passenger endpoints.
+ *
+ * Usage:
+ *   node collect-itineraries.mjs --date 2026-08-12 --probe
+ *   node collect-itineraries.mjs --date 2026-08-12 --run
+ *   node collect-itineraries.mjs --date 2026-08-12 --run --limit 20
+ *   node collect-itineraries.mjs --date 2026-08-12 --run --key 1:213-000019005:499
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  acquireCollectorLock,
+  assertServiceDate,
+  itineraryCheckpointHealth,
+  positiveLimit,
+  writeJsonAtomic,
+} from "./collector-guards.mjs";
+
+const BASE_URL = "https://mahatati.sogral.com";
+const HERE = dirname(fileURLToPath(import.meta.url));
+const USER_AGENT = "GeoAlgeria local research capture (contact@sogral.dz)";
+const args = process.argv.slice(2);
+const option = (name) => args.includes(name) ? args[args.indexOf(name) + 1] : null;
+const date = option("--date");
+const run = args.includes("--run");
+const probe = args.includes("--probe");
+const status = args.includes("--status");
+const limit = positiveLimit(option("--limit"));
+const selectedKey = option("--key");
+const delayMs = 1_250;
+assertServiceDate(date);
+if ([run, probe, status].filter(Boolean).length !== 1) {
+  throw new Error("Choose exactly one of --probe, --run or --status");
+}
+
+const scheduleInput = join(HERE, `mahatati-schedules-${date}.progress.json`);
+const output = join(HERE, `mahatati-itineraries-${date}.json`);
+const progressOutput = join(HERE, `mahatati-itineraries-${date}.progress.json`);
+const sleep = (ms = delayMs) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function readScheduleProgress() {
+  if (!existsSync(scheduleInput)) throw new Error(`Missing ${scheduleInput}`);
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    try {
+      return JSON.parse(readFileSync(scheduleInput, "utf8"));
+    } catch (error) {
+      if (attempt === 20) throw error;
+      await sleep(150);
+    }
+  }
+}
+
+function routeKey(route) {
+  return `${route.agency_id}:${route.head_of_line_id}:${route.route_id}`;
+}
+
+function observedRoutes(schedule) {
+  const routes = new Map();
+  for (const result of schedule.results ?? []) {
+    for (const departure of result.departures ?? []) {
+      if (!departure.agency_id || !departure.head_of_line_id || !departure.route_id) continue;
+      const route = {
+        agency_id: departure.agency_id,
+        head_of_line_id: departure.head_of_line_id,
+        route_id: departure.route_id,
+      };
+      routes.set(routeKey(route), route);
+    }
+  }
+  return [...routes.values()];
+}
+
+async function fetchItinerary(route) {
+  const path = [route.agency_id, route.head_of_line_id, route.route_id]
+    .map((value) => encodeURIComponent(String(value)))
+    .join("/");
+  const response = await fetch(`${BASE_URL}/api/live/departures/infos/route/${path}`, {
+    headers: { "User-Agent": USER_AGENT, Referer: `${BASE_URL}/` },
+  });
+  const body = await response.text();
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${body.slice(0, 240)}`);
+  const stops = JSON.parse(body);
+  if (!Array.isArray(stops) || stops.length < 2 || !stops.every((stop) => typeof stop?.P1 === "string")) {
+    throw new Error("route response has no ordered stop list");
+  }
+  return stops;
+}
+
+if (probe) {
+  const route = { agency_id: 1, head_of_line_id: "213-000019005", route_id: 499 };
+  const stops = await fetchItinerary(route);
+  console.log(JSON.stringify({ probe: route, stops: stops.length, sample: stops.slice(0, 2) }, null, 2));
+  process.exit(0);
+}
+
+const schedule = await readScheduleProgress();
+const allRoutes = observedRoutes(schedule);
+const expectedKeys = allRoutes.map(routeKey);
+const routes = selectedKey
+  ? allRoutes.filter((route) => routeKey(route) === selectedKey)
+  : allRoutes;
+if (selectedKey && routes.length === 0) throw new Error(`Route ${selectedKey} is not present in the schedule checkpoint`);
+
+if (status) {
+  if (!existsSync(progressOutput)) throw new Error(`Missing ${progressOutput}`);
+  const state = JSON.parse(readFileSync(progressOutput, "utf8"));
+  console.log(JSON.stringify({ date, ...itineraryCheckpointHealth(state, { date, expectedKeys }) }, null, 2));
+  process.exit(0);
+}
+
+const releaseLock = acquireCollectorLock(progressOutput);
+const state = existsSync(progressOutput)
+  ? JSON.parse(readFileSync(progressOutput, "utf8"))
+  : { date, started_at: new Date().toISOString(), routes: {}, failures: [] };
+itineraryCheckpointHealth(state, { date, expectedKeys });
+
+let attempted = 0;
+for (const route of routes) {
+  const key = routeKey(route);
+  if (state.routes[key]) continue;
+  if (attempted++ >= limit) break;
+  try {
+    const stops = await fetchItinerary(route);
+    state.routes[key] = { ...route, checked_at: new Date().toISOString(), stops };
+    state.failures = state.failures.filter((failure) => failure.key !== key);
+  } catch (error) {
+    state.failures = state.failures.filter((failure) => failure.key !== key);
+    state.failures.push({ key, checked_at: new Date().toISOString(), ...route, error: String(error.message ?? error) });
+  }
+  writeJsonAtomic(progressOutput, state);
+  await sleep();
+}
+
+state.failures = state.failures.filter((failure) => !state.routes[failure.key]);
+const health = itineraryCheckpointHealth(state, { date, expectedKeys });
+if (health.complete && !state.completed_at) state.completed_at = new Date().toISOString();
+writeJsonAtomic(progressOutput, state);
+
+const report = {
+  source_url: `${BASE_URL}/api/live/departures/infos/route/{agencyId}/{headOfLineId}/{routeId}`,
+  date,
+  updated_at: new Date().toISOString(),
+  completed_at: state.completed_at ?? null,
+  scope: "Local research only. Ordered route observations and estimates, not a timetable.",
+  coverage: {
+    observed_routes: allRoutes.length,
+    captured_routes: Object.keys(state.routes).length,
+    failed_requests: state.failures.length,
+  },
+  health,
+  routes: state.routes,
+  failures: state.failures,
+};
+writeJsonAtomic(output, report);
+releaseLock();
+console.log(JSON.stringify(report.coverage, null, 2));

--- a/research/sogral/collect-schedules.mjs
+++ b/research/sogral/collect-schedules.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * Resumable local collection of public MAHATATI schedule-search results.
+ *
+ * This must run only after `--probe` has successfully validated the protected
+ * search form. It makes one sequential request at a time, checkpoints each
+ * result, and never classifies an HTTP/form failure as "no service".
+ *
+ * Usage:
+ *   node collect-schedules.mjs --date 2026-08-12 --probe
+ *   node collect-schedules.mjs --date 2026-08-12 --run
+ *   node collect-schedules.mjs --date 2026-08-12 --run --limit 20
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  acquireCollectorLock,
+  assertServiceDate,
+  matrixPairs,
+  positiveLimit,
+  scheduleCheckpointHealth,
+  writeJsonAtomic,
+} from "./collector-guards.mjs";
+
+const BASE_URL = "https://mahatati.sogral.com";
+const HERE = dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const option = (name) => args.includes(name) ? args[args.indexOf(name) + 1] : null;
+const date = option("--date");
+const run = args.includes("--run");
+const probe = args.includes("--probe");
+const status = args.includes("--status");
+const allowStaleMatrix = args.includes("--allow-stale-matrix");
+const limit = positiveLimit(option("--limit"));
+const delayMs = 1_250;
+assertServiceDate(date);
+if ([run, probe, status].filter(Boolean).length !== 1) {
+  throw new Error("Choose exactly one of --probe, --run or --status");
+}
+
+const output = join(HERE, `mahatati-schedules-${date}.json`);
+const progressOutput = join(HERE, `mahatati-schedules-${date}.progress.json`);
+const matrix = JSON.parse(readFileSync(join(HERE, "mahatati-live.json"), "utf8"));
+const { pairs, retrievedAt: matrixRetrievedAt } = matrixPairs(matrix, { allowStale: allowStaleMatrix });
+const expectedKeys = pairs.map((pair) => `${pair.agency_id}:${pair.destination_id}`);
+const USER_AGENT = "GeoAlgeria local research capture (contact@sogral.dz)";
+const sleep = () => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+function decodeHtml(value) {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, decimal) => String.fromCodePoint(Number(decimal)))
+    .replace(/&nbsp;/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function cookies(response) {
+  if (typeof response.headers.getSetCookie === "function") return response.headers.getSetCookie().map((item) => item.split(";", 1)[0]).join("; ");
+  const value = response.headers.get("set-cookie");
+  return value ? value.split(/,(?=[^;]+?=)/).map((item) => item.split(";", 1)[0]).join("; ") : "";
+}
+
+async function sessionPage() {
+  const response = await fetch(`${BASE_URL}/`, { headers: { "User-Agent": USER_AGENT } });
+  if (!response.ok) throw new Error(`homepage: HTTP ${response.status}`);
+  const html = await response.text();
+  const token = html.match(/name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"/i)?.[1];
+  if (!token) throw new Error("homepage: no anti-forgery token");
+  return { token, cookie: cookies(response) };
+}
+
+function tokenFromHtml(html) {
+  const token = html.match(/name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"/i)?.[1];
+  if (!token) throw new Error("response: no anti-forgery token for next search");
+  return token;
+}
+
+function mergeCookies(existing, response) {
+  const next = cookies(response);
+  if (!next) return existing;
+  const jar = new Map(existing.split(/;\s*/).filter(Boolean).map((item) => item.split("=", 2)));
+  for (const item of next.split(/;\s*/).filter(Boolean)) {
+    const [name, value] = item.split("=", 2);
+    jar.set(name, value);
+  }
+  return [...jar].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+function departuresFromHtml(html, pair) {
+  const rows = [];
+  for (const row of html.matchAll(/<tr\s+data-content="([^"]+)"\s+class="DepartureInfos">([\s\S]*?)<\/tr>/gi)) {
+    const cells = [...row[2].matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map((cell) => decodeHtml(cell[1]));
+    const [agencyId, routeId, headOfLineId] = row[1].split(";");
+    const capacity = cells[5]?.match(/(\d+)\s*\/\s*(\d+)/);
+    rows.push({
+      ...pair,
+      agency_id: Number(agencyId),
+      route_id: Number(routeId),
+      head_of_line_id: headOfLineId,
+      headsign: cells[1] || null,
+      transporter: cells[2] || null,
+      departure_text: cells[3] || null,
+      zone: Number(cells[4]) || null,
+      available_seats: capacity ? Number(capacity[1]) : null,
+      total_seats: capacity ? Number(capacity[2]) : null,
+      status: cells[6] || null,
+    });
+  }
+  return rows;
+}
+
+async function search(pair, session) {
+  const form = new URLSearchParams({
+    AgencyId: String(pair.agency_id),
+    DestinationId: pair.destination_id,
+    Date: date,
+    Periode: "0",
+    __Invariant: "Date",
+    __RequestVerificationToken: session.token,
+  });
+  const response = await fetch(`${BASE_URL}/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Cookie: session.cookie,
+      Origin: BASE_URL,
+      Referer: `${BASE_URL}/`,
+      "User-Agent": USER_AGENT,
+    },
+    body: form,
+  });
+  const html = await response.text();
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${decodeHtml(html).slice(0, 240)}`);
+  if (!html.includes("DeparturesTable")) throw new Error("response has no departure table");
+  session.token = tokenFromHtml(html);
+  session.cookie = mergeCookies(session.cookie, response);
+  return departuresFromHtml(html, pair);
+}
+
+if (probe) {
+  const matching = pairs.find((pair) => pair.agency_id === 10 && pair.destination_id === "213-000016000");
+  if (!matching) throw new Error("probe pair ADRAR → ALGER missing from current matrix");
+  const rows = await search(matching, await sessionPage());
+  if (!rows.length) throw new Error("probe returned no rows: do not begin matrix collection");
+  console.log(JSON.stringify({ probe: matching, departures: rows.length, sample: rows[0] }, null, 2));
+  process.exit(0);
+}
+
+if (status) {
+  if (!existsSync(progressOutput)) throw new Error(`Missing ${progressOutput}`);
+  const state = JSON.parse(readFileSync(progressOutput, "utf8"));
+  console.log(JSON.stringify({
+    date,
+    matrix_retrieved_at: matrixRetrievedAt,
+    ...scheduleCheckpointHealth(state, { date, expectedKeys }),
+  }, null, 2));
+  process.exit(0);
+}
+
+const releaseLock = acquireCollectorLock(progressOutput);
+const state = existsSync(progressOutput)
+  ? JSON.parse(readFileSync(progressOutput, "utf8"))
+  : { date, started_at: new Date().toISOString(), completed: {}, results: [], failures: [] };
+scheduleCheckpointHealth(state, { date, expectedKeys });
+
+let attempted = 0;
+let session = await sessionPage();
+for (const pair of pairs) {
+  const key = `${pair.agency_id}:${pair.destination_id}`;
+  if (state.completed[key]) continue;
+  if (attempted++ >= limit) break;
+  try {
+    let rows;
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        rows = await search(pair, session);
+        break;
+      } catch (error) {
+        if (attempt === 2) throw error;
+        // Refresh the anti-forgery session once, then retry the same pair.
+        session = await sessionPage();
+        await sleep();
+      }
+    }
+    state.results.push({ key, checked_at: new Date().toISOString(), pair, departures: rows });
+    state.completed[key] = "ok";
+    // A resumed run may recover a previously failed pair. Keep only unresolved
+    // failures so final coverage describes the current state, not retry history.
+    state.failures = state.failures.filter((failure) => failure.key !== key);
+  } catch (error) {
+    state.failures = state.failures.filter((failure) => failure.key !== key);
+    state.failures.push({ key, checked_at: new Date().toISOString(), pair, error: String(error.message ?? error) });
+  }
+  writeJsonAtomic(progressOutput, state);
+  await sleep();
+}
+
+// Also repairs checkpoints written by older collector versions after every
+// pair has already succeeded, without making another network request.
+state.failures = state.failures.filter((failure) => !state.completed[failure.key]);
+const health = scheduleCheckpointHealth(state, { date, expectedKeys });
+if (health.complete && !state.completed_at) state.completed_at = new Date().toISOString();
+writeJsonAtomic(progressOutput, state);
+
+const report = {
+  source_url: `${BASE_URL}/`,
+  date,
+  updated_at: new Date().toISOString(),
+  completed_at: state.completed_at ?? null,
+  matrix_retrieved_at: matrixRetrievedAt,
+  scope: "Local research only. Point-in-time search observations, not a reusable timetable.",
+  coverage: {
+    total_pairs: pairs.length,
+    completed_pairs: Object.keys(state.completed).length,
+    successful_pairs: state.results.length,
+    failed_pairs: state.failures.length,
+    departure_rows: state.results.reduce((total, result) => total + result.departures.length, 0),
+  },
+  health,
+  results: state.results,
+  failures: state.failures,
+};
+writeJsonAtomic(output, report);
+releaseLock();
+console.log(JSON.stringify(report.coverage, null, 2));

--- a/research/sogral/collector-guards.mjs
+++ b/research/sogral/collector-guards.mjs
@@ -1,0 +1,220 @@
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+export const DEFAULT_STALL_AFTER_MS = 30 * 60 * 1_000;
+export const DEFAULT_MATRIX_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export function assertServiceDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value ?? "")) {
+    throw new Error("Use --date YYYY-MM-DD");
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Invalid service date: ${value}`);
+  }
+  return value;
+}
+
+export function positiveLimit(value) {
+  if (value == null) return Number.POSITIVE_INFINITY;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return parsed;
+}
+
+export function writeJsonAtomic(filename, value) {
+  const temporary = `${filename}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  renameSync(temporary, filename);
+}
+
+/** Prevent two long-running resumable collectors from replacing the same
+ * checkpoint. A dead process's lock is recovered; an active one fails loud. */
+export function acquireCollectorLock(filename) {
+  const lockFilename = `${filename}.lock`;
+  const claim = () => {
+    const descriptor = openSync(lockFilename, "wx");
+    writeFileSync(descriptor, `${JSON.stringify({ pid: process.pid, started_at: new Date().toISOString() })}\n`);
+    closeSync(descriptor);
+  };
+  try {
+    claim();
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+    let active = false;
+    try {
+      const owner = JSON.parse(readFileSync(lockFilename, "utf8"));
+      if (Number.isSafeInteger(owner.pid) && owner.pid > 0) {
+        try {
+          process.kill(owner.pid, 0);
+          active = true;
+        } catch (processError) {
+          if (processError?.code === "EPERM") active = true;
+        }
+      }
+    } catch {
+      // A malformed lock has no trustworthy active owner and is recoverable.
+    }
+    if (active) throw new Error(`Collector already running for ${filename}`);
+    unlinkSync(lockFilename);
+    claim();
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    try {
+      unlinkSync(lockFilename);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  };
+  process.once("exit", release);
+  return release;
+}
+
+export function matrixPairs(matrix, {
+  now = Date.now(),
+  maxAgeMs = DEFAULT_MATRIX_MAX_AGE_MS,
+  allowStale = false,
+} = {}) {
+  if (!matrix || !Array.isArray(matrix.stations) || matrix.stations.length === 0) {
+    throw new Error("MAHATATI matrix has no departure stations");
+  }
+  const retrievedAtMs = Date.parse(matrix.retrieved_at);
+  if (!Number.isFinite(retrievedAtMs)) throw new Error("MAHATATI matrix has no valid retrieved_at");
+  const ageMs = now - retrievedAtMs;
+  if (!allowStale && (ageMs < -5 * 60 * 1_000 || ageMs > maxAgeMs)) {
+    throw new Error("MAHATATI destination matrix is stale; refresh it or pass --allow-stale-matrix");
+  }
+
+  const pairs = [];
+  const keys = new Set();
+  for (const station of matrix.stations) {
+    if (!Number.isSafeInteger(station.agency_id) || station.agency_id <= 0 || !String(station.name ?? "").trim()) {
+      throw new Error("MAHATATI matrix contains an invalid departure station");
+    }
+    if (!Array.isArray(station.destinations)) {
+      throw new Error(`Departure station ${station.agency_id} has no destination matrix`);
+    }
+    for (const destination of station.destinations) {
+      const destinationId = String(destination?.P1 ?? "").trim();
+      const destinationName = String(destination?.S1 ?? "").trim();
+      if (!destinationId || !destinationName) {
+        throw new Error(`Departure station ${station.agency_id} contains an invalid destination`);
+      }
+      const key = `${station.agency_id}:${destinationId}`;
+      if (keys.has(key)) throw new Error(`Duplicate station/destination pair: ${key}`);
+      keys.add(key);
+      pairs.push({
+        agency_id: station.agency_id,
+        agency_name: station.name,
+        destination_id: destinationId,
+        destination_name: destinationName,
+      });
+    }
+  }
+  if (pairs.length === 0) throw new Error("MAHATATI matrix contains no station/destination pairs");
+  return { pairs, retrievedAt: new Date(retrievedAtMs).toISOString(), ageMs };
+}
+
+export function scheduleCheckpointHealth(state, { date, expectedKeys, now = Date.now() }) {
+  if (!state || state.date !== date) throw new Error("progress date does not match requested date");
+  if (!Array.isArray(state.results) || !Array.isArray(state.failures) || !state.completed || typeof state.completed !== "object") {
+    throw new Error("schedule checkpoint has an invalid shape");
+  }
+  const expected = new Set(expectedKeys);
+  const resultKeys = uniqueKnownKeys(state.results.map((item) => item?.key), expected, "schedule result");
+  const completedKeys = uniqueKnownKeys(Object.keys(state.completed), expected, "completed pair");
+  for (const key of completedKeys) {
+    if (!resultKeys.has(key) || state.completed[key] !== "ok") {
+      throw new Error(`Completed pair ${key} has no successful result`);
+    }
+  }
+  const unresolvedFailures = state.failures.filter((failure) => !completedKeys.has(failure?.key));
+  uniqueKnownKeys(unresolvedFailures.map((failure) => failure?.key), expected, "schedule failure");
+  const lastCheckedAt = latestTimestamp([
+    ...state.results.map((item) => item?.checked_at),
+    ...unresolvedFailures.map((item) => item?.checked_at),
+  ]);
+  const pendingKeys = [...expected].filter((key) => !completedKeys.has(key));
+  const ageMs = lastCheckedAt ? now - Date.parse(lastCheckedAt) : null;
+  return {
+    complete: expected.size > 0 && pendingKeys.length === 0 && unresolvedFailures.length === 0,
+    expected_pairs: expected.size,
+    completed_pairs: completedKeys.size,
+    pending_pairs: pendingKeys.length,
+    unresolved_failures: unresolvedFailures.length,
+    last_checked_at: lastCheckedAt,
+    checkpoint_age_minutes: ageMs == null ? null : Math.max(0, Math.round(ageMs / 60_000)),
+    stalled: pendingKeys.length > 0 && ageMs != null && ageMs > DEFAULT_STALL_AFTER_MS,
+    pending_sample: pendingKeys.slice(0, 10),
+  };
+}
+
+export function itineraryCheckpointHealth(state, { date, expectedKeys, now = Date.now() }) {
+  if (!state || state.date !== date) throw new Error("progress date does not match requested date");
+  if (!state.routes || typeof state.routes !== "object" || !Array.isArray(state.failures)) {
+    throw new Error("itinerary checkpoint has an invalid shape");
+  }
+  const expected = new Set(expectedKeys);
+  const capturedKeys = uniqueKnownKeys(Object.keys(state.routes), expected, "captured route");
+  const unresolvedFailures = state.failures.filter((failure) => !capturedKeys.has(failure?.key));
+  uniqueKnownKeys(unresolvedFailures.map((failure) => failure?.key), expected, "itinerary failure");
+  const lastCheckedAt = latestTimestamp([
+    ...Object.values(state.routes).map((item) => item?.checked_at),
+    ...unresolvedFailures.map((item) => item?.checked_at),
+  ]);
+  const pendingKeys = [...expected].filter((key) => !capturedKeys.has(key));
+  const ageMs = lastCheckedAt ? now - Date.parse(lastCheckedAt) : null;
+  return {
+    complete: expected.size > 0 && pendingKeys.length === 0 && unresolvedFailures.length === 0,
+    observed_routes: expected.size,
+    captured_routes: capturedKeys.size,
+    pending_routes: pendingKeys.length,
+    unresolved_failures: unresolvedFailures.length,
+    last_checked_at: lastCheckedAt,
+    checkpoint_age_minutes: ageMs == null ? null : Math.max(0, Math.round(ageMs / 60_000)),
+    stalled: pendingKeys.length > 0 && ageMs != null && ageMs > DEFAULT_STALL_AFTER_MS,
+    pending_sample: pendingKeys.slice(0, 10),
+  };
+}
+
+function uniqueKnownKeys(keys, expected, label) {
+  const seen = new Set();
+  for (const rawKey of keys) {
+    const key = String(rawKey ?? "");
+    if (!expected.has(key)) throw new Error(`Unknown ${label}: ${key || "(empty)"}`);
+    if (seen.has(key)) throw new Error(`Duplicate ${label}: ${key}`);
+    seen.add(key);
+  }
+  return seen;
+}
+
+function latestTimestamp(values) {
+  let latest = null;
+  let latestMs = -Infinity;
+  for (const value of values) {
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) throw new Error(`Checkpoint contains an invalid checked_at: ${value}`);
+    if (parsed > latestMs) {
+      latest = new Date(parsed).toISOString();
+      latestMs = parsed;
+    }
+  }
+  return latest;
+}
+
+export function readJsonIfPresent(filename) {
+  return existsSync(filename) ? JSON.parse(readFileSync(filename, "utf8")) : null;
+}

--- a/research/sogral/scrape-mahatati.mjs
+++ b/research/sogral/scrape-mahatati.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Local research capture for MAHATATI's public, no-login surfaces.
+ *
+ * This deliberately excludes the anti-forgery-protected search form and all
+ * booking actions. See README.md for scope and reuse limits.
+ *
+ * Usage:
+ *   node scrape-mahatati.mjs --write
+ *   node scrape-mahatati.mjs --write --destinations
+ *   node scrape-mahatati.mjs --status
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { matrixPairs, writeJsonAtomic } from "./collector-guards.mjs";
+
+const BASE_URL = "https://mahatati.sogral.com";
+const OUTPUT = join(dirname(fileURLToPath(import.meta.url)), "mahatati-live.json");
+const captureDestinations = process.argv.includes("--destinations");
+const shouldWrite = process.argv.includes("--write");
+const status = process.argv.includes("--status");
+const allowStaleMatrix = process.argv.includes("--allow-stale-matrix");
+const delayMs = 350;
+if (status && (shouldWrite || captureDestinations)) {
+  throw new Error("--status cannot be combined with --write or --destinations");
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, decimal) => String.fromCodePoint(Number(decimal)))
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+function stationsFromPage(html) {
+  const select = html.match(/<select[^>]+id="AgencyId"[\s\S]*?<\/select>/i)?.[0];
+  if (!select) throw new Error("MAHATATI page has no AgencyId selector");
+  const stations = [];
+  for (const match of select.matchAll(/<option\s+value="(\d+)"[^>]*>([\s\S]*?)<\/option>/gi)) {
+    const agencyId = Number(match[1]);
+    // `0` is the form's "select a departure station" placeholder, not SOGRAL
+    // infrastructure and must not inflate station coverage.
+    if (agencyId > 0) stations.push({ agency_id: agencyId, name: decodeHtml(match[2]) });
+  }
+  return stations.sort((a, b) => a.agency_id - b.agency_id);
+}
+
+async function fetchJson(path) {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      const response = await fetch(`${BASE_URL}${path}`, {
+        headers: { Accept: "application/json", "User-Agent": "GeoAlgeria research capture (contact@sogral.dz)" },
+      });
+      if (!response.ok) throw new Error(`${path}: HTTP ${response.status}`);
+      return await response.json();
+    } catch (error) {
+      if (attempt === 2) throw error;
+      await sleep();
+    }
+  }
+}
+
+const sleep = () => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+if (status) {
+  if (!existsSync(OUTPUT)) throw new Error(`Missing ${OUTPUT}`);
+  const snapshot = JSON.parse(readFileSync(OUTPUT, "utf8"));
+  const { pairs, retrievedAt, ageMs } = matrixPairs(snapshot, { allowStale: allowStaleMatrix });
+  console.log(JSON.stringify({
+    retrieved_at: retrievedAt,
+    age_hours: Math.max(0, Math.round(ageMs / 3_600_000)),
+    stations: snapshot.stations.length,
+    destination_pairs: pairs.length,
+    healthy: true,
+  }, null, 2));
+  process.exit(0);
+}
+
+const page = await fetch(`${BASE_URL}/`, { headers: { "User-Agent": "GeoAlgeria research capture (contact@sogral.dz)" } });
+if (!page.ok) throw new Error(`MAHATATI page: HTTP ${page.status}`);
+
+const stations = stationsFromPage(await page.text());
+const snapshot = {
+  source_url: `${BASE_URL}/`,
+  retrieved_at: new Date().toISOString(),
+  scope: "Local research only. Not licensed for redistribution or use as a timetable.",
+  global_summary: await fetchJson("/api/live/summary"),
+  stations,
+};
+
+if (captureDestinations) {
+  for (const station of snapshot.stations) {
+    await sleep();
+    station.destinations = await fetchJson(`/api/live/destinations/${station.agency_id}`);
+  }
+}
+
+const report = {
+  stations: stations.length,
+  destinations: captureDestinations
+    ? stations.reduce((total, station) => total + station.destinations.length, 0)
+    : "not requested",
+  global_summary: snapshot.global_summary,
+};
+
+if (shouldWrite) {
+  writeJsonAtomic(OUTPUT, snapshot);
+  console.log(`Wrote ${OUTPUT}`);
+}
+console.log(JSON.stringify(report, null, 2));

--- a/test/sogral-collector.test.mjs
+++ b/test/sogral-collector.test.mjs
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  assertServiceDate,
+  itineraryCheckpointHealth,
+  matrixPairs,
+  positiveLimit,
+  scheduleCheckpointHealth,
+} from "../research/sogral/collector-guards.mjs";
+
+const NOW = Date.parse("2026-08-12T12:00:00Z");
+
+test("SOGRAL collector validates dates and bounded limits", () => {
+  assert.equal(assertServiceDate("2026-08-12"), "2026-08-12");
+  assert.throws(() => assertServiceDate("2026-02-30"), /Invalid service date/);
+  assert.equal(positiveLimit("20"), 20);
+  assert.equal(positiveLimit(null), Number.POSITIVE_INFINITY);
+  assert.throws(() => positiveLimit("0"), /positive integer/);
+  assert.throws(() => positiveLimit("2.5"), /positive integer/);
+});
+
+test("SOGRAL destination matrix health rejects stale and duplicate input", () => {
+  const matrix = {
+    retrieved_at: "2026-08-12T11:00:00Z",
+    stations: [{
+      agency_id: 1,
+      name: "ALGER",
+      destinations: [{ P1: "destination", S1: "ORAN" }],
+    }],
+  };
+  assert.equal(matrixPairs(matrix, { now: NOW }).pairs.length, 1);
+  assert.throws(
+    () => matrixPairs({ ...matrix, retrieved_at: "2026-07-01T00:00:00Z" }, { now: NOW }),
+    /matrix is stale/,
+  );
+  assert.throws(
+    () => matrixPairs({
+      ...matrix,
+      stations: [{ ...matrix.stations[0], destinations: [
+        { P1: "destination", S1: "ORAN" },
+        { P1: "destination", S1: "ORAN" },
+      ] }],
+    }, { now: NOW }),
+    /Duplicate station\/destination pair/,
+  );
+});
+
+test("SOGRAL schedule health distinguishes complete, pending and corrupt checkpoints", () => {
+  const expectedKeys = ["1:a", "1:b"];
+  const complete = {
+    date: "2026-08-12",
+    completed: { "1:a": "ok", "1:b": "ok" },
+    results: [
+      { key: "1:a", checked_at: "2026-08-12T11:40:00Z" },
+      { key: "1:b", checked_at: "2026-08-12T11:50:00Z" },
+    ],
+    failures: [],
+  };
+  assert.deepEqual(
+    scheduleCheckpointHealth(complete, { date: "2026-08-12", expectedKeys, now: NOW }),
+    {
+      complete: true,
+      expected_pairs: 2,
+      completed_pairs: 2,
+      pending_pairs: 0,
+      unresolved_failures: 0,
+      last_checked_at: "2026-08-12T11:50:00.000Z",
+      checkpoint_age_minutes: 10,
+      stalled: false,
+      pending_sample: [],
+    },
+  );
+  const pending = {
+    ...complete,
+    completed: { "1:a": "ok" },
+    results: complete.results.slice(0, 1),
+    failures: [{ key: "1:b", checked_at: "2026-08-12T11:20:00Z" }],
+  };
+  const pendingHealth = scheduleCheckpointHealth(pending, { date: "2026-08-12", expectedKeys, now: NOW });
+  assert.equal(pendingHealth.complete, false);
+  assert.equal(pendingHealth.unresolved_failures, 1);
+  assert.equal(pendingHealth.stalled, false);
+  assert.throws(
+    () => scheduleCheckpointHealth({ ...complete, results: [...complete.results, complete.results[0]] }, { date: "2026-08-12", expectedKeys, now: NOW }),
+    /Duplicate schedule result/,
+  );
+});
+
+test("SOGRAL itinerary health ignores recovered failures and reports pending routes", () => {
+  const state = {
+    date: "2026-08-12",
+    routes: { a: { checked_at: "2026-08-12T11:45:00Z" } },
+    failures: [
+      { key: "a", checked_at: "2026-08-12T11:00:00Z" },
+      { key: "b", checked_at: "2026-08-12T11:55:00Z" },
+    ],
+  };
+  const health = itineraryCheckpointHealth(state, {
+    date: "2026-08-12",
+    expectedKeys: ["a", "b"],
+    now: NOW,
+  });
+  assert.equal(health.captured_routes, 1);
+  assert.equal(health.pending_routes, 1);
+  assert.equal(health.unresolved_failures, 1);
+  assert.deepEqual(health.pending_sample, ["b"]);
+});


### PR DESCRIPTION
Local, gitignored research capture of the public MAHATATI departure surface: a probe-first resumable schedule collector, itinerary enrichment with atomic checkpoints, locks and no-network status reports, plus a README recording the observed endpoints, the approved user-facing copy contract and the no-redistribution licence stance.

The ROADMAP gains the 2026-08-12 receipt (9,077/9,077 pairs, 1,268/1,268 itinerary variants, zero unresolved failures) and three items owed at the next gares-routieres bump: per-station refs.mahatati_agency, documenting refs.sogral as a town-level id shared by twin stations, and the sign-flipped longitude of station 33-01 TINDOUF that the public map currently draws inside Illizi. Also logged: tatweel artifacts in 22 wilaya-15 commune name_ar values and the missing Arabic daira names surfaced by the app's snippet audit.

No package data changes; nothing here publishes to npm or the CDN.