### PR TITLE
docs: align post-buses-2.1.0 docs and record release-process lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,23 +33,23 @@ term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's th
 | `packages/ooredoo/` | `@geoalgeria/ooredoo` | Ooredoo stores – 572 EO/CSO/ESO with real coordinates & wilaya/commune linkage (ooredoo.dz locator API); completes the telecom retail trio |
 | `packages/mosquees/` | `@geoalgeria/mosquees` | mosques – Wikidata + OpenStreetMap composite, bilingual, all 69 wilayas |
 | `packages/sante/` | `@geoalgeria/sante` | public health establishments – EPH, EPSP, EHS, CHU (Ministry of Health), bilingual, geocoded via OSM + Wikidata |
-| `packages/cliniques/` | `@geoalgeria/cliniques` | clinics & proximity-care facilities – 1,894 polycliniques, salles de soins, centres de santé, maternités & private clinics from OpenStreetMap, classified by type, bilingual, 66 wilayas; the community tier of the health sector, disjoint from `sante` (registry tier) |
+| `packages/cliniques/` | `@geoalgeria/cliniques` | clinics & proximity-care facilities – 1,913 polycliniques, salles de soins, centres de santé, maternités & private clinics from OpenStreetMap, classified by type, bilingual, 66 wilayas; the community tier of the health sector, disjoint from `sante` (registry tier) |
 | `packages/protection-civile/` | `@geoalgeria/protection-civile` | civil protection (fire & rescue) units – 880 DGPC units nationwide, Arabic-named, address/phone/fax, status tier, geocoded, official-primary (dgpc.dz), post-2026-reform wilaya linkage |
 | `packages/culture/` | `@geoalgeria/culture` | cultural atlas – protected sites, museums, theatres, libraries + cultural establishments (Ministry of Culture), bilingual, fully geocoded |
 | `packages/agriculture/` | `@geoalgeria/agriculture` | agriculture-sector institutions – services directorates (DSA), forest conservations, research/training institutes, chambers of agriculture, public offices & groups (Ministry of Agriculture), bilingual, geocoded |
 | `packages/industrie-pharmaceutique/` | `@geoalgeria/industrie-pharmaceutique` | approved pharmaceutical manufacturers – 171 medicine (PP) & medical-device (DM) makers from the Ministry of Pharmaceutical Industry (MIP) fabrication register, bilingual, typed by nature, geocoded to commune/wilaya centroid |
-| `packages/pharmacies/` | `@geoalgeria/pharmacies` | pharmacies (officines) – 3,797 geocoded across 67 wilayas, bilingual where named, phone/hours/dispensing where tagged, wilaya/commune-linked (OpenStreetMap, ODbL); honest ~half coverage |
+| `packages/pharmacies/` | `@geoalgeria/pharmacies` | pharmacies (officines) – 3,807 geocoded across 67 wilayas, bilingual where named, phone/hours/dispensing where tagged, wilaya/commune-linked (OpenStreetMap, ODbL); honest ~half coverage |
 | `packages/pharma/` | `@geoalgeria/pharma` | pharma umbrella – re-exports industrie-pharmaceutique + pharmacies in one install |
-| `packages/ecoles/` | `@geoalgeria/ecoles` | schools – 11,855 primaires/CEM/lycées/préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap, ODbL) |
+| `packages/ecoles/` | `@geoalgeria/ecoles` | schools – 11,858 primaires/CEM/lycées/préscolaires classified by cycle, bilingual, all 69 wilayas (OpenStreetMap, ODbL) |
 | `packages/gares-routieres/` | `@geoalgeria/gares-routieres` | intercity bus stations – 74 SOGRAL gares routières, 52 wilayas, geocoded with surfaces from the archived SOGRAL registry plus current MAHATATI agency ids |
 | `packages/ferroviaire/` | `@geoalgeria/ferroviaire` | rail & urban transit – 692 train/tram/metro/aerial-tramway/gondola nodes (SNTF/SETRAM/SEMA), Wikidata + OSM composite, bilingual |
-| `packages/buses/` | `@geoalgeria/buses` | urban/suburban bus networks – 59 Lines, 42 OSM shapes, 75 Directions and 1,046 Stations across 3 Operators |
+| `packages/buses/` | `@geoalgeria/buses` | urban/suburban bus networks – 153 Lines, 76 shapes, 128 Directions and 1,603 Stations across 14 Operators |
 | `packages/transport/` | `@geoalgeria/transport` | transport umbrella – re-exports aviation + ferroviaire + gares-routieres + buses |
 
 The postal data under `packages/dataset/data/poste/` is a **generated mirror**;
 edit it in `packages/poste`, then `npm run fetch` there. Never hand-edit the mirror.
 
