### PR TITLE
chore: release train and glossary admit a code-only package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,16 @@ jobs:
             fi
             echo "releasing: $TAG"
 
+            # A code-only package (no data/) still gets a Release, just no
+            # bundle: BUNDLE stays empty and drops out of the gh calls below.
             BUNDLE="$RUNNER_TEMP/geoalgeria-$(basename "$pkg")-$VER.zip"
             if [ "$pkg" = "packages/dataset" ]; then
               (cd "$pkg" && zip -qr "$BUNDLE" data algeria.geojson dataset-metadata.json)
-            else
+            elif [ -d "$pkg/data" ]; then
               (cd "$pkg" && zip -qr "$BUNDLE" data)
+            else
+              echo "no data/ in $pkg, releasing without a data bundle"
+              BUNDLE=""
             fi
 
             # Title + body + patch-flag come from scripts/release-notes.mjs (see
@@ -118,10 +123,13 @@ jobs:
 
             if [ -s "$NOTES" ]; then
               TITLE=$($RN title)
-              gh release create "$TAG" --title "$TITLE" --target "$GITHUB_SHA" --notes-file "$NOTES" "$BUNDLE"
+              # shellcheck disable=SC2086 -- ${BUNDLE:+"$BUNDLE"} is one quoted
+              # argument when set, and no argument at all when empty.
+              gh release create "$TAG" --title "$TITLE" --target "$GITHUB_SHA" --notes-file "$NOTES" ${BUNDLE:+"$BUNDLE"}
             else
               echo "::warning::No CHANGELOG section found for $TAG; using auto-generated notes"
-              gh release create "$TAG" --title "$TAG" --target "$GITHUB_SHA" --generate-notes "$BUNDLE"
+              # shellcheck disable=SC2086 -- see above.
+              gh release create "$TAG" --title "$TAG" --target "$GITHUB_SHA" --generate-notes ${BUNDLE:+"$BUNDLE"}
             fi
 
             # Announce this release. The release: published event won't fire (this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ avoiding the synonyms each lists under `_Avoid_`. If a concept is missing or a
 term conflicts, update `CONTEXT.md` rather than drifting to a synonym (that's the
 `/domain-modeling` skill).
 
