### PR TITLE
feat(schema): add reviewed correction contract

### DIFF
--- a/.changeset/reviewed-data-overrides.md
+++ b/.changeset/reviewed-data-overrides.md
@@ -1,0 +1,6 @@
+---
+"@geoalgeria/schema": minor
+---
+
+Add a reusable reviewed-correction ledger contract with stale-baseline protection,
+public evidence requirements, and deterministic keep, patch, and exclusion actions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ pnpm install
 - Improve Arabic transliterations
 - Add a new export format
 
+For generated sector packages, do not hand-edit an emitted JSON/CSV/GeoJSON
+file. Put an evidence-backed correction in
+[`quality/overrides/`](quality/overrides/README.md) instead. The ledger keeps the
+review finding separate from the publication action and stops regeneration if
+the upstream record no longer matches the reviewed value.
+
 Data lives under `packages/dataset/data/` and `packages/poste/data/`. The postal
 data in `packages/dataset/data/poste/` is **generated**: edit it in
 `packages/poste` and run `npm run fetch` there (it mirrors into the dataset), don't

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Every record follows the same shape:
 
 Machine-readable artifacts ride alongside: a root [`index.json`](index.json) catalog, a `schema.org/Dataset` descriptor (`dataset-metadata.json`) in each package, and the 69 wilaya boundary polygons in the core package at [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (display-grade).
 
+Human-reviewed corrections use the same contract across packages. A package can
+add `quality/overrides/<package>.json`; the canonical writer checks the expected
+old values, requires public evidence for changes or exclusions, applies the
+decision, and then runs the ordinary schema gate. See
+[`quality/overrides/README.md`](quality/overrides/README.md). Health data is the
+first pilot.
+
 One package predates the contract, the core `geoalgeria` dataset (administrative divisions, not GeoRecords; marked `schema_version: null` in the catalog).
 
 Migrating a package? See [`packages/schema/MIGRATING.md`](packages/schema/MIGRATING.md).

--- a/packages/schema/index.js
+++ b/packages/schema/index.js
@@ -23,3 +23,9 @@ export {
 } from "./src/geo.js";
 export { validateRecords, validateMetadata } from "./src/validate.js";
 export { buildMetadata, buildManifest, buildDcat, evidenceForSourceKey } from "./src/build.js";
+export {
+  REVIEW_STATUSES,
+  REVIEW_PUBLISH_ACTIONS,
+  validateReviewLedger,
+  applyReviewedOverrides,
+} from "./src/review.js";

--- a/packages/schema/src/review.js
+++ b/packages/schema/src/review.js
@@ -1,0 +1,408 @@
+// Human-reviewed corrections are data, not one-off script edits. This module is
+// deliberately domain-neutral: a package supplies a flat record collection and
+// a versioned ledger; the package's normal schema validator still decides
+// whether the corrected result is valid for that domain.
+
+export const REVIEW_STATUSES = [
+  "verified",
+  "corrected",
+  "duplicate",
+  "not-found",
+  "field-check",
+];
+
+export const REVIEW_PUBLISH_ACTIONS = ["keep", "patch", "exclude"];
+
+const ALLOWED_NEW_FIELDS = new Set([
+  "name",
+  "name_fr",
+  "name_ar",
+  "wilaya_code",
+  "commune_code",
+  "commune",
+  "commune_ar",
+  "lat",
+  "lng",
+  "geo_precision",
+  "geo_method",
+  "lifecycle",
+]);
+
+const FORBIDDEN_PATCH_FIELDS = new Set(["id", "source", "refs"]);
+
+const isObject = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const calendarDateIsValid = (value) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+};
+
+const isDate = (value) => {
+  if (typeof value !== "string") return false;
+  if (calendarDateIsValid(value)) return true;
+  const timestamp = value.match(
+    /^(\d{4}-\d{2}-\d{2})T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{1,9})?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/,
+  );
+  return Boolean(
+    timestamp &&
+      calendarDateIsValid(timestamp[1]) &&
+      !Number.isNaN(Date.parse(value)),
+  );
+};
+
+const isEvidenceUrl = (value) => {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    if (!new Set(["http:", "https:"]).has(url.protocol)) return false;
+    if (url.username || url.password) return false;
+    const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    if (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "::" ||
+      hostname === "::1" ||
+      hostname.startsWith("::ffff:") ||
+      /^f[cd][0-9a-f]{2}:/i.test(hostname) ||
+      /^fe[89ab][0-9a-f]:/i.test(hostname)
+    ) {
+      return false;
+    }
+    const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (ipv4) {
+      const [, aText, bText, cText, dText] = ipv4;
+      const octets = [aText, bText, cText, dText].map(Number);
+      if (octets.some((octet) => octet > 255)) return false;
+      const [a, b] = octets;
+      if (
+        a === 0 ||
+        a === 10 ||
+        a === 127 ||
+        (a === 100 && b >= 64 && b <= 127) ||
+        (a === 169 && b === 254) ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+function deepEqual(actual, expected) {
+  if (Object.is(actual, expected)) return true;
+  if (Array.isArray(actual) || Array.isArray(expected)) {
+    return (
+      Array.isArray(actual) &&
+      Array.isArray(expected) &&
+      actual.length === expected.length &&
+      actual.every((value, index) => deepEqual(value, expected[index]))
+    );
+  }
+  if (!isObject(actual) || !isObject(expected)) return false;
+  const actualKeys = Object.keys(actual);
+  const expectedKeys = Object.keys(expected);
+  return (
+    actualKeys.length === expectedKeys.length &&
+    expectedKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(actual, key) &&
+        deepEqual(actual[key], expected[key]),
+    )
+  );
+}
+
+function matchesExpected(record, expected) {
+  return Object.entries(expected).every(([key, value]) => {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) return false;
+    return deepEqual(record[key], value);
+  });
+}
+
+function validateEvidence(evidence, path, errors) {
+  if (!Array.isArray(evidence)) {
+    errors.push(`${path} must be an array`);
+    return;
+  }
+  evidence.forEach((item, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (!isObject(item)) {
+      errors.push(`${itemPath} must be an object`);
+      return;
+    }
+    if (!isEvidenceUrl(item.url)) {
+      errors.push(`${itemPath}.url must be a public http(s) URL`);
+    }
+    if (!isDate(item.checked_at)) {
+      errors.push(`${itemPath}.checked_at must be an ISO date or timestamp`);
+    }
+    if (item.note != null && typeof item.note !== "string") {
+      errors.push(`${itemPath}.note must be a string when present`);
+    }
+  });
+}
+
+/** Validate the versioned, project-wide human review ledger contract. */
+export function validateReviewLedger(ledger) {
+  const errors = [];
+  const warnings = [];
+  if (!isObject(ledger)) {
+    return { errors: ["review ledger must be an object"], warnings };
+  }
+  if (ledger.schema_version !== 1) {
+    errors.push("schema_version must be 1");
+  }
+  if (
+    typeof ledger.dataset !== "string" ||
+    !/^[a-z0-9][a-z0-9-]*$/.test(ledger.dataset)
+  ) {
+    errors.push("dataset must be a lowercase kebab-case identifier");
+  }
+  if (typeof ledger.reviewer !== "string" || !ledger.reviewer.trim()) {
+    errors.push("reviewer must be a non-empty string");
+  }
+  if (!isDate(ledger.reviewed_at)) {
+    errors.push("reviewed_at must be an ISO date or timestamp");
+  }
+  if (!Array.isArray(ledger.decisions)) {
+    errors.push("decisions must be an array");
+    return { errors, warnings };
+  }
+
+  const keys = new Set();
+  ledger.decisions.forEach((decision, index) => {
+    const path = `decisions[${index}]`;
+    if (!isObject(decision)) {
+      errors.push(`${path} must be an object`);
+      return;
+    }
+    if (
+      typeof decision.file !== "string" ||
+      !/^[A-Za-z0-9._-]+$/.test(decision.file)
+    ) {
+      errors.push(`${path}.file must be a plain file name`);
+    }
+    if (typeof decision.record_id !== "string" || !decision.record_id.trim()) {
+      errors.push(`${path}.record_id must be a non-empty string`);
+    }
+    const key = `${decision.file}:${decision.record_id}`;
+    if (keys.has(key)) errors.push(`${path} duplicates ${key}`);
+    keys.add(key);
+
+    if (!REVIEW_STATUSES.includes(decision.status)) {
+      errors.push(`${path}.status must be one of ${REVIEW_STATUSES.join(", ")}`);
+    }
+    if (!REVIEW_PUBLISH_ACTIONS.includes(decision.publish_action)) {
+      errors.push(
+        `${path}.publish_action must be one of ${REVIEW_PUBLISH_ACTIONS.join(", ")}`,
+      );
+    }
+    if (!isObject(decision.expect) || Object.keys(decision.expect).length === 0) {
+      errors.push(`${path}.expect must be a non-empty object`);
+    }
+    if (
+      decision.reviewer != null &&
+      (typeof decision.reviewer !== "string" || !decision.reviewer.trim())
+    ) {
+      errors.push(`${path}.reviewer must be a non-empty string when present`);
+    }
+    if (decision.reviewed_at != null && !isDate(decision.reviewed_at)) {
+      errors.push(`${path}.reviewed_at must be an ISO date or timestamp when present`);
+    }
+    if (decision.notes != null && typeof decision.notes !== "string") {
+      errors.push(`${path}.notes must be a string when present`);
+    }
+    const expectAbsent = decision.expect_absent;
+    const expectedAbsentFields = Array.isArray(expectAbsent) ? expectAbsent : [];
+    if (expectAbsent != null) {
+      if (decision.publish_action !== "patch") {
+        errors.push(`${path}.expect_absent is only allowed for patch actions`);
+      }
+      if (
+        !Array.isArray(expectAbsent) ||
+        expectAbsent.length === 0 ||
+        expectAbsent.some((field) => typeof field !== "string" || !field)
+      ) {
+        errors.push(`${path}.expect_absent must be a non-empty string array`);
+      } else {
+        if (new Set(expectAbsent).size !== expectAbsent.length) {
+          errors.push(`${path}.expect_absent must not contain duplicates`);
+        }
+        for (const field of expectAbsent) {
+          if (Object.prototype.hasOwnProperty.call(decision.expect, field)) {
+            errors.push(`${path}.${field} cannot be both expected and absent`);
+          }
+        }
+      }
+    }
+
+    if (decision.publish_action === "patch") {
+      if (decision.status !== "corrected") {
+        errors.push(`${path}: patch requires status "corrected"`);
+      }
+      if (!isObject(decision.patch) || Object.keys(decision.patch).length === 0) {
+        errors.push(`${path}.patch must be a non-empty object for patch actions`);
+      } else {
+        for (const [field, value] of Object.entries(decision.patch)) {
+          if (FORBIDDEN_PATCH_FIELDS.has(field)) {
+            errors.push(`${path}.patch.${field} cannot be changed by a review ledger`);
+          }
+          if (
+            !Object.prototype.hasOwnProperty.call(decision.expect, field) &&
+            !expectedAbsentFields.includes(field)
+          ) {
+            errors.push(`${path}.expect.${field} is required for a patched field`);
+          }
+          if (value !== null && typeof value === "object") {
+            errors.push(`${path}.patch.${field} must be a scalar or null`);
+          }
+        }
+        for (const field of expectedAbsentFields) {
+          if (!Object.prototype.hasOwnProperty.call(decision.patch, field)) {
+            errors.push(`${path}.expect_absent.${field} is not patched`);
+          }
+        }
+      }
+    } else if (decision.patch != null) {
+      errors.push(`${path}.patch is only allowed for patch actions`);
+    }
+
+    if (
+      decision.publish_action === "exclude" &&
+      !new Set(["duplicate", "not-found"]).has(decision.status)
+    ) {
+      errors.push(`${path}: exclude requires status "duplicate" or "not-found"`);
+    }
+    if (
+      decision.publish_action === "keep" &&
+      decision.status === "corrected"
+    ) {
+      errors.push(`${path}: corrected records must use the patch action`);
+    }
+
+    if (decision.evidence != null) {
+      validateEvidence(decision.evidence, `${path}.evidence`, errors);
+    }
+    if (
+      new Set(["patch", "exclude"]).has(decision.publish_action) &&
+      (!Array.isArray(decision.evidence) || decision.evidence.length === 0)
+    ) {
+      errors.push(`${path}.evidence is required for patch and exclude actions`);
+    }
+  });
+  return { errors, warnings };
+}
+
+/**
+ * Apply the decisions for one file. Expected old values are checked first, so a
+ * correction created against an older upstream snapshot cannot drift onto a new
+ * record. The input records are not mutated.
+ */
+export function applyReviewedOverrides(records, ledger, { file } = {}) {
+  const validation = validateReviewLedger(ledger);
+  if (validation.errors.length) {
+    throw new Error(
+      `review ledger is invalid:\n  ${validation.errors.join("\n  ")}`,
+    );
+  }
+  if (typeof file !== "string" || !file) {
+    throw new Error("review override application requires a file name");
+  }
+  if (!Array.isArray(records)) {
+    throw new Error(`review overrides [${file}]: records must be an array`);
+  }
+
+  const byId = new Map();
+  records.forEach((record, index) => {
+    if (byId.has(record.id)) {
+      throw new Error(`review overrides [${file}]: duplicate record id ${record.id}`);
+    }
+    byId.set(record.id, { record, index });
+  });
+
+  const output = records.map((record) => ({ ...record }));
+  const excluded = new Set();
+  const decisions = ledger.decisions.filter((decision) => decision.file === file);
+  let patched = 0;
+  let kept = 0;
+
+  for (const decision of decisions) {
+    const match = byId.get(decision.record_id);
+    if (!match) {
+      throw new Error(
+        `review overrides [${file}]: unknown record ${decision.record_id}`,
+      );
+    }
+    for (const field of Object.keys(decision.patch ?? {})) {
+      if (
+        !Object.prototype.hasOwnProperty.call(match.record, field) &&
+        !(
+          decision.expect_absent?.includes(field) &&
+          ALLOWED_NEW_FIELDS.has(field)
+        )
+      ) {
+        throw new Error(
+          `review overrides [${file}/${decision.record_id}]: patch field ${field} ` +
+            "does not exist on the baseline record or the shared optional-field vocabulary",
+        );
+      }
+    }
+    const unexpectedlyPresent = (decision.expect_absent ?? []).filter((field) =>
+      Object.prototype.hasOwnProperty.call(match.record, field),
+    );
+    if (unexpectedlyPresent.length) {
+      throw new Error(
+        `review overrides [${file}/${decision.record_id}]: stale decision; ` +
+          `expected absent field(s) are now present: ${unexpectedlyPresent.join(", ")}`,
+      );
+    }
+    if (!matchesExpected(match.record, decision.expect)) {
+      throw new Error(
+        `review overrides [${file}/${decision.record_id}]: stale decision; ` +
+          `the current record no longer matches expect=${JSON.stringify(decision.expect)}`,
+      );
+    }
+    if (decision.publish_action === "exclude") {
+      const missingExpected = Object.keys(match.record).filter(
+        (field) => !Object.prototype.hasOwnProperty.call(decision.expect, field),
+      );
+      if (missingExpected.length) {
+        throw new Error(
+          `review overrides [${file}/${decision.record_id}]: exclusion expect must ` +
+            `cover the full record; missing ${missingExpected.join(", ")}`,
+        );
+      }
+      excluded.add(match.index);
+      continue;
+    }
+    if (decision.publish_action === "keep") {
+      kept += 1;
+      continue;
+    }
+    for (const [field, value] of Object.entries(decision.patch)) {
+      output[match.index][field] = value;
+    }
+    output[match.index].review_status = "corrected";
+    output[match.index].reviewed_at = decision.reviewed_at ?? ledger.reviewed_at;
+    output[match.index].reviewed_by = decision.reviewer ?? ledger.reviewer;
+    output[match.index].review_evidence = decision.evidence.map(
+      (item) => item.url,
+    );
+    patched += 1;
+  }
+
+  return {
+    records: output.filter((_, index) => !excluded.has(index)),
+    stats: {
+      reviewed: decisions.length,
+      patched,
+      excluded: excluded.size,
+      kept,
+    },
+  };
+}

--- a/packages/schema/test/review.test.mjs
+++ b/packages/schema/test/review.test.mjs
@@ -1,0 +1,322 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyReviewedOverrides,
+  validateReviewLedger,
+} from "../index.js";
+
+const rows = [
+  {
+    id: "sante:16-00001",
+    name: "Old name",
+    source: "msp",
+    lat: 36.7657,
+    lng: 3.0587,
+    geo_precision: "exact",
+    geo_method: "official_locator",
+  },
+  {
+    id: "sante:16-00002",
+    name: "Duplicate",
+    source: "msp",
+    lat: null,
+    lng: null,
+    geo_precision: null,
+    geo_method: null,
+  },
+];
+
+const ledger = (decisions) => ({
+  schema_version: 1,
+  dataset: "sante",
+  reviewer: "reviewer@example.com",
+  reviewed_at: "2026-08-28",
+  decisions,
+});
+
+const evidence = [
+  {
+    url: "https://example.com/official-record",
+    checked_at: "2026-08-28",
+  },
+];
+
+test("review ledger keeps review status separate from publication action", () => {
+  const invalid = validateReviewLedger(
+    ledger([
+      {
+        file: "sante.json",
+        record_id: "sante:16-00002",
+        status: "duplicate",
+        publish_action: "patch",
+        expect: { name: "Duplicate" },
+        patch: { name: "Changed" },
+        evidence,
+      },
+    ]),
+  );
+  assert.match(invalid.errors.join("\n"), /patch requires status "corrected"/);
+});
+
+test("change evidence must be a genuinely public URL", () => {
+  for (const url of [
+    "http://127.0.0.1/evidence",
+    "http://192.168.1.5/evidence",
+    "https://user:secret@example.com/evidence",
+    "http://[::1]/evidence",
+    "http://[::ffff:127.0.0.1]/evidence",
+  ]) {
+    const invalid = validateReviewLedger(
+      ledger([
+        {
+          file: "sante.json",
+          record_id: "sante:16-00001",
+          status: "corrected",
+          publish_action: "patch",
+          expect: { name: "Old name" },
+          patch: { name: "Reviewed name" },
+          evidence: [{ url, checked_at: "2026-08-28" }],
+        },
+      ]),
+    );
+    assert.match(invalid.errors.join("\n"), /must be a public http\(s\) URL/);
+  }
+});
+
+test("review provenance rejects nonexistent calendar dates", () => {
+  const invalid = validateReviewLedger({
+    ...ledger([]),
+    reviewed_at: "2026-02-30",
+  });
+  assert.match(invalid.errors.join("\n"), /reviewed_at must be an ISO date/);
+
+  const invalidEvidence = validateReviewLedger(
+    ledger([
+      {
+        file: "sante.json",
+        record_id: "sante:16-00001",
+        status: "corrected",
+        publish_action: "patch",
+        expect: { name: "Old name" },
+        patch: { name: "Reviewed name" },
+        evidence: [
+          { url: "https://example.com/evidence", checked_at: "2026-02-30" },
+        ],
+      },
+    ]),
+  );
+  assert.match(invalidEvidence.errors.join("\n"), /checked_at must be an ISO date/);
+});
+
+test("reviewed patches and exclusions apply without mutating source rows", () => {
+  const result = applyReviewedOverrides(
+    rows,
+    ledger([
+      {
+        file: "sante.json",
+        record_id: "sante:16-00001",
+        status: "corrected",
+        publish_action: "patch",
+        reviewer: "first reviewer",
+        reviewed_at: "2026-08-27T12:00:00Z",
+        expect: { name: "Old name", lat: 36.7657, lng: 3.0587 },
+        patch: { name: "Reviewed name", lat: 36.766, lng: 3.059 },
+        evidence,
+      },
+      {
+        file: "sante.json",
+        record_id: "sante:16-00002",
+        status: "duplicate",
+        publish_action: "exclude",
+        expect: { ...rows[1] },
+        evidence,
+      },
+    ]),
+    { file: "sante.json" },
+  );
+
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].name, "Reviewed name");
+  assert.equal(result.records[0].lat, 36.766);
+  assert.equal(result.records[0].review_status, "corrected");
+  assert.equal(result.records[0].reviewed_at, "2026-08-27T12:00:00Z");
+  assert.equal(result.records[0].reviewed_by, "first reviewer");
+  assert.deepEqual(result.records[0].review_evidence, [
+    "https://example.com/official-record",
+  ]);
+  assert.equal(rows[0].name, "Old name");
+  assert.deepEqual(result.stats, {
+    reviewed: 2,
+    patched: 1,
+    excluded: 1,
+    kept: 0,
+  });
+});
+
+test("stale decisions fail instead of landing on changed upstream data", () => {
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        [{ ...rows[0], name: "Upstream changed" }],
+        ledger([
+          {
+            file: "sante.json",
+            record_id: "sante:16-00001",
+            status: "corrected",
+            publish_action: "patch",
+            expect: { name: "Old name" },
+            patch: { name: "Reviewed name" },
+            evidence,
+          },
+        ]),
+        { file: "sante.json" },
+      ),
+    /stale decision/,
+  );
+});
+
+test("every patched field must carry its previous value", () => {
+  const validation = validateReviewLedger(
+    ledger([
+      {
+        file: "sante.json",
+        record_id: "sante:16-00001",
+        status: "corrected",
+        publish_action: "patch",
+        expect: { name: "Old name" },
+        patch: { lat: 36.766 },
+        evidence,
+      },
+    ]),
+  );
+  assert.match(validation.errors.join("\n"), /expect.lat is required/);
+});
+
+test("an absent-value expectation safely adds a shared optional field", () => {
+  const baseline = { ...rows[0] };
+  delete baseline.name_ar;
+  const decision = {
+    file: "sante.json",
+    record_id: baseline.id,
+    status: "corrected",
+    publish_action: "patch",
+    expect: { name: baseline.name },
+    expect_absent: ["name_ar"],
+    patch: { name_ar: "الاسم الصحيح" },
+    evidence,
+  };
+  const result = applyReviewedOverrides([baseline], ledger([decision]), {
+    file: "sante.json",
+  });
+  assert.equal(result.records[0].name_ar, "الاسم الصحيح");
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        [{ ...baseline, name_ar: "اسم من المصدر" }],
+        ledger([decision]),
+        { file: "sante.json" },
+      ),
+    /expected absent field.*now present/,
+  );
+});
+
+test("exclusions must expect the complete baseline record", () => {
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        rows,
+        ledger([
+          {
+            file: "sante.json",
+            record_id: "sante:16-00002",
+            status: "duplicate",
+            publish_action: "exclude",
+            expect: { id: rows[1].id, name: rows[1].name },
+            evidence,
+          },
+        ]),
+        { file: "sante.json" },
+      ),
+    /exclusion expect must cover the full record/,
+  );
+});
+
+test("exclusion snapshots compare nested values completely", () => {
+  const nestedRow = {
+    ...rows[1],
+    refs: { osm: "node/1", wikidata: "Q1" },
+  };
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        [nestedRow],
+        ledger([
+          {
+            file: "sante.json",
+            record_id: nestedRow.id,
+            status: "duplicate",
+            publish_action: "exclude",
+            expect: { ...nestedRow, refs: { osm: "node/1" } },
+            evidence,
+          },
+        ]),
+        { file: "sante.json" },
+      ),
+    /stale decision/,
+  );
+});
+
+test("unknown ids, forbidden identity changes, and unsupported new fields fail", () => {
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        rows,
+        ledger([
+          {
+            file: "sante.json",
+            record_id: "missing",
+            status: "verified",
+            publish_action: "keep",
+            expect: { name: "Missing" },
+          },
+        ]),
+        { file: "sante.json" },
+      ),
+    /unknown record missing/,
+  );
+
+  const identityChange = validateReviewLedger(
+    ledger([
+      {
+        file: "sante.json",
+        record_id: "sante:16-00001",
+        status: "corrected",
+        publish_action: "patch",
+        expect: { name: "Old name" },
+        patch: { id: "new-id" },
+        evidence,
+      },
+    ]),
+  );
+  assert.match(identityChange.errors.join("\n"), /id cannot be changed/);
+
+  assert.throws(
+    () =>
+      applyReviewedOverrides(
+        rows,
+        ledger([
+          {
+            file: "sante.json",
+            record_id: "sante:16-00001",
+            status: "corrected",
+            publish_action: "patch",
+            expect: { invented_domain_field: null },
+            patch: { invented_domain_field: "value" },
+            evidence,
+          },
+        ]),
+        { file: "sante.json" },
+      ),
+    /does not exist on the baseline record or the shared optional-field vocabulary/,
+  );
+});