-`sources/` holds the **committed raw captures** the fetchers build from — one
+`sources/` holds the **committed raw captures** the fetchers build from: one
 canonical latest capture per (package, source), written only via
 `scripts/lib/source-store.mjs`, so refreshes are reviewable git diffs and every
 converted package rebuilds offline (`--cache`). Rules in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,6 +65,11 @@ regenerating `sante` can change `cliniques` output with nothing in
 `packages/cliniques` having changed. When a release touches both, rebuild
 `sante` first, then `cliniques`, and review the two diffs together.
 
+`pnpm --filter <pkg> fetch` runs pnpm's own built-in `fetch` command, not the
+package's generator, and tries to purge `node_modules` in the process. Run the
+generator directly instead: `node packages/<pkg>/scripts/fetch.mjs` (offline,
+deterministic) or `pnpm --filter <pkg> run fetch`.
+
 ### 1–2. Add a changeset, let the bot open the PR
 
 ```bash
@@ -106,6 +111,32 @@ then:
 
 The new GitHub Release fires the **Announce** workflow (see below).
 
+> ⚠️ **A Release cut before the Version PR merges is stuck with a bad title.**
+> Observed once (`@geoalgeria/buses` 2.1.0): the workflow cut the GitHub Release
+> and tag at the changeset-PR merge, before the Version PR merged (cause not
+> fully traced). The release-notes step then found no `CHANGELOG.md` section
+> for that version yet and fell back to a truncated first bullet as the title.
+> Fix: `gh release delete '<tag>' --cleanup-tag` before merging the Version PR,
+> so the tag-existence guard lets the workflow recreate the Release with the
+> real changelog notes once the CHANGELOG section exists. This is also why a
+> changeset's **first line must be a headline**: `scripts/release-notes.mjs`
+> falls back to it (clamped) whenever a CHANGELOG section has no headline line.
+
+### One-off: publishing an umbrella away from a terminal
+
+The `transport`/`pharma` umbrellas (see One-time setup, step 2) publish with
+pnpm, which needs interactive OTP entry. If you're away from a terminal:
+
+```bash
+pnpm pack   # in packages/<umbrella>; verify the tarball's deps resolve to real semver
+script -q -F publish.log npm publish <tgz>.tgz --access public --auth-type=web
+```
+
+Running `npm publish --auth-type=web` inside a pseudo-terminal (`script`) makes
+npm print the **unmasked** web-auth link, which you can open on a phone. A
+non-interactive `npm publish` masks the link as `***`, and `pnpm publish` itself
+refuses outright with `ERR_PNPM_OTP_NON_INTERACTIVE`.
+
 ### 5. Approve the staged packages
 
 Staging does **not** publish, approve to go live:
@@ -116,6 +147,12 @@ npm stage approve <stage-id>     # requires 2FA
 ```
 
 …or approve on npmjs.com → Staged packages.
+
+Staged packages can sit unapproved for days if the maintainer isn't at a
+terminal (the August 2026 refresh was staged 31 Aug and only approved 4 Sept).
+After merging a Version PR, check `npm view <pkg> version` for **every**
+package listed in that PR's body, not just the one you set out to release,
+before assuming the batch is live.
 
 ### 6. Purge the CDN
 
@@ -158,6 +195,10 @@ human-readable headline** (it becomes the announcement title and social hook).
 The canonical structure + a worked example is in
 [`.github/RELEASE_TEMPLATE.md`](.github/RELEASE_TEMPLATE.md); the Discussion/social
 copy built from it lives in `.agents/release-notes-templates.md` (local, gitignored).
+
+Changesets own a package's `CHANGELOG.md`; never hand-write an "## Unreleased"
+section into one. It goes stale under the next generated section instead of
+being replaced by it.
 
 ## Announcements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,12 +134,12 @@ reads as further along than it is.
   `COMMUNE_FIX` in the gares-routieres fetch as deliberately unresolved.
   _(logged 2026-08-14)_
 