+Text folding has its own canonical terms under
+[Search and normalization](CONTEXT.md#search-and-normalization): Search key,
+Conservative key, Loose key, Rule, Golden corpus.
+
 ## Layout
 
 | Path | Package | Contents |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -153,6 +153,28 @@ _Avoid_: multilingual, translated, i18n
 Carrying real `lat`/`lng` coordinates for a record (as opposed to density-only or wilaya-linked-only).
 _Avoid_: located, mapped, positioned
 
+### Search and normalization
+
+**Search key**:
+The umbrella term for a folded form of a name, produced by the shared normalization package and matched against instead of the display name. Always qualified as a **Conservative key** or a **Loose key**; unqualified "search key" names the concept, never one of the two.
+_Avoid_: slug (that is a URL identity), normalized name, canonical name, search string
+
+**Conservative key**:
+The strict fold every consumer must reproduce byte for byte: presentation forms, alef and hamza variants, tatweel, combining marks, Arabic-Indic digits and case are all resolved, word boundaries are preserved, and nothing that changes which letter a reader sees is folded away. A published catalog's keys are this fold, so a change to it is a major version.
+_Avoid_: strict key, exact key, base key
+
+**Loose key**:
+The additional equivalence tier over the Conservative key, folding the pairs a speaker may spell either way (alef maqsura with yaa, taa marbuta with haa). It exists so a loose hit can be ranked below an exact one instead of being indistinguishable from it.
+_Avoid_: fuzzy key, relaxed key, approximate key
+
+**Rule**:
+One reviewed fold or alias in the normalization package's frozen table, carrying an id (`ar.taa-marbuta-haa`), its class, the script it applies to, one sentence a speaker can argue with, and a review record. A Rule states something about the script and is safe for every name; a statement about one Place is a per-record alias with its own Source, not a Rule.
+_Avoid_: mapping, transform, substitution
+
+**Golden corpus**:
+The exported fixture of cases every consumer asserts against, so the package, the release generator, Web and Mobile all prove the same keys from the same inputs. Every Rule is exercised by at least one case, and every case declares which Rule it proves.
+_Avoid_: test fixtures, sample data, test corpus
+
 ### Provenance
 
 **Source**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -168,7 +168,7 @@ The additional equivalence tier over the Conservative key, folding the pairs a s
 _Avoid_: fuzzy key, relaxed key, approximate key
 
 **Rule**:
-One reviewed fold or alias in the normalization package's frozen table, carrying an id (`ar.taa-marbuta-haa`), its class, the script it applies to, one sentence a speaker can argue with, and a review record. A Rule states something about the script and is safe for every name; a statement about one Place is a per-record alias with its own Source, not a Rule.
+One reviewed fold or alias in the normalization package's frozen table, carrying an id (`ar.taa-marbuta-haa`), its class, the script it applies to, one sentence a speaker can argue with, and a review record. A Rule states something about the script and is safe for every name; a statement about one record is that record's own alias, carrying its own Source, not a Rule.
 _Avoid_: mapping, transform, substitution
 
 **Golden corpus**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ pnpm changeset   # pick package(s) + bump type + a one-line note
 - Keep entries sorted by `wilaya_code`, then alphabetically by `name_fr`
 
 ### Naming
+- Use the project glossary's terms ([`CONTEXT.md`](CONTEXT.md)), including [Search and normalization](CONTEXT.md#search-and-normalization) for Search key, Conservative key, Loose key, Rule and Golden corpus
 - **French**: official JORA spelling (e.g., "Oum El Bouaghi")
 - **Arabic**: standard script, no tashkeel (diacritics)
 - **Daira**: the French name of the daira seat (chef-lieu)


### PR DESCRIPTION
Makes the release train and the glossary ready for a package that ships code and no data (the normalization package of yasserstudio/geoalgeria.com#126), without adding anything to `packages/`.

## What changed

- `.github/workflows/release.yml`: the "GitHub Releases + data bundles" step now zips `data/` only when the directory exists. A package without one still gets a Release, with no asset attached: `BUNDLE` is set to the empty string and `${BUNDLE:+"$BUNDLE"}` drops the argument from both `gh release create` calls. `packages/dataset` keeps its own three-path zip.
- `CONTEXT.md`: new "Search and normalization" section with **Search key**, **Conservative key**, **Loose key**, **Rule** and **Golden corpus**, each with an `_Avoid_` line (notably "slug" and "normalized name" for Search key).
- `AGENTS.md` and `CONTRIBUTING.md`: one line each pointing at those entries where they already cover vocabulary.

Note: the workflow's package loop is a hardcoded list, in both the dry-run publish step and the Releases step. It is left as it is; only the bundling decision inside the loop changed. Adding the code-only package to that list is the follow-up ticket's job.

## Dry run: same set of bundles before and after

A local reproduction of the loop over the exact hardcoded list (not committed) gives:

**Before** (zip unconditionally), 27 bundles:

```
bundle: packages/dataset (data + algeria.geojson + dataset-metadata.json)
bundle: packages/poste (data)
bundle: packages/emploi (data)
bundle: packages/mobilis (data)
bundle: packages/telecom (data)
bundle: packages/aviation (data)
bundle: packages/banques (data)
bundle: packages/livraison (data)
bundle: packages/jeunesse (data)
bundle: packages/sports (data)
bundle: packages/enseignement-superieur (data)
bundle: packages/tourisme (data)
bundle: packages/formation-professionnelle (data)
bundle: packages/djezzy (data)
bundle: packages/mosquees (data)
bundle: packages/sante (data)
bundle: packages/cliniques (data)
bundle: packages/culture (data)
bundle: packages/agriculture (data)
bundle: packages/ecoles (data)
bundle: packages/gares-routieres (data)
bundle: packages/ferroviaire (data)
bundle: packages/buses (data)
bundle: packages/industrie-pharmaceutique (data)
bundle: packages/pharmacies (data)
bundle: packages/ooredoo (data)
bundle: packages/protection-civile (data)
```

**After** (zip only when `data/` exists), the same 27 bundles:

```
bundle: packages/dataset (data + algeria.geojson + dataset-metadata.json)
bundle: packages/poste (data)
bundle: packages/emploi (data)
bundle: packages/mobilis (data)
bundle: packages/telecom (data)
bundle: packages/aviation (data)
bundle: packages/banques (data)
bundle: packages/livraison (data)
bundle: packages/jeunesse (data)
bundle: packages/sports (data)
bundle: packages/enseignement-superieur (data)
bundle: packages/tourisme (data)
bundle: packages/formation-professionnelle (data)
bundle: packages/djezzy (data)
bundle: packages/mosquees (data)
bundle: packages/sante (data)
bundle: packages/cliniques (data)
bundle: packages/culture (data)
bundle: packages/agriculture (data)
bundle: packages/ecoles (data)
bundle: packages/gares-routieres (data)
bundle: packages/ferroviaire (data)
bundle: packages/buses (data)
bundle: packages/industrie-pharmaceutique (data)
bundle: packages/pharmacies (data)
bundle: packages/ooredoo (data)
bundle: packages/protection-civile (data)
```

Every package in the list has a `data/` directory today, so the lists are identical: the skip is reachable only by a package that does not exist yet.

## Validator outcome (no change needed)

A throwaway `packages/tmp-code-only` (a `package.json` with `"license": "MIT"`, the plain MIT `LICENSE`, an `index.js`, no `data/`, no `dataset-metadata.json`) was created in the worktree, validated, and deleted. `pnpm validate` exited 0 and the only line it produced for the package was from the licence gate:

```
[licence terms: manifest ↔ LICENSE ↔ metadata]
  OK: tmp-code-only declares "MIT" and its LICENSE says so
```

That is the existing `code-only` class in `scripts/lib/licence-terms.mjs` (`metadata === null`, manifest `MIT`, plain MIT text). No `[@geoalgeria/tmp-code-only]` dataset section ran, and the `files[]`, types, retired-ids and boundary gates all skipped it silently, since each is keyed on a `data/` directory or on `metadata.json`. The validator is unchanged, so no new test was added.

## Verification

`pnpm validate` on the branch: `PASSED: all scoped packages valid`, then 244 tests, 244 pass, 0 fail.

Tracker: yasserstudio/geoalgeria.com#128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
