### PR TITLE
fix: ecoles: 3 records labeled commune El Harrach (16) sit at Bordj Menaiel/Isser coordinates, 55 km away

### DIFF
--- a/.changeset/ecoles-el-harrach-wilaya-35.md
+++ b/.changeset/ecoles-el-harrach-wilaya-35.md
@@ -1,0 +1,5 @@
+---
+'@geoalgeria/ecoles': patch
+---
+
+fix: re-link 3 schools mislabeled as commune El Harrach (wilaya 16) to their true communes in Boumerdes (wilaya 35) - their coordinates (3.707-3.757 E, 36.68-36.72 N) sit in Isser / Bordj Menaiel territory, ~55 km east of El Harrach. The 2.1.0 re-extract re-runs the commune join under the PIP wilaya-containment guard (PR #158), which rejects exactly this cross-wilaya shape. Closes #165.


### PR DESCRIPTION
Closes yasserstudio/geoalgeria.com#93

Patch generated by `qwen3.8-27b-nvfp4 via local API`.