--- a/packages/schema/types/index.d.ts
+++ b/packages/schema/types/index.d.ts
@@ -203,6 +203,50 @@ export interface ValidateOptions {
   boundaries?: BoundaryIndex;
 }
 
+export type ReviewStatus =
+  | "verified"
+  | "corrected"
+  | "duplicate"
+  | "not-found"
+  | "field-check";
+
+export type ReviewPublishAction = "keep" | "patch" | "exclude";
+
+export interface ReviewEvidence {
+  url: string;
+  checked_at: string;
+  note?: string;
+}
+
+export interface ReviewDecision {
+  file: string;
+  record_id: string;
+  status: ReviewStatus;
+  publish_action: ReviewPublishAction;
+  /** Old values that must still match. Patches require every patched field; exclusions require the full record. */
+  expect: Record<string, unknown>;
+  /** Patched optional fields that were absent from the baseline record. */
+  expect_absent?: string[];
+  /** Flat scalar changes to existing baseline fields. `id`, `source`, and `refs` cannot be patched. */
+  patch?: Record<string, string | number | boolean | null>;
+  evidence?: ReviewEvidence[];
+  notes?: string;
+  /** Per-decision reviewer, preserved when ledgers are merged. */
+  reviewer?: string;
+  /** Per-decision ISO review time, preserved when ledgers are merged. */
+  reviewed_at?: string;
+}
+
+export interface ReviewLedger {
+  schema_version: 1;
+  dataset: string;
+  /** Default provenance for decisions that do not carry their own reviewer. */
+  reviewer: string;
+  /** Default provenance for decisions that do not carry their own review time. */
+  reviewed_at: string;
+  decisions: ReviewDecision[];
+}
+
 /** A `wilaya_code → GeoJSON geometry` lookup for boundary checks. */
 export type BoundaryIndex = Map<string, { type: string; coordinates: unknown }>;
 