-- [x] **Nearest-centroid fallback can cross a boundary** — fixed in the shared
+- [x] **Nearest-centroid fallback can cross a boundary**, fixed in the shared
   helper: `attachCommune` now resolves the containing wilaya by point-in-polygon
   against the 69 boundaries first and restricts the centroid search to it, so
   the join can never cross a wilaya boundary (commune-level containment stays
   best-effort; commune polygons don't exist). Data effects land at each
-  package's next refresh — the 3 known ooredoo records (documented in their
+  package's next refresh: the 3 known ooredoo records (documented in their
   coverageNote) repair themselves on the next ooredoo fetch. Per-package local
   copies of `nearestCommune` (djezzy, ooredoo, culture, ecoles,
   enseignement-superieur) converge on the shared helper as those packages are
@@ -148,7 +148,7 @@ reads as further along than it is.
 - [ ] **Ferroviaire regeneration drifts from the committed dataset.** Discovered
   while testing the fix above: re-running `packages/ferroviaire/scripts/fetch.mjs`
   on today's committed research/ferroviaire raws produces 233 coordinate
-  changes, 232 name changes and 18 id add/removes against the committed data —
+  changes, 232 name changes and 18 id add/removes against the committed data:
   the OSM↔Wikidata merge no longer reproduces what shipped, and the per-wilaya
   sequential ids reshuffle (the id-churn class the v2 generator rework
   eliminated elsewhere). Until diagnosed, do NOT regenerate ferroviaire; the
@@ -235,6 +235,20 @@ reads as further along than it is.
   Demand signal: a user on Reddit (2026-08-09) describing exactly this gap,
   planning a move to an unfamiliar area with no way to see what serves it.
   _(logged 2026-08-09)_
+
+  **Update 2026-09-04:** the breaking id-scheme change sketched above never
+  shipped. Every ETUSA Line kept its Wikipedia registry id; OSM only supplies
+  geometry and identifies additional Lines the registry omitted (the 6xx/7xx
+  suburban network), so the release stayed additive and went out as **2.0.0**
+  then **2.1.0**, not 3.0.0. The package has since grown well past the numbers
+  above: **153 Lines across 14 Operators** (ETUSA plus ETUS Setif, Tiaret,
+  ETUSTO Tizi Ouzou, Bejaia, M'Sila, Sidi Bel Abbes, Mostaganem, Ain Defla,
+  Annaba, Tlemcen, Oum El Bouaghi, ETUL Laghouat and ETO Oran), **76 shapes,
+  128 Directions, 1,603 Stations and 2,685 memberships**. Next levers: an ETO
+  Oran numbered Line list (only one of six ETO drawings carries a ref today,
+  the rest are evidence-only), the ETUSA network API probed 2026-09-03
+  (validation-only, see `research/buses/ETUSA-API-PROBE.md`), and Constantine
+  (ETUSC), whose page is login-walled.
 
 - [ ] **Intercity bus schedules are a licence problem, not a scraping
   problem.** ETUSA is Algiers **urban** transport only, so the OSM re-extraction

--- a/packages/transport/README.ar.md
+++ b/packages/transport/README.ar.md
@@ -19,7 +19,7 @@ import transport from "@geoalgeria/transport";
 transport.aviation.airports();        // المطارات (ANAC)
 transport.ferroviaire.stations();     // السكك / الترامواي / المترو (SNTF / SETRAM / SEMA)
 transport.garesRoutieres.stations();  // المحطات البرية (SOGRAL)
-transport.buses.lines();              // شبكات الحافلات الحضرية (ETUSA)
+transport.buses.lines();              // شبكات الحافلات الحضرية وشبه الحضرية (14 مشغلًا)
 ```
 
 <div dir="rtl">
@@ -31,7 +31,7 @@ transport.buses.lines();              // شبكات الحافلات الحضر�
 | `aviation` | `@geoalgeria/aviation` | المطارات المدنية (ANAC) |
 | `ferroviaire` | `@geoalgeria/ferroviaire` | السكك والترامواي والمترو |
 | `garesRoutieres` | `@geoalgeria/gares-routieres` | المحطات البرية (SOGRAL) |
-| `buses` | `@geoalgeria/buses` | شبكات الحافلات الحضرية (ETUSA) |
+| `buses` | `@geoalgeria/buses` | شبكات الحافلات الحضرية وشبه الحضرية (14 مشغلًا) |
 
 ## الرخصة
 

--- a/packages/transport/README.fr.md
+++ b/packages/transport/README.fr.md
@@ -15,7 +15,7 @@ import transport from "@geoalgeria/transport";
 transport.aviation.airports();        // aéroports (ANAC)
 transport.ferroviaire.stations();     // rail / tram / métro (SNTF / SETRAM / SEMA)
 transport.garesRoutieres.stations();  // gares routières (SOGRAL)
-transport.buses.lines();              // réseaux de bus urbains (ETUSA)
+transport.buses.lines();              // réseaux de bus urbains et suburbains (14 exploitants)
 ```
 
 ## Membres
