### PR TITLE
docs: align the family docs with the normalize package

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -166,7 +166,7 @@ dz.getPostOfficesByCommune(1731); // مكاتب بريد الجزائر الحق
 - المعرّفات الخارجية مجمّعة تحت `refs` (`osm`، `wikidata`، …).
 - `geo_precision` يأخذ حصرًا القيم `exact | approximate | null`، و`null` فقط عند غياب الإحداثيات، مع طريقة الترميز الجغرافي في `geo_method`.
 
-تُرافقها أدوات قابلة للقراءة آليًا: فهرس جذري [`index.json`](index.json)، وواصف `schema.org/Dataset` (`dataset-metadata.json`) في كل حزمة، و69 مضلّع حدود للولايات في الحزمة الأساسية ضمن [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (بجودة العرض).
+تُرافقها أدوات قابلة للقراءة آليًا: فهرس جذري [`index.json`](index.json)، وواصف `schema.org/Dataset` (`dataset-metadata.json`) في كل حزمة تحمل بيانات (الحزمة `@geoalgeria/normalize`، شيفرة فقط، لا تحمل واصفًا من هذا النوع)، و69 مضلّع حدود للولايات في الحزمة الأساسية ضمن [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (بجودة العرض).
 
 حزمة واحدة تسبق العقد، مجموعة البيانات الأساسية `geoalgeria` (تقسيمات إدارية وليست GeoRecords؛ مميَّزة بـ `schema_version: null` في الفهرس).
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -164,7 +164,7 @@ Chaque enregistrement suit la même forme :
 - Les identifiants externes sont regroupés sous `refs` (`osm`, `wikidata`, …).
 - `geo_precision` vaut strictement `exact | approximate | null`, `null` exactement lorsqu'il n'y a pas de coordonnée, avec la méthode de géocodage dans `geo_method`.
 
-Des artefacts lisibles par machine les accompagnent : un catalogue racine [`index.json`](index.json), un descripteur `schema.org/Dataset` (`dataset-metadata.json`) dans chaque paquet, et les 69 polygones de limites des wilayas dans le paquet principal, sous [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (qualité d'affichage).
+Des artefacts lisibles par machine les accompagnent : un catalogue racine [`index.json`](index.json), un descripteur `schema.org/Dataset` (`dataset-metadata.json`) dans chaque paquet porteur de données (le paquet `@geoalgeria/normalize`, code seul, n'en porte pas), et les 69 polygones de limites des wilayas dans le paquet principal, sous [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (qualité d'affichage).
 
 Un paquet est antérieur au contrat, le jeu de données principal `geoalgeria` (divisions administratives, pas des GeoRecords ; marqué `schema_version: null` dans le catalogue).
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Every record follows the same shape:
 - External ids live under `refs` (`osm`, `wikidata`, …).
 - `geo_precision` is strictly `exact | approximate | null`, `null` exactly when there is no coordinate, with the geocoding method in `geo_method`.
 
-Machine-readable artifacts ride alongside: a root [`index.json`](index.json) catalog, a `schema.org/Dataset` descriptor (`dataset-metadata.json`) in each package, and the 69 wilaya boundary polygons in the core package at [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (display-grade).
+Machine-readable artifacts ride alongside: a root [`index.json`](index.json) catalog, a `schema.org/Dataset` descriptor (`dataset-metadata.json`) in each data-bearing package (the code-only `@geoalgeria/normalize` carries no dataset descriptor), and the 69 wilaya boundary polygons in the core package at [`data/geojson/wilaya-boundaries.geojson`](packages/dataset/data/geojson/wilaya-boundaries.geojson) (display-grade).
 
 Human-reviewed corrections use the same contract across packages. A package can
 add `quality/overrides/<package>.json`; the canonical writer checks the expected

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,6 +337,23 @@ reads as further along than it is.
   page on exactly the basis this repo already redistributes their station list.
   _(logged 2026-08-09)_
 
+## Search
+
+- [ ] **Publish `@geoalgeria/normalize`.** Tickets #128 to #132 (PRs #211 to
+  #214) landed the package at 1.0.0: seven exports, a fixtures subpath, 24
+  reviewed Rules with a review gate, punctuation as a separator so tokens
+  match SQLite FTS5 `unicode61`, and a Match class documented in the fixtures
+  but not exported. The release script skips a package npm has never seen, so
+  publish is a manual bootstrap (ticket #134, Owner action per RELEASING.md),
+  gated on the Owner's native Arabic review of the Arabic rationales.
+  _(logged 2026-09-06)_
+
+- [ ] **Web adoption of `@geoalgeria/normalize`** (ticket #136), after #134
+  publishes and after the core-extraction ticket #139. Replaces the live Web
+  normalizer's three deviations (concatenated tokens, taa marbuta/alef
+  maqsura folded into its only key, tatweel not stripped) with the package's
+  keys. _(logged 2026-09-06)_
+
 ## Releases
 
 - [ ] **Umbrella release tag for the current state.** Per-package releases have


### PR DESCRIPTION
Stale prose found now that the 31st package (`@geoalgeria/normalize`, code-only) exists:

- README.md / README.fr.md / README.ar.md: the "machine-readable artifacts" line claimed a `dataset-metadata.json` `schema.org/Dataset` descriptor "in each package"; normalize carries no dataset (and no such descriptor), so the sentence now scopes to data-bearing packages and calls out the exception.
- ROADMAP.md: no entry existed for the normalize chain (tickets #128-#132, PRs #211-#214, all landed 2026-09-06). Added a `## Search` section: the package is published-yet-unpublished at 1.0.0 (bootstrap owed as ticket #134, gated on the Owner's Arabic review), and Web adoption is tracked as ticket #136.

Checked and already current, no change needed: the `Packages` table (normalize already listed), `RELEASING.md`'s Trusted Publisher list (normalize already in the 28-package CI-staged set, with the unpublished-package exception documented), `AGENTS.md` and `CONTRIBUTING.md` (both already describe the package and its rule/changeset guard), the root `CHANGELOG.md` (only records cut umbrella tags; no tag has been cut since normalize landed), and `docs/agents/*.md` (no package-count claims).

`pnpm validate` passes (690 tests, includes docs parity). No em dashes in the changed prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)