@@ -216,6 +260,8 @@ export const WILAYA_CODES: readonly string[];
 export const DZ_BBOX: { minLng: number; maxLng: number; minLat: number; maxLat: number };
 /** Fewest fraction digits a coordinate must carry to be called `exact`. */
 export const MIN_EXACT_DECIMALS: number;
+export const REVIEW_STATUSES: readonly ReviewStatus[];
+export const REVIEW_PUBLISH_ACTIONS: readonly ReviewPublishAction[];
 
 export function wcode(c: string | number | null | undefined): string | null;
 export function round6(n: number | string | null | undefined): number | null;
@@ -268,6 +314,15 @@ export function sharedPoints(rows: GeoRecord[]): Set<number>;
 
 export function validateRecords(records: GeoRecord[], opts?: ValidateOptions): ValidationResult;
 export function validateMetadata(meta: DatasetMetadata): ValidationResult;
+export function validateReviewLedger(ledger: unknown): ValidationResult;
+export function applyReviewedOverrides(
+  records: Record<string, unknown>[],
+  ledger: ReviewLedger,
+  options: { file: string },
+): {
+  records: Record<string, unknown>[];
+  stats: { reviewed: number; patched: number; excluded: number; kept: number };
+};
 
 export interface BuildMetadataInput {
   package: string;

--- a/quality/overrides/README.md
+++ b/quality/overrides/README.md
@@ -1,0 +1,56 @@
+# Reviewed data corrections
+
+These versioned ledgers are the publication boundary between research/review and
+the public `@geoalgeria/*` packages. `scripts/lib/v2-transforms.mjs` automatically
+loads `quality/overrides/<package>.json` before it validates and emits a package.
+
+The first pilot is `sante.json`. Any other package can adopt the same workflow by
+adding a ledger named after the package; no generator-specific correction code is
+needed.
+
+## Safety contract
+
+- `status` records what the reviewer found. `publish_action` separately chooses
+  `keep`, `patch`, or `exclude`; marking something missing or duplicate does not
+  delete it automatically.
+- Every patched field includes its old value in `expect`; exclusions snapshot the
+  complete old record. A build stops if any affected upstream value changed.
+- To add a missing shared optional field, list it in `expect_absent`; publication
+  stops if upstream has since added that field. Arbitrary new fields are rejected.
+- `patch` and `exclude` require a public evidence URL and check date. Local,
+  private-network, and credential-bearing URLs are rejected.
+- Ledgers cannot change record identity, source attribution, or external refs.
+- The normal package schema validation runs after corrections, so reviewed data
+  receives the same coordinate, ID, provenance, and vocabulary checks as upstream
+  data.
+- Patched records expose `review_status`, `reviewed_at`, `reviewed_by`, and the
+  public `review_evidence` URLs alongside their original source provenance.
+  Decisions may carry their own reviewer and timestamp so later ledger merges do
+  not rewrite the provenance of earlier reviews.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "dataset": "sante",
+  "reviewer": "reviewer@example.com",
+  "reviewed_at": "2026-08-28",
+  "decisions": [
+    {
+      "file": "sante.json",
+      "record_id": "sante:16-00001",
+      "status": "corrected",
+      "publish_action": "patch",
+      "expect": { "name": "Old name", "lat": 36.75, "lng": 3.05 },
+      "patch": { "name": "Correct name", "lat": 36.76, "lng": 3.06 },
+      "evidence": [
+        {
+          "url": "https://authority.example/facility/1",
+          "checked_at": "2026-08-28"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/quality/overrides/sante.json
+++ b/quality/overrides/sante.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "dataset": "sante",
+  "reviewer": "geoalgeria-maintainers",
+  "reviewed_at": "2026-08-28",
+  "decisions": []
+}

--- a/scripts/lib/v2-transforms.mjs
+++ b/scripts/lib/v2-transforms.mjs
@@ -12,7 +12,7 @@
 // v1 fixture and asserts it reproduces the committed record byte-for-byte, so a
 // generator importing its own slice inherits that guarantee.
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -26,6 +26,8 @@ import {
   sharedPoints,
   validateRecords,
   MIN_EXACT_DECIMALS,
+  validateReviewLedger,
+  applyReviewedOverrides,
 } from "../../packages/schema/index.js";
 
 /** Write via a temp sibling + rename so a reader never sees a torn file. Not a
@@ -43,6 +45,17 @@ function writeAtomic(path, content) {
  *  from resolveDates()/committedDates(), not from this constant. */
 export const CUTOVER_DATE = "2026-07-18";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** A package opts into reviewed corrections by adding one committed ledger. */
+export function loadReviewLedger(pkg) {
+  const path = join(REPO_ROOT, "quality", "overrides", `${pkg}.json`);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`writePackageV2 [${pkg}]: cannot read review ledger ${path}: ${error.message}`);
+  }
+}
 
 // --- shared record helpers --------------------------------------------------
 /** commune_code (int|str) → 4-digit ONS string ("1607", "0105"), or null. */
@@ -837,11 +850,53 @@ export const MIGRATIONS = {
  *   meta: { sources: object[], license: string, estimatedUniverse?: number|null,
  *           coverageNote?: string, titles?: object, preserve?: string[],
  *           stats?: (rows: object[]) => object },
- *   oldMeta?: object,
+ *   oldMeta?: object, reviewLedger?: object|null,
  * }} input
- * @returns {{ records: object[], metadata: object }}
+ * @returns {{ records: object[], metadata: object, review: object }}
  */
-export function writePackageV2({ pkg, dir, files, meta, updated, retrieved, snapshots = {}, stats = {}, oldMeta = {} }) {
+export function writePackageV2({
+  pkg,
+  dir,
+  files,
+  meta,
+  updated,
+  retrieved,
+  snapshots = {},
+  stats = {},
+  oldMeta = {},
+  reviewLedger = undefined,
+}) {
+  const effectiveReviewLedger =
+    reviewLedger === undefined ? loadReviewLedger(pkg) : reviewLedger;
+  if (effectiveReviewLedger) {
+    const { errors } = validateReviewLedger(effectiveReviewLedger);
+    if (errors.length) {
+      throw new Error(
+        `writePackageV2 [${pkg}]: invalid review ledger:\n  ${errors.join("\n  ")}`,
+      );
+    }
+    if (effectiveReviewLedger.dataset !== pkg) {
+      throw new Error(
+        `writePackageV2 [${pkg}]: review ledger dataset is ${JSON.stringify(effectiveReviewLedger.dataset)}`,
+      );
+    }
+    const ownedFiles = new Set(
+      files.filter((file) => file.rows != null).map((file) => file.file),
+    );
+    const unknownFiles = [
+      ...new Set(
+        effectiveReviewLedger.decisions
+          .map((decision) => decision.file)
+          .filter((file) => !ownedFiles.has(file)),
+      ),
+    ];
+    if (unknownFiles.length) {
+      throw new Error(
+        `writePackageV2 [${pkg}]: review ledger targets file(s) not owned by this writer: ${unknownFiles.join(", ")}`,
+      );
+    }
+  }
+
   mkdirSync(join(dir, "csv"), { recursive: true });
   mkdirSync(join(dir, "geojson"), { recursive: true });
 
@@ -852,6 +907,7 @@ export function writePackageV2({ pkg, dir, files, meta, updated, retrieved, snap
   const all = [];
   const entities = [];
   const pending = []; // { path, content } queued for the atomic write phase
+  const review = { reviewed: 0, patched: 0, excluded: 0, kept: 0 };
   for (const f of files) {
     // A file this writer does not own. A package can legitimately have more than
     // one generator: aviation's airports come from a live ANAC+OurAirports pull,
@@ -866,7 +922,14 @@ export function writePackageV2({ pkg, dir, files, meta, updated, retrieved, snap
       continue;
     }
     const base = f.file.replace(/\.json$/, "");
-    const rows = f.rows;
+    const reviewed = effectiveReviewLedger
+      ? applyReviewedOverrides(f.rows, effectiveReviewLedger, { file: f.file })
+      : {
+          records: f.rows,
+          stats: { reviewed: 0, patched: 0, excluded: 0, kept: 0 },
+        };
+    for (const key of Object.keys(review)) review[key] += reviewed.stats[key];
+    const rows = reviewed.records;
     demoteSharedPoints(rows);
     // Plain codepoint order — localeCompare() without a locale reads the ambient
     // ICU and can reorder committed JSON between machines.
@@ -950,7 +1013,7 @@ export function writePackageV2({ pkg, dir, files, meta, updated, retrieved, snap
 
   // Phase 2 — everything validated; now write each file atomically.
   for (const { path, content } of pending) writeAtomic(path, content);
-  return { records: all, metadata };
+  return { records: all, metadata, review };
 }
 
 /**

--- a/test/review-writer.test.mjs
+++ b/test/review-writer.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePackageV2 } from "../scripts/lib/v2-transforms.mjs";
+
+const row = {
+  id: "sante:16-00001",
+  name: "Old name",
+  wilaya_code: "16",
+  commune_code: null,
+  commune: null,
+  lat: 36.7657,
+  lng: 3.0587,
+  geo_precision: "exact",
+  geo_method: "official_locator",
+  source: "msp",
+};
+
+const evidence = [
+  {
+    url: "https://example.com/health-register",
+    checked_at: "2026-08-28",
+  },
+];
+
+const ledger = (expect = { name: "Old name" }) => ({
+  schema_version: 1,
+  dataset: "sante",
+  reviewer: "reviewer@example.com",
+  reviewed_at: "2026-08-28",
+  decisions: [
+    {
+      file: "sante.json",
+      record_id: row.id,
+      status: "corrected",
+      publish_action: "patch",
+      expect,
+      patch: { name: "Reviewed name" },
+      evidence,
+    },
+  ],
+});
+
+const write = (dir, reviewLedger) =>
+  writePackageV2({
+    pkg: "sante",
+    dir,
+    files: [{ file: "sante.json", rows: [{ ...row }] }],
+    meta: {
+      sources: [
+        {
+          key: "msp",
+          name: "Ministry of Health",
+          license: "Open data",
+          evidence_type: "official",
+        },
+      ],
+      license: "Open data",
+    },
+    updated: "2026-08-28",
+    retrieved: "2026-08-28",
+    reviewLedger,
+  });
+
+test("canonical writer applies the reviewed ledger before validation and emit", () => {
+  const dir = mkdtempSync(join(tmpdir(), "geoalgeria-review-writer-"));
+  const result = write(dir, ledger());
+  const emitted = JSON.parse(readFileSync(join(dir, "sante.json"), "utf8"));
+  assert.equal(emitted[0].name, "Reviewed name");
+  assert.deepEqual(result.review, {
+    reviewed: 1,
+    patched: 1,
+    excluded: 0,
+    kept: 0,
+  });
+});
+
+test("canonical writer rejects stale reviewed corrections before emitting data", () => {
+  const dir = mkdtempSync(join(tmpdir(), "geoalgeria-review-stale-"));
+  assert.throws(() => write(dir, ledger({ name: "Older upstream name" })), /stale decision/);
+});


### PR DESCRIPTION
## Summary
- add a reusable reviewed-correction ledger with stale-value and evidence safeguards
- apply dataset-owned ledgers in every v2 writer before publication
- document the workflow and add schema plus writer integration coverage

## Verification
- pnpm validate
- direct review contract and writer tests