@@ -25,7 +25,7 @@ transport.buses.lines();              // réseaux de bus urbains (ETUSA)
 | `aviation` | `@geoalgeria/aviation` | Aéroports civils (ANAC) |
 | `ferroviaire` | `@geoalgeria/ferroviaire` | Rail, tram & métro (SNTF / SETRAM / SEMA) |
 | `garesRoutieres` | `@geoalgeria/gares-routieres` | Gares routières (SOGRAL) |
-| `buses` | `@geoalgeria/buses` | Réseaux de bus urbains (ETUSA) |
+| `buses` | `@geoalgeria/buses` | Réseaux de bus urbains et suburbains (14 exploitants) |
 
 ## Licence
 

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -24,7 +24,7 @@ import transport from "@geoalgeria/transport";
 transport.aviation.airports();          // civil airports (ANAC)
 transport.ferroviaire.stations();       // rail / tram / metro (SNTF / SETRAM / SEMA)
 transport.garesRoutieres.stations();    // intercity bus stations (SOGRAL)
-transport.buses.lines();                // urban bus networks (ETUSA)
+transport.buses.lines();                // urban & suburban bus networks (14 Operators)
 
 // or import a member directly:
 import { ferroviaire } from "@geoalgeria/transport";
@@ -37,7 +37,7 @@ import { ferroviaire } from "@geoalgeria/transport";
 | `aviation` | [`@geoalgeria/aviation`](https://www.npmjs.com/package/@geoalgeria/aviation) | Civil airports (ANAC) |
 | `ferroviaire` | [`@geoalgeria/ferroviaire`](https://www.npmjs.com/package/@geoalgeria/ferroviaire) | Rail, tram & metro (SNTF / SETRAM / SEMA) |
 | `garesRoutieres` | [`@geoalgeria/gares-routieres`](https://www.npmjs.com/package/@geoalgeria/gares-routieres) | Intercity bus stations (SOGRAL) |
-| `buses` | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban bus networks (ETUSA) |
+| `buses` | [`@geoalgeria/buses`](https://www.npmjs.com/package/@geoalgeria/buses) | Urban & suburban bus networks (14 Operators) |
 
 Prefer a single dataset? Install just that member. This umbrella is for when you want the
 whole sector.

--- a/research/buses/EXPANSION.md
+++ b/research/buses/EXPANSION.md
@@ -7,6 +7,14 @@ note; it does not promote data.
 `seen` means directly present in a cited committed file. `inferred` means a
 recommended action derived from those observations.
 
+> **Superseded 2026-09-04:** `@geoalgeria/buses` 2.1.0 shipped since this was
+> written. The "current directory and map coverage" totals below (85 Lines,
+> eight Operators, 47 shapes, 1,290 Stations, 2,105 memberships) are the
+> 2026-09-02 snapshot, not the live package, which now carries 153 Lines
+> across 14 Operators, 76 shapes, 128 Directions, 1,603 Stations and 2,685
+> memberships (see `packages/buses/README.md`). The per-Operator directory-only
+> vs. shapes-available calls made below still hold; only the totals are stale.
+
 ## Current directory and map coverage
 
 - **[seen]** The published working tree currently has **85 Lines across eight
@@ -79,26 +87,26 @@ recommended action derived from those observations.
 
 ## Next concrete geometry priorities
 
-1. **[inferred] Sidi Bel Abbès — fill the largest structured shape gap.** Eight
+1. **[inferred] Sidi Bel Abbès: fill the largest structured shape gap.** Eight
    official timetable Lines already exist; obtain vector paths and ordered
    Stations for those exact refs. This improves the map without inventing new
    Line identity.
-2. **[inferred] M'Sila — vectorize through an authorized source.** Four official
+2. **[inferred] M'Sila: vectorize through an authorized source.** Four official
    Line identities and diagrams exist, but neither reusable vectors nor ordered
    Station data are committed.
-3. **[inferred] Béjaïa — resolve licensing and identity.** Five official Line
+3. **[inferred] Béjaïa: resolve licensing and identity.** Five official Line
    pages expose fetchable Google My Maps KML, but no open reuse licence was
    found, and nine Béjaïa OSM candidates do not safely match the official refs.
    Use the official KML for validation only until permission is obtained; do a
    manual termini/ref reconciliation against OSM. Source:
    [`research/buses/SOURCE.md`](./SOURCE.md),
    [`research/buses/osm/READINESS.md`](./osm/READINESS.md).
-4. **[inferred] Aïn Defla — identity audit.** Two ETUAD OSM
+4. **[inferred] Aïn Defla: identity audit.** Two ETUAD OSM
    relations have complete paths and 3/5 Station members, but both remain
    `needs_identity`; they are not ready for automatic promotion. Verify Line X
    and Line 2 termini with an Operator-owned source. Source:
    [`research/buses/osm/candidate-lines.json`](./osm/candidate-lines.json).
-5. **[inferred] Oran — establish a publishable static network before any live
+5. **[inferred] Oran: establish a publishable static network before any live
    pilot.** The operator tracker is an authorization lead, not a Line dataset.
    Request current Line identities, termini, shapes, and reuse terms; do not
    derive a public network from authenticated vehicles or exposed tokens.


### PR DESCRIPTION
## Summary

Prose-only cleanup after today's `@geoalgeria/buses` 2.1.0 release and the
August package refresh (pharmacies 2.2.0, protection-civile 1.0.2, ecoles
2.2.0, cliniques 1.1.0, mobilis 2.1.0, djezzy 2.0.2, emploi 2.0.1, ooredoo
2.0.3, gares-routieres 2.2.3).

- **RELEASING.md**: records five release-process lessons verified today:
  the `pnpm --filter <pkg> fetch` trap (it runs pnpm's own fetch, not the
  generator), the Release workflow cutting a GitHub Release/tag before the
  Version PR merges (fix: delete the release + tag first), publishing an
  umbrella away from a terminal via `pnpm pack` + `script -q -F publish.log
  npm publish --auth-type=web`, staged packages sitting unapproved for days
  (check `npm view <pkg> version` for every package in the Version PR, not
  just one), and that changesets own `CHANGELOG.md` (never hand-write an
  `## Unreleased` section).
- **ROADMAP.md**: the completed buses Transport item still described a
  42-shape / 1,046-Station snapshot and a planned breaking 3.0.0 (id scheme
  swap to OSM relation ids). That never shipped; ids stayed stable and the
  release went out as additive 2.0.0 then 2.1.0. Added an update note with
  the current totals (153 Lines / 14 Operators / 76 shapes / 128 Directions
  / 1,603 Stations / 2,685 memberships) and the current next levers (ETO
  Oran numbered list, the validation-only ETUSA network API, Constantine/
  ETUSC being login-walled).
- **packages/transport/README(.fr/.ar).md**: `buses` was still described as
  "(ETUSA)"; it's 14 Operators now.
- **AGENTS.md**: the buses/cliniques/pharmacies/ecoles layout-table counts
  were stale (buses especially: 59 Lines/3 Operators, now 153/14).
- **research/buses/EXPANSION.md**: flagged its 2026-09-02 coverage totals
  as superseded by the 2.1.0 release (the per-Operator directory-only vs.
  shapes-available calls it made still hold; only the totals were stale).
- Removed a handful of pre-existing em dashes from the files touched, per
  the project's no-em-dash rule.

## Verified, not changed

- Root READMEs (EN/FR/AR): buses counts (153/14/76/128/1,603) and the
  Line-name colon format were already correct from PR #205/#206.
- CONTEXT.md glossary: Line/Direction/Membership/Station/Operator terms
  already cover buses usage, nothing missing.
- Docs-parity: root README table-row counts for buses and every August
  package match each package's `data/metadata.json` `record_count`
  exactly (pharmacies 3,807, protection-civile 880, ecoles 11,858,
  cliniques 1,913, mobilis 12,344, djezzy 128, emploi 331, ooredoo 572,
  gares-routieres 74). No mismatches found.
- Root CHANGELOG.md: no stale buses/transport mentions; a project umbrella
  minor (new package/substantial data expansion) looks warranted given the
  buses expansion from a single-operator to a 14-operator, 153-Line
  release, but that's a maintainer call and is **not** bumped here per
  instructions.
- `pnpm test`: 232/232 passing after these edits.
- `grep -rn "—"` over every changed file: empty.

## Test plan

- [x] `pnpm test` (232/232 passing)
- [x] `grep -rn "—"` on all changed files (empty)
- [x] Root README EN/FR/AR buses table rows cross-checked against
      `packages/buses/data/metadata.json` and against each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i4pzmWX9bgmV9aCDzAoTP